### PR TITLE
Remove oldest logs in the persistence if it gets more logs than expected

### DIFF
--- a/AvalancheHub/AvalancheHub/Internals/Storage/AVAStorage.h
+++ b/AvalancheHub/AvalancheHub/Internals/Storage/AVAStorage.h
@@ -17,11 +17,18 @@ typedef void (^AVALoadDataCompletionBlock)(NSArray<AVALog> *logArray, NSString *
 @protocol AVAStorage <NSObject>
 
 /*
- * Defines the maximum count of app logs per storage key on the file system.
+ * Defines the maximum count of app log files per storage key on the file system.
+ *
+ * Default: 7
+ */
+@property(nonatomic) NSUInteger bucketFileCountLimit;
+
+/*
+ * Defines the maximum count of app logs per storage key in a file.
  *
  * Default: 50
  */
-@property(nonatomic) NSUInteger bucketFileCountLimit;
+@property(nonatomic) NSUInteger bucketFileLogCountLimit;
 
 @required
 
@@ -49,15 +56,6 @@ typedef void (^AVALoadDataCompletionBlock)(NSArray<AVALog> *logArray, NSString *
  * @return a list of logs
  */
 - (void)loadLogsForStorageKey:(NSString *)storageKey withCompletion:(nullable AVALoadDataCompletionBlock)completion;
-
-/**
- * Determines if the maximum number of files has been reached.
- *
- * param storageKey The key used for grouping
- *
- * @return YES, if the maximum number of files has been reached
- */
-- (BOOL)maxFileCountReachedForStorageKey:(NSString *)storageKey;
 
 @end
 


### PR DESCRIPTION
We have some technical/performance issues to accomplish maintaining up to 300 logs in the persistence. We are approaching the dead line, slightly change a logic and fix the root cause later with database or other storage types.

The fix will maintain up to 50 logs in a file, persistence will maintain up to 7 files (except files that are in pending status). If persistence needs to create 8th file (which means it already has 350 logs), it will first create the 8th file and then delete the oldest file (which is expected to contain 50 oldest logs).

This way, we can maintain at least 300 logs and up to 350 logs.
