### PR TITLE
Remove calls to synchronize-calls for NSUserDefaults

### DIFF
--- a/SonomaAnalytics/SonomaAnalytics/Internals/Session/SNMSessionTracker.m
+++ b/SonomaAnalytics/SonomaAnalytics/Internals/Session/SNMSessionTracker.m
@@ -80,7 +80,6 @@ static NSUInteger const kSNMMaxSessionHistoryCount = 5;
 
     // Persist the session history in NSData format.
     [kSNMUserDefaults setObject:[NSKeyedArchiver archivedDataWithRootObject:self.pastSessions] forKey:kSNMPastSessionsKey];
-    [kSNMUserDefaults synchronize];
     SNMLogVerbose(@"INFO:new session ID: %@", _sessionId);
 
     // Create a start session log.

--- a/SonomaCore/SonomaCore/Internals/Model/Utils/SNMUserDefaults.h
+++ b/SonomaCore/SonomaCore/Internals/Model/Utils/SNMUserDefaults.h
@@ -69,10 +69,4 @@
  */
 - (void)removeObjectForKey:(NSString *)key;
 
-/**
- * Writes any modifications to the persistent domains to disk and updates
- * all unmodified persistent domains to what is on disk.
- */
-- (void)synchronize;
-
 @end

--- a/SonomaCore/SonomaCore/Internals/Model/Utils/SNMUserDefaults.m
+++ b/SonomaCore/SonomaCore/Internals/Model/Utils/SNMUserDefaults.m
@@ -83,8 +83,4 @@ static NSString *const kSNMUserDefaultsTs = @"_ts";
   return [self updateObject:o forKey:key expiration:0.0];
 }
 
-- (void)synchronize {
-  [[NSUserDefaults standardUserDefaults] synchronize];
-}
-
 @end

--- a/SonomaCore/SonomaCore/Internals/SNMFeatureAbstract.m
+++ b/SonomaCore/SonomaCore/Internals/SNMFeatureAbstract.m
@@ -36,7 +36,6 @@
 
       // Persist the enabled status.
       [self.storage setObject:[NSNumber numberWithBool:isEnabled] forKey:self.isEnabledKey];
-      [self.storage synchronize];
     }
   }
 }

--- a/SonomaCore/SonomaCore/SNMSonoma.m
+++ b/SonomaCore/SonomaCore/SNMSonoma.m
@@ -118,7 +118,6 @@ static NSString *const kSNMBaseUrl = @"http://in-integration.dev.avalanch.es:808
 
       // Persist the enabled status.
       [kSNMUserDefaults setObject:[NSNumber numberWithBool:isEnabled] forKey:kSNMHubIsEnabledKey];
-      [kSNMUserDefaults synchronize];
     }
   }
 }
@@ -183,7 +182,6 @@ static NSString *const kSNMBaseUrl = @"http://in-integration.dev.avalanch.es:808
 
         // Persist the install Id string.
         [kSNMUserDefaults setObject:[_installId UUIDString] forKey:kSNMInstallIdKey];
-        [kSNMUserDefaults synchronize];
       }
     }
     return _installId;


### PR DESCRIPTION
I just found that we call `synchronize` on `NSUserDefaults` which is considered a back practise, leads to bugs (at least on HA in the past), etc..
For iOS 7 and before, calling synchronize was common as setting values wasn't persisted immediately. Since iOS 7 this has changed and as we're targetting iOS8+, we're good removing them.
There is an article by the developer at Apple who's in charge of NSUserDefaults if you want tor ead more about this http://dscoder.com/defaults.html.

I know that Apple's documentation on NSUserDefaults mentions calling synchronize, but I'd trust the dev who implements it more than the documentation ;)
