### PR TITLE
move isDebuggerAttached from SNMCrashes to SNMCore.

### DIFF
--- a/SonomaCore/SonomaCore/SNMSonoma.h
+++ b/SonomaCore/SonomaCore/SNMSonoma.h
@@ -68,4 +68,12 @@
  */
 + (NSUUID *)installId;
 
+/**
+ * Detect if a debugger is attached to the app process. This is only invoked once on app startup and can not detect
+ * if the debugger is being attached during runtime!
+ *
+ *  @return BOOL if the debugger is attached.
+ */
++ (BOOL)isDebuggerAttached;
+
 @end

--- a/SonomaCore/SonomaCore/SNMSonoma.m
+++ b/SonomaCore/SonomaCore/SNMSonoma.m
@@ -4,6 +4,8 @@
 #import "SNMLogManagerDefault.h"
 #import "SNMUserDefaults.h"
 #import "SNMUtils.h"
+#import <sys/sysctl.h>
+
 
 // Http Headers + Query string.
 static NSString *const kSNMHeaderAppSecretKey = @"App-Secret";
@@ -61,6 +63,43 @@ static NSString *const kSNMBaseUrl = @"http://in-integration.dev.avalanch.es:808
 + (void)setLogHandler:(SNMLogHandler)logHandler {
   [SNMLogger setLogHandler:logHandler];
 }
+
+/**
+ * Check if the debugger is attached
+ *
+ * Taken from
+ * https://github.com/plausiblelabs/plcrashreporter/blob/2dd862ce049e6f43feb355308dfc710f3af54c4d/Source/Crash%20Demo/main.m#L96
+ *
+ * @return `YES` if the debugger is attached to the current process, `NO`
+ * otherwise
+ */
++ (BOOL)isDebuggerAttached {
+  static BOOL debuggerIsAttached = NO;
+  
+  static dispatch_once_t debuggerPredicate;
+  dispatch_once(&debuggerPredicate, ^{
+    struct kinfo_proc info;
+    size_t info_size = sizeof(info);
+    int name[4];
+    
+    name[0] = CTL_KERN;
+    name[1] = KERN_PROC;
+    name[2] = KERN_PROC_PID;
+    name[3] = getpid();
+    
+    if (sysctl(name, 4, &info, &info_size, NULL, 0) == -1) {
+      NSLog(@"[SNMCrashes] ERROR: Checking for a running debugger via sysctl() "
+            @"failed.");
+      debuggerIsAttached = false;
+    }
+    
+    if (!debuggerIsAttached && (info.kp_proc.p_flag & P_TRACED) != 0)
+      debuggerIsAttached = true;
+  });
+  
+  return debuggerIsAttached;
+}
+
 
 #pragma mark - private
 

--- a/SonomaCrashes/SonomaCrashes/Internals/Utils/SNMCrashesHelper.h
+++ b/SonomaCrashes/SonomaCrashes/Internals/Utils/SNMCrashesHelper.h
@@ -20,11 +20,4 @@
  */
 + (BOOL)isAppExtension;
 
-/**
- * Determines if the app is running with a debugger attached.
- *
- *  @return YES, if the app is running with a debugger attached.
- */
-+ (BOOL)isDebuggerAttached;
-
 @end

--- a/SonomaCrashes/SonomaCrashes/Internals/Utils/SNMCrashesHelper.m
+++ b/SonomaCrashes/SonomaCrashes/Internals/Utils/SNMCrashesHelper.m
@@ -3,7 +3,6 @@
  */
 
 #import "SNMCrashesHelper.h"
-#import <sys/sysctl.h>
 
 static NSString *const kSNMCrashesDirectory = @"com.microsoft.sonoma/crashes";
 
@@ -55,42 +54,6 @@ NSString *snm_crashesDir(void);
   });
 
   return isRunningInAppExtension;
-}
-
-/**
- * Check if the debugger is attached
- *
- * Taken from
- * https://github.com/plausiblelabs/plcrashreporter/blob/2dd862ce049e6f43feb355308dfc710f3af54c4d/Source/Crash%20Demo/main.m#L96
- *
- * @return `YES` if the debugger is attached to the current process, `NO`
- * otherwise
- */
-+ (BOOL)isDebuggerAttached {
-  static BOOL debuggerIsAttached = NO;
-
-  static dispatch_once_t debuggerPredicate;
-  dispatch_once(&debuggerPredicate, ^{
-    struct kinfo_proc info;
-    size_t info_size = sizeof(info);
-    int name[4];
-
-    name[0] = CTL_KERN;
-    name[1] = KERN_PROC;
-    name[2] = KERN_PROC_PID;
-    name[3] = getpid();
-
-    if (sysctl(name, 4, &info, &info_size, NULL, 0) == -1) {
-      NSLog(@"[SNMCrashes] ERROR: Checking for a running debugger via sysctl() "
-            @"failed.");
-      debuggerIsAttached = false;
-    }
-
-    if (!debuggerIsAttached && (info.kp_proc.p_flag & P_TRACED) != 0)
-      debuggerIsAttached = true;
-  });
-
-  return debuggerIsAttached;
 }
 
 @end

--- a/SonomaCrashes/SonomaCrashes/SNMCrashes.h
+++ b/SonomaCrashes/SonomaCrashes/SNMCrashes.h
@@ -56,17 +56,6 @@ typedef NS_ENUM(NSUInteger, SNMUserConfirmation) {
 ///-----------------------------------------------------------------------------
 
 /**
- *  Detect if a debugger is attached to the app process
- *
- *  This is only invoked once on app startup and can not detect if the debugger
- * is being
- *  attached during runtime!
- *
- *  @return BOOL if the debugger is attached on app startup
- */
-+ (BOOL)isDebuggerAttached;
-
-/**
  * Lets the app crash for easy testing of the SDK.
  *
  * The best way to use this is to trigger the crash with a button action.

--- a/SonomaCrashes/SonomaCrashes/SNMCrashes.m
+++ b/SonomaCrashes/SonomaCrashes/SNMCrashes.m
@@ -51,14 +51,10 @@ static void uncaught_cxx_exception_handler(const SNMCrashesUncaughtCXXExceptionI
 
 #pragma mark - Public Methods
 
-+ (BOOL)isDebuggerAttached {
-  return [SNMCrashesHelper isDebuggerAttached];
-}
-
 + (void)generateTestCrash {
   if ([[self sharedInstance] canBeUsed]) {
     if ([SNMEnvironmentHelper currentAppEnvironment] != SNMEnvironmentAppStore) {
-      if ([self isDebuggerAttached]) {
+      if ([SNMSonoma isDebuggerAttached]) {
         SNMLogWarning(
             @"[SNMCrashes] Error: The debugger is attached. The following crash cannot be detected by the SDK!");
       }
@@ -160,7 +156,7 @@ static void uncaught_cxx_exception_handler(const SNMCrashesUncaughtCXXExceptionI
    the following part when a debugger is attached no matter which signal
    handler type is set.
    */
-  if ([SNMCrashesHelper isDebuggerAttached]) {
+  if ([SNMSonoma isDebuggerAttached]) {
     SNMLogWarning(@"[SNMCrashes] WARNING: Detecting crashes is NOT "
                   @"enabled due to running the app with a debugger "
                   @"attached.");


### PR DESCRIPTION
This is a convenience method that allows devs to check if a debugger is attached. This is can be used to setup the SDK differently depending the methods value, etc..
