### PR TITLE
#901 remove ObjC linker flag

### DIFF
--- a/SonomaAnalytics/SonomaAnalytics.xcodeproj/project.pbxproj
+++ b/SonomaAnalytics/SonomaAnalytics.xcodeproj/project.pbxproj
@@ -637,7 +637,7 @@
 			buildSettings = {
 				"ARCHS[sdk=iphonesimulator*]" = "$(SNM_SIM_ARCHS)";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.sonoma.SonomaAnalytics;
 				PRODUCT_NAME = SonomaAnalytics;
@@ -653,7 +653,7 @@
 			buildSettings = {
 				"ARCHS[sdk=iphonesimulator*]" = "$(SNM_SIM_ARCHS)";
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.sonoma.SonomaAnalytics;
 				PRODUCT_NAME = SonomaAnalytics;

--- a/SonomaCrashes/SonomaCrashes.xcodeproj/project.pbxproj
+++ b/SonomaCrashes/SonomaCrashes.xcodeproj/project.pbxproj
@@ -776,7 +776,7 @@
 					"$(inherited)",
 					"\"$(SRCROOT)/../Vendor\"/**",
 				);
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.sonoma.SonomaCrashes;
 				PRODUCT_NAME = SonomaCrashes;
@@ -795,7 +795,7 @@
 					"$(inherited)",
 					"\"$(SRCROOT)/../Vendor\"/**",
 				);
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.sonoma.SonomaCrashes;
 				PRODUCT_NAME = SonomaCrashes;


### PR DESCRIPTION
Just removing the ObjC linker flag. I don't think that we need it and it adds constraints for customers.
