### PR TITLE
#875 Disable channels on HTTP unrecoverable errors

### DIFF
--- a/SonomaCore/SonomaCore.xcodeproj/project.pbxproj
+++ b/SonomaCore/SonomaCore.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		387C75961D64EE1900D68CC1 /* SNMFeatureAbstractTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 387C75951D64EE1900D68CC1 /* SNMFeatureAbstractTest.m */; };
 		387C76DA1D677EC100D68CC1 /* SNMFeatureAbstractPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 387C76D91D677EC100D68CC1 /* SNMFeatureAbstractPrivate.h */; };
 		387C76FD1D6C9CF100D68CC1 /* SNMFeatureAbstract.h in Headers */ = {isa = PBXBuildFile; fileRef = 387C76FC1D6C9CF100D68CC1 /* SNMFeatureAbstract.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		389124281DC7ABB600197086 /* SNMRetriableCallPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 389124271DC7ABB600197086 /* SNMRetriableCallPrivate.h */; };
 		38CA60ED1D949F5000B82420 /* SNMFileStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E40D4621D2700000046D85B /* SNMFileStorage.m */; };
 		38EAD9AC1DA6A8C500CE6030 /* SNMEnable.h in Headers */ = {isa = PBXBuildFile; fileRef = 38EAD9AB1DA6A8C500CE6030 /* SNMEnable.h */; };
 		38F1944E1DADB93100D3E0FE /* SNMHttpSenderPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 38F1944D1DADB93100D3E0FE /* SNMHttpSenderPrivate.h */; };
@@ -173,6 +174,7 @@
 		387C75951D64EE1900D68CC1 /* SNMFeatureAbstractTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = SNMFeatureAbstractTest.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		387C76D91D677EC100D68CC1 /* SNMFeatureAbstractPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNMFeatureAbstractPrivate.h; sourceTree = "<group>"; };
 		387C76FC1D6C9CF100D68CC1 /* SNMFeatureAbstract.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNMFeatureAbstract.h; sourceTree = "<group>"; };
+		389124271DC7ABB600197086 /* SNMRetriableCallPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNMRetriableCallPrivate.h; sourceTree = "<group>"; };
 		38EAD9AB1DA6A8C500CE6030 /* SNMEnable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNMEnable.h; sourceTree = "<group>"; };
 		38F1944D1DADB93100D3E0FE /* SNMHttpSenderPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNMHttpSenderPrivate.h; sourceTree = "<group>"; };
 		5949380E604D45340244FEF1 /* SNMChannelDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SNMChannelDelegate.h; sourceTree = "<group>"; };
@@ -547,6 +549,7 @@
 				E84B8E341D235226006FD231 /* SNMHttpSender.m */,
 				E80EB1091D50278F00C9003F /* SNMSenderCall.h */,
 				E80EB1051D50273700C9003F /* SNMRetriableCall.h */,
+				389124271DC7ABB600197086 /* SNMRetriableCallPrivate.h */,
 				E80EB1061D50273700C9003F /* SNMRetriableCall.m */,
 				E8E48F941D50FF4300A8C1B0 /* SNMSenderCallDelegate.h */,
 			);
@@ -659,6 +662,7 @@
 				E80EB10A1D50278F00C9003F /* SNMSenderCall.h in Headers */,
 				38EAD9AC1DA6A8C500CE6030 /* SNMEnable.h in Headers */,
 				6E2BA1AF1D2499F9002D7B88 /* SNMFileHelper.h in Headers */,
+				389124281DC7ABB600197086 /* SNMRetriableCallPrivate.h in Headers */,
 				381C91E91D3DB65D004512F1 /* SNMDeviceTracker.h in Headers */,
 				6E0401731D1C9E460051BCFA /* SNMLoggerPrivate.h in Headers */,
 				E84B8E2F1D2351DB006FD231 /* SNMLogManagerDefault.h in Headers */,

--- a/SonomaCore/SonomaCore/Internals/Channel/SNMLogManagerDefault.h
+++ b/SonomaCore/SonomaCore/Internals/Channel/SNMLogManagerDefault.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  A queue which makes adding new items thread safe.
  */
-@property(nonatomic, strong) dispatch_queue_t dataItemsOperations;
+@property(nonatomic, strong) dispatch_queue_t logsDispatchQueue;
 
 /**
  * A dictionary containing priority keys and their channel.

--- a/SonomaCore/SonomaCore/Internals/Channel/SNMLogManagerDefault.m
+++ b/SonomaCore/SonomaCore/Internals/Channel/SNMLogManagerDefault.m
@@ -6,7 +6,7 @@
 #import "SNMLogManagerDefault.h"
 #import "SonomaCore+Internal.h"
 
-static char *const SNMDataItemsOperationsQueue = "com.microsoft.sonoma.LogManagerQueue";
+static char *const SNMlogsDispatchQueue = "com.microsoft.sonoma.LogManagerQueue";
 
 /**
  * Private declaration of the log manager.
@@ -26,9 +26,9 @@ static char *const SNMDataItemsOperationsQueue = "com.microsoft.sonoma.LogManage
 
 - (instancetype)init {
   if (self = [super init]) {
-    dispatch_queue_t serialQueue = dispatch_queue_create(SNMDataItemsOperationsQueue, DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_t serialQueue = dispatch_queue_create(SNMlogsDispatchQueue, DISPATCH_QUEUE_SERIAL);
     _enabled = YES;
-    _dataItemsOperations = serialQueue;
+    _logsDispatchQueue = serialQueue;
     _channels = [NSMutableDictionary<NSNumber *, id<SNMChannel>> new];
     _delegates = [NSHashTable weakObjectsHashTable];
     _deviceTracker = [[SNMDeviceTracker alloc] init];
@@ -107,7 +107,7 @@ static char *const SNMDataItemsOperationsQueue = "com.microsoft.sonoma.LogManage
     channel = [[SNMChannelDefault alloc] initWithSender:self.sender
                                                 storage:self.storage
                                           configuration:configuration
-                                          logsDispatchQueue:self.dataItemsOperations];
+                                      logsDispatchQueue:self.logsDispatchQueue];
     self.channels[@(priority)] = channel;
   }
   return channel;

--- a/SonomaCore/SonomaCore/Internals/Sender/SNMHttpSenderPrivate.h
+++ b/SonomaCore/SonomaCore/Internals/Sender/SNMHttpSenderPrivate.h
@@ -11,6 +11,11 @@
 @property(nonatomic, strong) NSURLSession *session;
 
 /**
+ * Retry intervals used by calls in case of recoverable errors.
+ */
+@property(nonatomic, strong) NSArray *callsRetryIntervals;
+
+/**
  * Hash table containing all the delegates as weak references.
  */
 @property(atomic, strong) NSHashTable<id<SNMSenderDelegate>> *delegates;
@@ -20,25 +25,5 @@
  * Enable/disable does resume/suspend the sender as needed under the hood.
  */
 @property(nonatomic) BOOL enabled;
-
-/**
- * A boolean value set to YES if the sender is suspended or NO otherwise.
- */
-@property(nonatomic) BOOL suspended;
-
-/**
- * Suspend the sender.
- * A sender is suspended when it becomes disabled or on network issues.
- * A suspended sender still persists logs but doesn't forward them to the sender.
- * A suspended state doesn't impact the current enabled state.
- * @see resume.
- */
-- (void)suspend;
-
-/**
- * Resume the sender.
- * @see suspend.
- */
-- (void)resume;
 
 @end

--- a/SonomaCore/SonomaCore/Internals/Sender/SNMRetriableCall.h
+++ b/SonomaCore/SonomaCore/Internals/Sender/SNMRetriableCall.h
@@ -14,14 +14,23 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable) dispatch_source_t timerSource;
 
 /**
- *  Number of retries performed for this call.
+ * Number of retries performed for this call.
  */
 @property(nonatomic) NSUInteger retryCount;
 
 /**
- *  Indicate if has reached the max retried.
+ * Initialize a call with specified retry intervals.
  *
- *  @return YES if max retry has reached, NO otherwise.
+ * @param retryIntervals Retry intervals used in case of recoverable errors.
+ *
+ * @return A retriable call instance.
+ */
+- (id)initWithRetryIntervals:(NSArray *)retryIntervals;
+
+/**
+ * Indicate if the limit of maximum retries has been reached.
+ *
+ * @return YES if the limit of maximum retries has been reached, NO otherwise.
  */
 - (BOOL)hasReachedMaxRetries;
 

--- a/SonomaCore/SonomaCore/Internals/Sender/SNMRetriableCallPrivate.h
+++ b/SonomaCore/SonomaCore/Internals/Sender/SNMRetriableCallPrivate.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface SNMRetriableCall ()
+
+@property(nonatomic) NSArray *retryIntervals;
+
+@end

--- a/SonomaCore/SonomaCore/Internals/Sender/SNMSender.h
+++ b/SonomaCore/SonomaCore/Internals/Sender/SNMSender.h
@@ -21,6 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) SNM_Reachability *reachability;
 
 /**
+ * A boolean value set to YES if the sender is suspended or NO otherwise.
+ */
+@property(nonatomic) BOOL suspended;
+
+/**
  * Initialize the Sender.
  *
  * @param url Base url.
@@ -37,12 +42,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Send logs in batch.
  *
  * @param logContainer Batch of logs.
- * @param queue Queue for dispatching the completion handler.
  * @param handler Completion handler.
  */
-- (void)sendAsync:(nonnull SNMLogContainer *)logs
-    logsDispatchQueue:(nullable dispatch_queue_t)logsDispatchQueue
-completionHandler:(nonnull SNMSendAsyncCompletionHandler)handler;
+- (void)sendAsync:(nonnull SNMLogContainer *)logs completionHandler:(nonnull SNMSendAsyncCompletionHandler)handler;
 
 /**
  *  Add the given delegate to the sender.
@@ -57,6 +59,20 @@ completionHandler:(nonnull SNMSendAsyncCompletionHandler)handler;
  *  @param delegate Sender's delegate.
  */
 - (void)removeDelegate:(id<SNMSenderDelegate>)delegate;
+
+/**
+ * Suspend the sender.
+ * A sender is suspended when it becomes disabled or on network issues.
+ * A suspended state doesn't impact the current enabled state.
+ * @see resume.
+ */
+- (void)suspend;
+
+/**
+ * Resume the sender.
+ * @see suspend.
+ */
+- (void)resume;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/SonomaCore/SonomaCore/Internals/Sender/SNMSenderCall.h
+++ b/SonomaCore/SonomaCore/Internals/Sender/SNMSenderCall.h
@@ -6,6 +6,8 @@
 #import "SNMSenderUtils.h"
 #import <Foundation/Foundation.h>
 
+@protocol SNMSender;
+
 @protocol SNMSenderCall <NSObject>
 
 /**
@@ -24,11 +26,6 @@
 @property(nonatomic) SNMLogContainer *logContainer;
 
 /**
- *  Callback queue.
- */
-@property(nonatomic) dispatch_queue_t logsDispatchQueue;
-
-/**
  *  Call completion handler used for communicating with calling component.
  */
 @property(nonatomic) SNMSendAsyncCompletionHandler completionHandler;
@@ -37,9 +34,9 @@
  *  Call completed with error/success.
  *
  *  @param sender     sender object.
- *  @param error      call error.
  *  @param statusCode status code.
+ *  @param error      call error.
  */
-- (void)sender:(id<SNMSenderCallDelegate>)sender callCompletedWithError:(NSError *)error status:(NSUInteger)statusCode;
+- (void)sender:(id<SNMSender>)sender callCompletedWithStatus:(NSUInteger)statusCode error:(NSError *)error;
 
 @end

--- a/SonomaCore/SonomaCore/Internals/Sender/SNMSenderDelegate.h
+++ b/SonomaCore/SonomaCore/Internals/Sender/SNMSenderDelegate.h
@@ -9,17 +9,26 @@
 @optional
 
 /**
- *  Triggered after the sender has suspended its state.
+ * Triggered after the sender has suspended its state.
  *
- *  @param sender Sender.
+ * @param sender Sender.
  */
 - (void)senderDidSuspend:(id<SNMSender>)sender;
 
 /**
- *  Triggered after the sender has resumed its state.
+ * Triggered after the sender has resumed its state.
  *
- *  @param sender Sender.
+ * @param sender Sender.
  */
 - (void)senderDidResume:(id<SNMSender>)sender;
+
+/**
+ *  Triggered after the sender has set its enabled state.
+ *
+ *  @param sender     Sender.
+ *  @param isEnabled  A boolean reflecting the sender's enabled state.
+ *  @param deleteData A boolean value set to YES if sender's data deletion was requested, NO otherwise.
+ */
+- (void)sender:(id<SNMSender>)sender didSetEnabled:(BOOL)isEnabled andDeleteDataOnDisabled:(BOOL)deleteData;
 
 @end

--- a/SonomaCore/SonomaCoreTests/SNMLogManagerDefaultTests.m
+++ b/SonomaCore/SonomaCoreTests/SNMLogManagerDefaultTests.m
@@ -27,7 +27,7 @@
 
   // Then
   assertThat(sut, notNilValue());
-  assertThat(sut.dataItemsOperations, notNilValue());
+  assertThat(sut.logsDispatchQueue, notNilValue());
   assertThat(sut.channels, isEmpty());
   assertThat(sut.sender, equalTo(senderMock));
   assertThat(sut.storage, equalTo(storageMock));


### PR DESCRIPTION
* Sender and Channels disabled on call fatal errors
* Enclose the last async calls to the channel in the channel
* Add more console logs on channels and sender
* Inject retry intervals to the calls from the sender for testing purposes
* Fix retryer skip 1st interval