### PR TITLE
Support processing of handled exceptions coming from wrapper SDKs

### DIFF
--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -139,6 +139,11 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
  */
 @property dispatch_semaphore_t delayedProcessingSemaphore;
 
+/**
+ * Track handled exception directly as model form. This API is not public and is used by wrapper SDKs.
+ */
++ (void)trackModelException:(MSException *)exception;
+
 @end
 
 @implementation MSCrashes


### PR DESCRIPTION
## Context

While the currently exposed methods to enable crash reporting for wrapper SDKs only accepts one exception (that gets correlated to the actual iOS crash), for Unity we need a way to enqueue and send out multiple handled exceptions per session.

## Changes

Expose a function that directly adds an exception object to the channel queue.