### PR TITLE
Add social media url to podspec to link to our twitter account

### DIFF
--- a/AppCenter.podspec
+++ b/AppCenter.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
 
   s.homepage          = 'https://appcenter.ms'
   s.documentation_url = "https://docs.microsoft.com/en-us/appcenter/sdk"
+  s.social_media_url = 'https://twitter.com/vsappcenter'
 
   s.license           = { :type => 'MIT', :file => 'AppCenter-SDK-Apple/iOS/LICENSE' }
   s.author            = { 'Microsoft' => 'appcentersdk@microsoft.com' }


### PR DESCRIPTION
Just something that might be useful as we have lots of interaction on Twitter with our customers.