### PR TITLE
Fix UI tests

### DIFF
--- a/Puppet/Puppet.xcodeproj/project.pbxproj
+++ b/Puppet/Puppet.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		E89E6A2D1D396D7900CAA2CD /* MSMainViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E89E6A2B1D396D7900CAA2CD /* MSMainViewController.m */; };
 		E89E6A301D39704900CAA2CD /* MSAnalyticsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E89E6A2F1D39704900CAA2CD /* MSAnalyticsViewController.m */; };
 		F85AAE251E890226006797CA /* MSDeviceInfoViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F85AAE241E890226006797CA /* MSDeviceInfoViewController.m */; };
+		F8650EE4201F74180017E0FE /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8650EE3201F74180017E0FE /* Helpers.swift */; };
 		F8EB8ED51FD83A1F00F7ADC1 /* MSAnalyticsPropertyTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = F8EB8ED31FD83A1F00F7ADC1 /* MSAnalyticsPropertyTableViewCell.m */; };
 		F8EB8ED61FD83A1F00F7ADC1 /* MSAnalyticsPropertyTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = F8EB8ED41FD83A1F00F7ADC1 /* MSAnalyticsPropertyTableViewCell.xib */; };
 		F8F73BD41FD803C200CB7144 /* MSCustomPropertyTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = F8F73BD31FD803C200CB7144 /* MSCustomPropertyTableViewCell.m */; };
@@ -431,6 +432,7 @@
 		E89E6A2F1D39704900CAA2CD /* MSAnalyticsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSAnalyticsViewController.m; sourceTree = "<group>"; };
 		F85AAE231E890226006797CA /* MSDeviceInfoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSDeviceInfoViewController.h; sourceTree = "<group>"; };
 		F85AAE241E890226006797CA /* MSDeviceInfoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDeviceInfoViewController.m; sourceTree = "<group>"; };
+		F8650EE3201F74180017E0FE /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		F8EB8ED21FD83A1F00F7ADC1 /* MSAnalyticsPropertyTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSAnalyticsPropertyTableViewCell.h; sourceTree = "<group>"; };
 		F8EB8ED31FD83A1F00F7ADC1 /* MSAnalyticsPropertyTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSAnalyticsPropertyTableViewCell.m; sourceTree = "<group>"; };
 		F8EB8ED41FD83A1F00F7ADC1 /* MSAnalyticsPropertyTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MSAnalyticsPropertyTableViewCell.xib; sourceTree = "<group>"; };
@@ -565,6 +567,7 @@
 				5CE2589A1EA5FBD400DA8FB9 /* CrashesUITests.swift */,
 				5CE2589C1EA5FBE900DA8FB9 /* DistributeUITests.swift */,
 				5C4E0BFE1EE6F50F00FB0CF2 /* AppCenterUITests.swift */,
+				F8650EE3201F74180017E0FE /* Helpers.swift */,
 			);
 			path = PuppetUITests;
 			sourceTree = "<group>";
@@ -1145,6 +1148,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F8650EE4201F74180017E0FE /* Helpers.swift in Sources */,
 				5CE258991EA5FBCA00DA8FB9 /* AnalyticsUITests.swift in Sources */,
 				5CE2589D1EA5FBE900DA8FB9 /* DistributeUITests.swift in Sources */,
 				5C4E0BFF1EE6F50F00FB0CF2 /* AppCenterUITests.swift in Sources */,

--- a/Puppet/Puppet/Base.lproj/Main.storyboard
+++ b/Puppet/Puppet/Base.lproj/Main.storyboard
@@ -49,6 +49,9 @@
                                 </cells>
                             </tableViewSection>
                         </sections>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Push"/>
+                        </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="dataSource" destination="Kxj-Wa-KwA" id="wT3-P6-I9r"/>
                             <outlet property="delegate" destination="Kxj-Wa-KwA" id="aOM-FW-AJ5"/>
@@ -209,6 +212,9 @@
                             </tableViewCell>
                         </prototypes>
                         <sections/>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Custom Properties"/>
+                        </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="dataSource" destination="ijk-oD-Aik" id="s0N-Bm-XCx"/>
                             <outlet property="delegate" destination="ijk-oD-Aik" id="xhV-rO-HiT"/>
@@ -361,6 +367,9 @@
                                 </cells>
                             </tableViewSection>
                         </sections>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Analytics"/>
+                        </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="dataSource" destination="GhP-bn-tCW" id="22X-EB-AQx"/>
                             <outlet property="delegate" destination="GhP-bn-tCW" id="IFf-IO-6UR"/>
@@ -595,6 +604,9 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Crashes"/>
+                        </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="dataSource" destination="MLz-YP-ZEx" id="JR6-Bn-ZNU"/>
                             <outlet property="delegate" destination="MLz-YP-ZEx" id="x5y-f8-N4z"/>
@@ -712,6 +724,9 @@
                                 </cells>
                             </tableViewSection>
                         </sections>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Distribute"/>
+                        </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="dataSource" destination="axH-Yn-1RM" id="uCo-U7-0Sy"/>
                             <outlet property="delegate" destination="axH-Yn-1RM" id="npk-MN-yUs"/>
@@ -1143,6 +1158,9 @@
                                 </cells>
                             </tableViewSection>
                         </sections>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="App Center"/>
+                        </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="dataSource" destination="9Ck-4D-Ozb" id="Mt3-pk-ThE"/>
                             <outlet property="delegate" destination="9Ck-4D-Ozb" id="XKu-8j-qab"/>
@@ -1195,6 +1213,9 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Device Info"/>
+                        </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="dataSource" destination="S1U-v1-0jg" id="aKL-Ds-FWV"/>
                             <outlet property="delegate" destination="S1U-v1-0jg" id="KWx-cH-H1O"/>

--- a/Puppet/Puppet/Base.lproj/Main.storyboard
+++ b/Puppet/Puppet/Base.lproj/Main.storyboard
@@ -113,6 +113,7 @@
                                         </label>
                                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BhR-cQ-Pif" userLabel="Type Text Field">
                                             <rect key="frame" x="80" y="0.0" width="279" height="44"/>
+                                            <accessibility key="accessibilityConfiguration" identifier="Type"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="44" id="0c0-xW-tJR"/>
                                             </constraints>

--- a/Puppet/Puppet/Base.lproj/Main.storyboard
+++ b/Puppet/Puppet/Base.lproj/Main.storyboard
@@ -101,7 +101,7 @@
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Value" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GwB-r2-vuT">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Value" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GwB-r2-vuT" userLabel="Value Label">
                                             <rect key="frame" x="16" y="89" width="60" height="44"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="i2e-8w-Q5s"/>

--- a/Puppet/Puppet/Base.lproj/Main.storyboard
+++ b/Puppet/Puppet/Base.lproj/Main.storyboard
@@ -122,6 +122,7 @@
                                         </textField>
                                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Key" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JOx-oC-0In" userLabel="Key Text Field">
                                             <rect key="frame" x="80" y="44" width="279" height="44"/>
+                                            <accessibility key="accessibilityConfiguration" identifier="Key"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="44" id="cOq-Kd-dFP"/>
                                             </constraints>
@@ -131,6 +132,7 @@
                                         </textField>
                                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Value" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="TMR-2O-O4o" userLabel="Value Text Field">
                                             <rect key="frame" x="80" y="88" width="279" height="44"/>
+                                            <accessibility key="accessibilityConfiguration" identifier="Value"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="44" id="Rjt-co-iO9"/>
                                             </constraints>

--- a/Puppet/Puppet/Base.lproj/Main.storyboard
+++ b/Puppet/Puppet/Base.lproj/Main.storyboard
@@ -515,6 +515,9 @@
                                 </cells>
                             </tableViewSection>
                         </sections>
+                        <userDefinedRuntimeAttributes>
+                            <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Analytics Result"/>
+                        </userDefinedRuntimeAttributes>
                         <connections>
                             <outlet property="dataSource" destination="hlU-dM-cs9" id="rEn-te-s6q"/>
                             <outlet property="delegate" destination="hlU-dM-cs9" id="z6m-tz-MCl"/>

--- a/Puppet/Puppet/MSAnalyticsPropertyTableViewCell.xib
+++ b/Puppet/Puppet/MSAnalyticsPropertyTableViewCell.xib
@@ -21,12 +21,14 @@
                 <subviews>
                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Key" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qGa-iy-qLz">
                         <rect key="frame" x="20" y="0.0" width="160" height="44"/>
+                        <accessibility key="accessibilityConfiguration" identifier="Key"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <textInputTraits key="textInputTraits"/>
                     </textField>
                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Value" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="D1s-aI-k64">
                         <rect key="frame" x="195.5" y="0.0" width="159.5" height="43"/>
+                        <accessibility key="accessibilityConfiguration" identifier="Value"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <textInputTraits key="textInputTraits"/>

--- a/Puppet/Puppet/MSAnalyticsViewController.m
+++ b/Puppet/Puppet/MSAnalyticsViewController.m
@@ -54,11 +54,13 @@ static NSInteger kPropertiesSection = 3;
   sender.on = [MSAnalytics isEnabled];
 }
 
-- (NSDictionary *) properties {
+- (NSDictionary *)properties {
   NSMutableDictionary *properties = [NSMutableDictionary new];
   for (int i = 0; i < self.propertiesCount; i++) {
     MSAnalyticsPropertyTableViewCell *cell = [self.tableView cellForRowAtIndexPath:[NSIndexPath indexPathForRow:i inSection:kPropertiesSection]];
-    [properties setObject:cell.valueField.text forKey:cell.keyField.text];
+    if (cell) {
+      [properties setObject:cell.valueField.text forKey:cell.keyField.text];
+    }
   }
   return properties;
 }

--- a/Puppet/Puppet/MSCustomPropertyTableViewCell.m
+++ b/Puppet/Puppet/MSCustomPropertyTableViewCell.m
@@ -128,6 +128,7 @@
       self.valueBottomConstraint.active = YES;
       self.valueLabel.hidden = NO;
       self.valueTextField.hidden = NO;
+      self.valueTextField.isAccessibilityElement = YES;
       self.valueTextField.keyboardType = UIKeyboardTypeASCIICapable;
       self.boolValue.hidden = YES;
       break;
@@ -137,6 +138,7 @@
       self.valueBottomConstraint.active = YES;
       self.valueLabel.hidden = NO;
       self.valueTextField.hidden = NO;
+      self.valueTextField.isAccessibilityElement = YES;
       self.valueTextField.keyboardType = UIKeyboardTypeNumbersAndPunctuation;
       self.boolValue.hidden = YES;
       break;
@@ -154,6 +156,7 @@
       self.valueBottomConstraint.active = YES;
       self.valueLabel.hidden = NO;
       self.valueTextField.hidden = NO;
+      self.valueTextField.isAccessibilityElement = YES;
       self.valueTextField.tintColor = [UIColor clearColor];
       self.valueTextField.delegate = self;
       self.boolValue.hidden = YES;

--- a/Puppet/PuppetUITests/AnalyticsUITests.swift
+++ b/Puppet/PuppetUITests/AnalyticsUITests.swift
@@ -25,7 +25,7 @@ class AnalyticsUITests: XCTestCase {
     // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
 
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
+    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
     if (!appCenterButton.boolValue) {
       appCenterButton.tap()
     }
@@ -52,7 +52,7 @@ class AnalyticsUITests: XCTestCase {
 
     // Go back to start page and disable SDK.
     app.buttons["App Center"].tap()
-    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
+    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
 
     // SDK should be enabled.
     XCTAssertTrue(appCenterButton.boolValue)

--- a/Puppet/PuppetUITests/AnalyticsUITests.swift
+++ b/Puppet/PuppetUITests/AnalyticsUITests.swift
@@ -14,18 +14,19 @@ class AnalyticsUITests: XCTestCase {
 
     // In UI tests it is usually best to stop immediately when a failure occurs.
     continueAfterFailure = false
-
+    
     // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
     app = XCUIApplication()
     app?.launch()
     guard let `app` = app else {
       return
     }
-
+    
     // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-
+    handleSystemAlert()
+    
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
+    let appCenterButton = app.tables["App Center"].switches["Set Enabled"]
     if (!appCenterButton.boolValue) {
       appCenterButton.tap()
     }
@@ -39,7 +40,7 @@ class AnalyticsUITests: XCTestCase {
 
     // Go to analytics page and find "Set Enabled" button.
     app.tables["App Center"].staticTexts["Analytics"].tap()
-    let analyticsButton : XCUIElement = app.tables["Analytics"].switches["Set Enabled"]
+    let analyticsButton = app.tables["Analytics"].switches["Set Enabled"]
 
     // Service should be enabled by default.
     XCTAssertTrue(analyticsButton.boolValue)
@@ -52,7 +53,7 @@ class AnalyticsUITests: XCTestCase {
 
     // Go back to start page and disable SDK.
     app.buttons["App Center"].tap()
-    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
+    let appCenterButton = app.tables["App Center"].switches["Set Enabled"]
 
     // SDK should be enabled.
     XCTAssertTrue(appCenterButton.boolValue)
@@ -64,7 +65,7 @@ class AnalyticsUITests: XCTestCase {
     app.tables["App Center"].staticTexts["Analytics"].tap()
 
     // Button should be disabled.
-    XCTAssertFalse(appCenterButton.boolValue)
+    XCTAssertFalse(analyticsButton.boolValue)
 
     // Go back and enable SDK.
     app.buttons["App Center"].tap()
@@ -89,7 +90,7 @@ class AnalyticsUITests: XCTestCase {
     app.tables["App Center"].staticTexts["Analytics"].tap()
     
     // Make sure the module is enabled.
-    let analyticsButton : XCUIElement = app.tables["Analytics"].switches["Set Enabled"]
+    let analyticsButton = app.tables["Analytics"].switches["Set Enabled"]
     if (!analyticsButton.boolValue) {
       analyticsButton.tap()
     }
@@ -129,7 +130,7 @@ class AnalyticsUITests: XCTestCase {
     app.tables["App Center"].staticTexts["Analytics"].tap()
 
     // Make sure the module is enabled.
-    let analyticsButton : XCUIElement = app.tables["Analytics"].switches["Set Enabled"]
+    let analyticsButton = app.tables["Analytics"].switches["Set Enabled"]
     if (!analyticsButton.boolValue) {
       analyticsButton.tap()
     }
@@ -203,7 +204,7 @@ class AnalyticsUITests: XCTestCase {
     app.tables["App Center"].staticTexts["Analytics"].tap()
     
     // Disable service.
-    let analyticsButton : XCUIElement = app.tables["Analytics"].switches["Set Enabled"]
+    let analyticsButton = app.tables["Analytics"].switches["Set Enabled"]
     if (analyticsButton.boolValue) {
       analyticsButton.tap()
     }

--- a/Puppet/PuppetUITests/AnalyticsUITests.swift
+++ b/Puppet/PuppetUITests/AnalyticsUITests.swift
@@ -227,7 +227,7 @@ class AnalyticsUITests: XCTestCase {
      }*/
     
     // Set name.
-    let eventName = analyticsTable.cell(containing: "Event Name").textFields.firstMatch
+    let eventName = analyticsTable.cell(containing: "Event Name").textFields.element
     eventName.clearAndTypeText(name)
     
     // Send.

--- a/Puppet/PuppetUITests/AnalyticsUITests.swift
+++ b/Puppet/PuppetUITests/AnalyticsUITests.swift
@@ -6,6 +6,8 @@ class AnalyticsUITests: XCTestCase {
   private let kDidSentEventText : String = "Sent event occurred"
   private let kDidFailedToSendEventText : String = "Failed to send event occurred"
   private let kDidSendingEventText : String = "Sending event occurred"
+  
+  private let timeout : TimeInterval = 5
 
   override func setUp() {
     super.setUp()
@@ -85,6 +87,12 @@ class AnalyticsUITests: XCTestCase {
 
     // Go to analytics page.
     app.tables["App Center"].staticTexts["Analytics"].tap()
+    
+    // Make sure the module is enabled.
+    let analyticsButton : XCUIElement = app.tables["Analytics"].switches["Set Enabled"]
+    if (!analyticsButton.boolValue) {
+      analyticsButton.tap()
+    }
 
     // Track event.
     self.trackEvent(name: "myEvent", propertiesCount: 0)
@@ -108,7 +116,7 @@ class AnalyticsUITests: XCTestCase {
                                 evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
                                 handler: nil)
 
-    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 15)
+    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: timeout)
   }
 
   func testTrackEventWithOneProps() {
@@ -119,6 +127,12 @@ class AnalyticsUITests: XCTestCase {
 
     // Go to analytics page.
     app.tables["App Center"].staticTexts["Analytics"].tap()
+
+    // Make sure the module is enabled.
+    let analyticsButton : XCUIElement = app.tables["Analytics"].switches["Set Enabled"]
+    if (!analyticsButton.boolValue) {
+      analyticsButton.tap()
+    }
 
     // Track event with one property.
     self.trackEvent(name: "myEvent", propertiesCount: 1)
@@ -142,7 +156,7 @@ class AnalyticsUITests: XCTestCase {
                                 evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
                                 handler: nil)
 
-    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 5)
+    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: timeout)
   }
 
   func testTrackEventWithTooMuchProps() {
@@ -176,7 +190,7 @@ class AnalyticsUITests: XCTestCase {
                                 evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
                                 handler: nil)
 
-    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 5)
+    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: timeout)
   }
 
   func testTrackEventWithDisabledAnalytics() {
@@ -187,9 +201,12 @@ class AnalyticsUITests: XCTestCase {
 
     // Go to analytics page.
     app.tables["App Center"].staticTexts["Analytics"].tap()
-
+    
     // Disable service.
-    app.switches.element(boundBy: 0).tap()
+    let analyticsButton : XCUIElement = app.tables["Analytics"].switches["Set Enabled"]
+    if (analyticsButton.boolValue) {
+      analyticsButton.tap()
+    }
 
     // Track event.
     self.trackEvent(name: "myEvent", propertiesCount: 0)
@@ -213,18 +230,22 @@ class AnalyticsUITests: XCTestCase {
                                 evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
                                 handler: nil)
 
-    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 5)
+    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: timeout)
   }
 
-  private func trackEvent(name : String, propertiesCount : Int) {
+  private func trackEvent(name : String, propertiesCount : UInt) {
     guard let analyticsTable = app?.tables["Analytics"] else {
       XCTFail()
       return
     }
     
-    /*for _ in 0..<numOfProps {
-     app?.tables.cells.element(boundBy: propCell).tap()
-     }*/
+    // Add properties.
+    for i in 0..<propertiesCount {
+      analyticsTable.staticTexts["Add Property"].tap()
+      let propertyCell = analyticsTable.cells.containing(.textField, identifier: "Key").element(boundBy: i)
+      propertyCell.textFields["Key"].clearAndTypeText("key\(i)")
+      propertyCell.textFields["Value"].clearAndTypeText("value\(i)")
+    }
     
     // Set name.
     let eventName = analyticsTable.cell(containing: "Event Name").textFields.element

--- a/Puppet/PuppetUITests/AnalyticsUITests.swift
+++ b/Puppet/PuppetUITests/AnalyticsUITests.swift
@@ -1,12 +1,11 @@
 import XCTest
 
 class AnalyticsUITests: XCTestCase {
-  private var app : XCUIApplication?;
-  private let AnalyticsCellIndex : UInt = 0;
+  private var app : XCUIApplication?
 
-  private let kDidSentEventText : String = "Sent event occurred";
-  private let kDidFailedToSendEventText : String = "Failed to send event occurred";
-  private let kDidSendingEventText : String = "Sending event occurred";
+  private let kDidSentEventText : String = "Sent event occurred"
+  private let kDidFailedToSendEventText : String = "Failed to send event occurred"
+  private let kDidSendingEventText : String = "Sending event occurred"
 
   override func setUp() {
     super.setUp()
@@ -15,225 +14,223 @@ class AnalyticsUITests: XCTestCase {
     continueAfterFailure = false
 
     // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-    app = XCUIApplication();
-    app?.launch();
+    app = XCUIApplication()
+    app?.launch()
+    guard let `app` = app else {
+      return
+    }
 
     // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
 
-    guard let `app` = app else {
-      return;
-    }
-
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    let appCenterButton : XCUIElement = app.switches["Set Enabled"];
-    if (appCenterButton.value as! String == "0") {
-      appCenterButton.tap();
+    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
+    if (!appCenterButton.boolValue) {
+      appCenterButton.tap()
     }
-
-    // Enable Analytics
-    app.tables.cells.element(boundBy: AnalyticsCellIndex).tap();
-    let analyticsButton : XCUIElement = app.switches["Set Enabled"];
-    if (analyticsButton.value as! String == "0") {
-      analyticsButton.tap();
-    }
-
-    // Go back
-    app.buttons["App Center"].tap();
   }
 
   func testAnalytics() {
     guard let `app` = app else {
-      XCTFail();
-      return;
+      XCTFail()
+      return
     }
 
     // Go to analytics page and find "Set Enabled" button.
-    app.tables.cells.element(boundBy: AnalyticsCellIndex).tap();
-    let analyticsButton : XCUIElement = app.switches.element(boundBy: 0);
+    app.tables["App Center"].staticTexts["Analytics"].tap()
+    let analyticsButton : XCUIElement = app.tables["Analytics"].switches["Set Enabled"]
 
     // Service should be enabled by default.
-    XCTAssertEqual("1", analyticsButton.value as! String);
+    XCTAssertTrue(analyticsButton.boolValue)
 
     // Disable service.
-    analyticsButton.tap();
+    analyticsButton.tap()
 
     // Button is disabled.
-    XCTAssertEqual("0", analyticsButton.value as! String);
+    XCTAssertFalse(analyticsButton.boolValue)
 
     // Go back to start page and disable SDK.
-    app.buttons["App Center"].tap();
-    let appCenterButton : XCUIElement = app.switches.element(boundBy: 0);
+    app.buttons["App Center"].tap()
+    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
 
     // SDK should be enabled.
-    XCTAssertEqual("1", appCenterButton.value as! String);
+    XCTAssertTrue(appCenterButton.boolValue)
 
     // Disable SDK.
-    appCenterButton.tap();
+    appCenterButton.tap()
 
     // Go to analytics page.
-    app.tables.cells.element(boundBy: AnalyticsCellIndex).tap();
+    app.tables["App Center"].staticTexts["Analytics"].tap()
 
     // Button should be disabled.
-    XCTAssertEqual("0", analyticsButton.value as! String);
+    XCTAssertFalse(appCenterButton.boolValue)
 
     // Go back and enable SDK.
-    app.buttons["App Center"].tap();
+    app.buttons["App Center"].tap()
 
     // Enable SDK.
-    appCenterButton.tap();
+    appCenterButton.tap()
 
     // Go to analytics page.
-    app.tables.cells.element(boundBy: AnalyticsCellIndex).tap();
+    app.tables["App Center"].staticTexts["Analytics"].tap()
 
     // Service should be enabled.
-    XCTAssertEqual("1", analyticsButton.value as! String);
+    XCTAssertTrue(analyticsButton.boolValue)
   }
 
   func testTrackEvent() {
     guard let `app` = app else {
-      XCTFail();
-      return;
+      XCTFail()
+      return
     }
 
-    // Go to analytics page
-    app.tables.cells.element(boundBy: AnalyticsCellIndex).tap();
+    // Go to analytics page.
+    app.tables["App Center"].staticTexts["Analytics"].tap()
 
-    // Track event
-    self.trackEvent(withProps: 0);
+    // Track event.
+    self.trackEvent(name: "myEvent", propertiesCount: 0)
 
-    // Go to result page
-    app.tables.cells.element(boundBy: 4).tap();
+    // Go to result page.
+    app.buttons["Results"].tap()
 
     let eventNameExp = expectation(for: NSPredicate(format: "label = 'myEvent'"),
                                    evaluatedWith: app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
-                                   handler: nil);
+                                   handler: nil)
     let propNumExp = expectation(for: NSPredicate(format: "label = '0'"),
                                  evaluatedWith: app.tables.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
-                                 handler: nil);
+                                 handler: nil)
     let didSentExp = expectation(for: NSPredicate(format: "label = %@", kDidSentEventText),
                                  evaluatedWith: app.tables.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
-                                 handler: nil);
+                                 handler: nil)
     let didSendingExp = expectation(for: NSPredicate(format: "label = %@", kDidSendingEventText),
                                     evaluatedWith: app.tables.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
-                                    handler: nil);
+                                    handler: nil)
     let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidSendingEventText),
                                 evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
-                                handler: nil);
+                                handler: nil)
 
-    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 15);
+    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 15)
   }
 
   func testTrackEventWithOneProps() {
     guard let `app` = app else {
-      XCTFail();
-      return;
+      XCTFail()
+      return
     }
 
-    // Go to analytics page
-    app.tables.cells.element(boundBy: AnalyticsCellIndex).tap();
+    // Go to analytics page.
+    app.tables["App Center"].staticTexts["Analytics"].tap()
 
-    // Track event with one property
-    self.trackEvent(withProps: 1);
+    // Track event with one property.
+    self.trackEvent(name: "myEvent", propertiesCount: 1)
 
-    // Go to result page
-    app.tables.cells.element(boundBy: 4).tap();
+    // Go to result page.
+    app.buttons["Results"].tap()
 
     let eventNameExp = expectation(for: NSPredicate(format: "label = 'myEvent'"),
                                    evaluatedWith: app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
-                                   handler: nil);
+                                   handler: nil)
     let propNumExp = expectation(for: NSPredicate(format: "label = '1'"),
                                  evaluatedWith: app.tables.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
-                                 handler: nil);
+                                 handler: nil)
     let didSentExp = expectation(for: NSPredicate(format: "label = %@", kDidSentEventText),
                                  evaluatedWith: app.tables.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
-                                 handler: nil);
+                                 handler: nil)
     let didSendingExp = expectation(for: NSPredicate(format: "label = %@", kDidSendingEventText),
                                     evaluatedWith: app.tables.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
-                                    handler: nil);
+                                    handler: nil)
     let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidSendingEventText),
                                 evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
-                                handler: nil);
+                                handler: nil)
 
-    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 5);
+    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 5)
   }
 
   func testTrackEventWithTooMuchProps() {
     guard let `app` = app else {
-      XCTFail();
-      return;
+      XCTFail()
+      return
     }
 
-    // Go to analytics page
-    app.tables.cells.element(boundBy: AnalyticsCellIndex).tap();
+    // Go to analytics page.
+    app.tables["App Center"].staticTexts["Analytics"].tap()
 
-    // Track event with seven properties
-    self.trackEvent(withProps: 7);
+    // Track event with seven properties.
+    self.trackEvent(name: "myEvent", propertiesCount: 7)
 
-    // Go to result page
-    app.tables.cells.element(boundBy: 4).tap();
+    // Go to result page.
+    app.buttons["Results"].tap()
 
     let eventNameExp = expectation(for: NSPredicate(format: "label = 'myEvent'"),
                                    evaluatedWith: app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
-                                   handler: nil);
+                                   handler: nil)
     let propNumExp = expectation(for: NSPredicate(format: "label = '5'"),
                                  evaluatedWith: app.tables.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
-                                 handler: nil);
+                                 handler: nil)
     let didSentExp = expectation(for: NSPredicate(format: "label = %@", kDidSentEventText),
                                  evaluatedWith: app.tables.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
-                                 handler: nil);
+                                 handler: nil)
     let didSendingExp = expectation(for: NSPredicate(format: "label = %@", kDidSendingEventText),
                                     evaluatedWith: app.tables.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
-                                    handler: nil);
+                                    handler: nil)
     let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidSendingEventText),
                                 evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
-                                handler: nil);
+                                handler: nil)
 
-    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 5);
+    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 5)
   }
 
   func testTrackEventWithDisabledAnalytics() {
     guard let `app` = app else {
-      XCTFail();
-      return;
+      XCTFail()
+      return
     }
 
-    // Go to analytics page
-    app.tables.cells.element(boundBy: AnalyticsCellIndex).tap();
+    // Go to analytics page.
+    app.tables["App Center"].staticTexts["Analytics"].tap()
 
-    // Disable service
-    app.switches.element(boundBy: 0).tap();
+    // Disable service.
+    app.switches.element(boundBy: 0).tap()
 
-    // Track event
-    self.trackEvent(withProps: 0);
+    // Track event.
+    self.trackEvent(name: "myEvent", propertiesCount: 0)
 
-    // Go to result page
-    app.tables.cells.element(boundBy: 4).tap();
+    // Go to result page.
+    app.buttons["Results"].tap()
 
     let eventNameExp = expectation(for: NSPredicate(format: "label != 'myEvent'"),
                                    evaluatedWith: app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
-                                   handler: nil);
+                                   handler: nil)
     let propNumExp = expectation(for: NSPredicate(format: "label != '0'"),
                                  evaluatedWith: app.tables.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
-                                 handler: nil);
+                                 handler: nil)
     let didSentExp = expectation(for: NSPredicate(format: "label != %@", kDidSentEventText),
                                  evaluatedWith: app.tables.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
-                                 handler: nil);
+                                 handler: nil)
     let didSendingExp = expectation(for: NSPredicate(format: "label != %@", kDidSendingEventText),
                                     evaluatedWith: app.tables.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
-                                    handler: nil);
+                                    handler: nil)
     let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidSendingEventText),
                                 evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
-                                handler: nil);
+                                handler: nil)
 
-    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 5);
+    wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: 5)
   }
 
-  private func trackEvent(withProps numOfProps : Int) {
-    let trackEventCell : UInt = 0;
-    let propCell : UInt = 2;
-    for _ in 0..<numOfProps {
-      app?.tables.cells.element(boundBy: propCell).tap();
+  private func trackEvent(name : String, propertiesCount : Int) {
+    guard let analyticsTable = app?.tables["Analytics"] else {
+      XCTFail()
+      return
     }
-    app?.tables.cells.element(boundBy: trackEventCell).tap();
+    
+    /*for _ in 0..<numOfProps {
+     app?.tables.cells.element(boundBy: propCell).tap()
+     }*/
+    
+    // Set name.
+    let eventName = analyticsTable.cell(containing: "Event Name").textFields.firstMatch
+    eventName.clearAndTypeText(name)
+    
+    // Send.
+    analyticsTable.buttons["Track Event"].tap()
   }
 }

--- a/Puppet/PuppetUITests/AnalyticsUITests.swift
+++ b/Puppet/PuppetUITests/AnalyticsUITests.swift
@@ -7,7 +7,7 @@ class AnalyticsUITests: XCTestCase {
   private let kDidFailedToSendEventText : String = "Failed to send event occurred"
   private let kDidSendingEventText : String = "Sending event occurred"
   
-  private let timeout : TimeInterval = 5
+  private let timeout : TimeInterval = 10
 
   override func setUp() {
     super.setUp()
@@ -101,20 +101,21 @@ class AnalyticsUITests: XCTestCase {
     // Go to result page.
     app.buttons["Results"].tap()
 
+    let resultsTable = app.tables["Analytics Result"]
     let eventNameExp = expectation(for: NSPredicate(format: "label = 'myEvent'"),
-                                   evaluatedWith: app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
+                                   evaluatedWith: resultsTable.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
                                    handler: nil)
     let propNumExp = expectation(for: NSPredicate(format: "label = '0'"),
-                                 evaluatedWith: app.tables.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
+                                 evaluatedWith: resultsTable.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
                                  handler: nil)
     let didSentExp = expectation(for: NSPredicate(format: "label = %@", kDidSentEventText),
-                                 evaluatedWith: app.tables.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
+                                 evaluatedWith: resultsTable.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
                                  handler: nil)
     let didSendingExp = expectation(for: NSPredicate(format: "label = %@", kDidSendingEventText),
-                                    evaluatedWith: app.tables.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
+                                    evaluatedWith: resultsTable.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
                                     handler: nil)
-    let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidSendingEventText),
-                                evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
+    let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidFailedToSendEventText),
+                                evaluatedWith: resultsTable.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
                                 handler: nil)
 
     wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: timeout)
@@ -141,20 +142,21 @@ class AnalyticsUITests: XCTestCase {
     // Go to result page.
     app.buttons["Results"].tap()
 
+    let resultsTable = app.tables["Analytics Result"]
     let eventNameExp = expectation(for: NSPredicate(format: "label = 'myEvent'"),
-                                   evaluatedWith: app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
+                                   evaluatedWith: resultsTable.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
                                    handler: nil)
     let propNumExp = expectation(for: NSPredicate(format: "label = '1'"),
-                                 evaluatedWith: app.tables.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
+                                 evaluatedWith: resultsTable.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
                                  handler: nil)
     let didSentExp = expectation(for: NSPredicate(format: "label = %@", kDidSentEventText),
-                                 evaluatedWith: app.tables.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
+                                 evaluatedWith: resultsTable.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
                                  handler: nil)
     let didSendingExp = expectation(for: NSPredicate(format: "label = %@", kDidSendingEventText),
-                                    evaluatedWith: app.tables.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
+                                    evaluatedWith: resultsTable.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
                                     handler: nil)
-    let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidSendingEventText),
-                                evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
+    let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidFailedToSendEventText),
+                                evaluatedWith: resultsTable.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
                                 handler: nil)
 
     wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: timeout)
@@ -175,20 +177,21 @@ class AnalyticsUITests: XCTestCase {
     // Go to result page.
     app.buttons["Results"].tap()
 
+    let resultsTable = app.tables["Analytics Result"]
     let eventNameExp = expectation(for: NSPredicate(format: "label = 'myEvent'"),
-                                   evaluatedWith: app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
+                                   evaluatedWith: resultsTable.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
                                    handler: nil)
     let propNumExp = expectation(for: NSPredicate(format: "label = '5'"),
-                                 evaluatedWith: app.tables.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
+                                 evaluatedWith: resultsTable.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
                                  handler: nil)
     let didSentExp = expectation(for: NSPredicate(format: "label = %@", kDidSentEventText),
-                                 evaluatedWith: app.tables.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
+                                 evaluatedWith: resultsTable.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
                                  handler: nil)
     let didSendingExp = expectation(for: NSPredicate(format: "label = %@", kDidSendingEventText),
-                                    evaluatedWith: app.tables.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
+                                    evaluatedWith: resultsTable.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
                                     handler: nil)
-    let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidSendingEventText),
-                                evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
+    let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidFailedToSendEventText),
+                                evaluatedWith: resultsTable.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
                                 handler: nil)
 
     wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: timeout)
@@ -215,20 +218,21 @@ class AnalyticsUITests: XCTestCase {
     // Go to result page.
     app.buttons["Results"].tap()
 
+    let resultsTable = app.tables["Analytics Result"]
     let eventNameExp = expectation(for: NSPredicate(format: "label != 'myEvent'"),
-                                   evaluatedWith: app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
+                                   evaluatedWith: resultsTable.cells.element(boundBy: 0).staticTexts.element(boundBy: 0),
                                    handler: nil)
     let propNumExp = expectation(for: NSPredicate(format: "label != '0'"),
-                                 evaluatedWith: app.tables.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
+                                 evaluatedWith: resultsTable.cells.element(boundBy: 1).staticTexts.element(boundBy: 0),
                                  handler: nil)
     let didSentExp = expectation(for: NSPredicate(format: "label != %@", kDidSentEventText),
-                                 evaluatedWith: app.tables.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
+                                 evaluatedWith: resultsTable.cells.element(boundBy: 2).staticTexts.element(boundBy: 0),
                                  handler: nil)
     let didSendingExp = expectation(for: NSPredicate(format: "label != %@", kDidSendingEventText),
-                                    evaluatedWith: app.tables.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
+                                    evaluatedWith: resultsTable.cells.element(boundBy: 3).staticTexts.element(boundBy: 0),
                                     handler: nil)
-    let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidSendingEventText),
-                                evaluatedWith: app.tables.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
+    let failedExp = expectation(for: NSPredicate(format: "label != %@", kDidFailedToSendEventText),
+                                evaluatedWith: resultsTable.cells.element(boundBy: 4).staticTexts.element(boundBy: 0),
                                 handler: nil)
 
     wait(for: [eventNameExp, propNumExp, didSentExp, didSendingExp, failedExp], timeout: timeout)

--- a/Puppet/PuppetUITests/AppCenterUITests.swift
+++ b/Puppet/PuppetUITests/AppCenterUITests.swift
@@ -83,7 +83,10 @@ class AppCenterUITests: XCTestCase {
   }
 
   /**
-   * There is a known bug with user defaults on iOS >= 10.
+   * There is a known bug with NSUserDefaults on iOS 10 and later.
+   * See:
+   *   https://forums.developer.apple.com/thread/61287
+   *   http://www.openradar.me/radar?id=5057804138184704
    */
   func testDisableSDKPersistance() {
     guard let `app` = app else {

--- a/Puppet/PuppetUITests/AppCenterUITests.swift
+++ b/Puppet/PuppetUITests/AppCenterUITests.swift
@@ -134,22 +134,45 @@ class AppCenterUITests: XCTestCase {
     guard let `app` = app else {
       return
     }
-    app.tables["App Center"].staticTexts["Custom Properties"].tap()
     
+    // Go to custom properties page.
+    app.tables["App Center"].staticTexts["Custom Properties"].tap()
     let customPropertiesTable = app.tables["Custom Properties"]
     
+    // Add clear property.
     customPropertiesTable.staticTexts["Add Property"].tap()
-    let stringPropertyCell = customPropertiesTable.cells.element(boundBy: 0)
-    stringPropertyCell.children(matching: .textField).element(boundBy: 0).tap()
+    let clearPropertyCell = customPropertiesTable.cells.element(boundBy: 0)
+    XCTAssertEqual("Clear", clearPropertyCell.textFields["Type"].value as! String)
+    clearPropertyCell.textFields["Key"].tap()
+    clearPropertyCell.textFields["Key"].typeText("key0")
+    
+    // Add string property.
+    customPropertiesTable.staticTexts["Add Property"].tap()
+    let stringPropertyCell = customPropertiesTable.cells.element(boundBy: 1)
+    stringPropertyCell.textFields["Type"].tap()
     app.pickerWheels.element.adjust(toPickerWheelValue: "String")
     app.toolbars.buttons["Done"].tap()
+    XCTAssertEqual("String", stringPropertyCell.textFields["Type"].value as! String)
     stringPropertyCell.textFields["Key"].tap()
     stringPropertyCell.textFields["Key"].typeText("key1")
     stringPropertyCell.textFields["Value"].tap()
     stringPropertyCell.textFields["Value"].typeText("test1")
     
+    // Add number property.
+    customPropertiesTable.staticTexts["Add Property"].tap()
+    let numbarPropertyCell = customPropertiesTable.cells.element(boundBy: 2)
+    numbarPropertyCell.textFields["Type"].tap()
+    app.pickerWheels.element.adjust(toPickerWheelValue: "Number")
+    app.toolbars.buttons["Done"].tap()
+    XCTAssertEqual("Number", numbarPropertyCell.textFields["Type"].value as! String)
+    numbarPropertyCell.textFields["Key"].tap()
+    numbarPropertyCell.textFields["Key"].typeText("key2")
+    numbarPropertyCell.textFields["Value"].tap()
+    numbarPropertyCell.textFields["Value"].typeText("-42.42")
+    
+    // Send properties.
     customPropertiesTable.buttons["Send Custom Properties"].tap()
-    app.alerts["The custom properties log is queued"].buttons["OK"].tap()
+    app.alerts.firstMatch.buttons["OK"].tap()
   }
 
   func testMiscellaneousInfo() {

--- a/Puppet/PuppetUITests/AppCenterUITests.swift
+++ b/Puppet/PuppetUITests/AppCenterUITests.swift
@@ -23,7 +23,7 @@ class AppCenterUITests: XCTestCase {
 
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
     let appCenterButton : XCUIElement = app.switches["Set Enabled"];
-    if (appCenterButton.value as! String == "0") {
+    if (!appCenterButton.boolValue) {
       appCenterButton.tap();
     }
   }
@@ -32,29 +32,33 @@ class AppCenterUITests: XCTestCase {
     guard let `app` = app else {
       return;
     }
-    let appCenterButton : XCUIElement = app.switches.element(boundBy: 0);
+    let appCenterButton : XCUIElement = app.switches["Set Enabled"];
 
     // SDK should be enabled.
-    XCTAssertEqual("1", appCenterButton.value as! String);
+    XCTAssertTrue(appCenterButton.boolValue);
 
     // Disable SDK.
     appCenterButton.tap();
 
     // All services should be disabled.
     // Analytics.
-    app.tables.cells.element(boundBy: 0).tap();
-    XCTAssertEqual("0", app.switches.element(boundBy: 0).value as! String);
+    app.tables["App Center"].staticTexts["Analytics"].tap();
+    XCTAssertFalse(app.tables["Analytics"].switches["Set Enabled"].boolValue);
     app.buttons["App Center"].tap();
 
     // Crashes.
-    app.tables.cells.element(boundBy: 1).tap();
-    XCTAssertEqual("0", app.switches.element(boundBy: 0).value as! String);
+    app.tables["App Center"].staticTexts["Crashes"].tap();
+    XCTAssertFalse(app.tables["Crashes"].switches["Set Enabled"].boolValue);
     app.buttons["App Center"].tap();
 
     // Distribute.
-    app.tables.cells.element(boundBy: 2).tap();
-    let distributeSwitchButton : XCUIElement = app.switches.element(matching: XCUIElementType.switch, identifier: "Set Enabled");
-    XCTAssertEqual("0", distributeSwitchButton.value as! String);
+    app.tables["App Center"].staticTexts["Distribute"].tap();
+    XCTAssertFalse( app.tables["Distribute"].switches["Set Enabled"].boolValue);
+    app.buttons["App Center"].tap();
+    
+    // Push.
+    app.tables["App Center"].staticTexts["Push"].tap();
+    XCTAssertFalse(app.tables["Push"].switches["Set Enabled"].boolValue);
     app.buttons["App Center"].tap();
 
     // Enable SDK.
@@ -62,18 +66,23 @@ class AppCenterUITests: XCTestCase {
 
     // All services should be enabled.
     // Analytics.
-    app.tables.cells.element(boundBy: 0).tap();
-    XCTAssertEqual("1", app.switches.element(boundBy: 0).value as! String);
+    app.tables["App Center"].staticTexts["Analytics"].tap();
+    XCTAssertTrue(app.tables["Analytics"].switches["Set Enabled"].boolValue);
     app.buttons["App Center"].tap();
 
     // Crashes.
-    app.tables.cells.element(boundBy: 1).tap();
-    XCTAssertEqual("1", app.switches.element(boundBy: 0).value as! String);
+    app.tables["App Center"].staticTexts["Crashes"].tap();
+    XCTAssertTrue(app.tables["Crashes"].switches["Set Enabled"].boolValue);
     app.buttons["App Center"].tap();
 
     // Distribute.
-    app.tables.cells.element(boundBy: 2).tap();
-    XCTAssertEqual("1", distributeSwitchButton.value as! String);
+    app.tables["App Center"].staticTexts["Distribute"].tap();
+    XCTAssertTrue(app.tables["Distribute"].switches["Set Enabled"].boolValue);
+    app.buttons["App Center"].tap();
+    
+    // Push.
+    app.tables["App Center"].staticTexts["Push"].tap();
+    XCTAssertTrue(app.tables["Push"].switches["Set Enabled"].boolValue);
     app.buttons["App Center"].tap();
   }
 
@@ -82,17 +91,8 @@ class AppCenterUITests: XCTestCase {
       return;
     }
 
-    // Go to custom properties page.
-    app.cells.element(boundBy: 3).tap();
-
-    // Check custom properties. There shouldn't be any crash.
-    for cellIndex in 0..<app.cells.count {
-      app.cells.element(boundBy: cellIndex).tap();
-    }
-    app.buttons["App Center"].tap();
-
     // Go to device info page.
-    app.cells.element(boundBy: 4).tap();
+    app.tables["App Center"].staticTexts["Device Info"].tap();
 
     // Check device info. Device info shouldn't contain an empty info.
     for cellIndex in 0..<app.cells.count {
@@ -103,17 +103,17 @@ class AppCenterUITests: XCTestCase {
     app.buttons["App Center"].tap();
 
     // Check install id.
-    let installIdCell : XCUIElement = app.cells.element(boundBy: 5);
+    let installIdCell : XCUIElement = app.tables["App Center"].cell(containing: "Install ID");
     let installId : String = installIdCell.staticTexts.element(boundBy: 1).label;
     XCTAssertNotNil(UUID(uuidString: installId));
 
     // Check app secret.
-    let appSecretCell : XCUIElement = app.cells.element(boundBy: 6);
+    let appSecretCell : XCUIElement = app.tables["App Center"].cell(containing: "App Secret");
     let appSecret : String = appSecretCell.staticTexts.element(boundBy: 1).label;
     XCTAssertNotNil(UUID(uuidString: appSecret));
 
     // Check log url.
-    let logUrlCell : XCUIElement = app.cells.element(boundBy: 7);
+    let logUrlCell : XCUIElement = app.tables["App Center"].cell(containing: "Log URL");
     let logUrl : String = logUrlCell.staticTexts.element(boundBy: 1).label;
     XCTAssertNotNil(URL(string: logUrl));
   }

--- a/Puppet/PuppetUITests/AppCenterUITests.swift
+++ b/Puppet/PuppetUITests/AppCenterUITests.swift
@@ -167,7 +167,7 @@ class AppCenterUITests: XCTestCase {
     
     // Send properties.
     customPropertiesTable.buttons["Send Custom Properties"].tap()
-    app.alerts.firstMatch.buttons["OK"].tap()
+    app.alerts.element.buttons["OK"].tap()
   }
 
   func testMiscellaneousInfo() {

--- a/Puppet/PuppetUITests/AppCenterUITests.swift
+++ b/Puppet/PuppetUITests/AppCenterUITests.swift
@@ -88,7 +88,7 @@ class AppCenterUITests: XCTestCase {
    *   https://forums.developer.apple.com/thread/61287
    *   http://www.openradar.me/radar?id=5057804138184704
    */
-  func testDisableSDKPersistance() {
+  func testDisableSDKPersistence() {
     guard let `app` = app else {
       XCTFail()
       return

--- a/Puppet/PuppetUITests/AppCenterUITests.swift
+++ b/Puppet/PuppetUITests/AppCenterUITests.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 class AppCenterUITests: XCTestCase {
-  private var app : XCUIApplication?;
+  private var app : XCUIApplication?
 
   override func setUp() {
     super.setUp()
@@ -10,76 +10,76 @@ class AppCenterUITests: XCTestCase {
     continueAfterFailure = false
 
     // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-    app = XCUIApplication();
-    app?.launch();
+    app = XCUIApplication()
+    app?.launch()
     guard let `app` = app else {
-      return;
+      return
     }
 
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    let appCenterButton : XCUIElement = app.switches["Set Enabled"];
+    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
     if (!appCenterButton.boolValue) {
-      appCenterButton.tap();
+      appCenterButton.tap()
     }
   }
 
   func testEnableDisableSDK() {
     guard let `app` = app else {
-      XCTFail();
-      return;
+      XCTFail()
+      return
     }
-    let appCenterButton : XCUIElement = app.switches["Set Enabled"];
+    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
 
     // SDK should be enabled.
-    XCTAssertTrue(appCenterButton.boolValue);
+    XCTAssertTrue(appCenterButton.boolValue)
 
     // Disable SDK.
-    appCenterButton.tap();
+    appCenterButton.tap()
 
     // All services should be disabled.
     // Analytics.
-    app.tables["App Center"].staticTexts["Analytics"].tap();
-    XCTAssertFalse(app.tables["Analytics"].switches["Set Enabled"].boolValue);
-    app.buttons["App Center"].tap();
+    app.tables["App Center"].staticTexts["Analytics"].tap()
+    XCTAssertFalse(app.tables["Analytics"].switches["Set Enabled"].boolValue)
+    app.buttons["App Center"].tap()
 
     // Crashes.
-    app.tables["App Center"].staticTexts["Crashes"].tap();
-    XCTAssertFalse(app.tables["Crashes"].switches["Set Enabled"].boolValue);
-    app.buttons["App Center"].tap();
+    app.tables["App Center"].staticTexts["Crashes"].tap()
+    XCTAssertFalse(app.tables["Crashes"].switches["Set Enabled"].boolValue)
+    app.buttons["App Center"].tap()
 
     // Distribute.
-    app.tables["App Center"].staticTexts["Distribute"].tap();
-    XCTAssertFalse( app.tables["Distribute"].switches["Set Enabled"].boolValue);
-    app.buttons["App Center"].tap();
+    app.tables["App Center"].staticTexts["Distribute"].tap()
+    XCTAssertFalse(app.tables["Distribute"].switches["Set Enabled"].boolValue)
+    app.buttons["App Center"].tap()
     
     // Push.
-    app.tables["App Center"].staticTexts["Push"].tap();
-    XCTAssertFalse(app.tables["Push"].switches["Set Enabled"].boolValue);
-    app.buttons["App Center"].tap();
+    app.tables["App Center"].staticTexts["Push"].tap()
+    XCTAssertFalse(app.tables["Push"].switches["Set Enabled"].boolValue)
+    app.buttons["App Center"].tap()
 
     // Enable SDK.
-    appCenterButton.tap();
+    appCenterButton.tap()
 
     // All services should be enabled.
     // Analytics.
-    app.tables["App Center"].staticTexts["Analytics"].tap();
-    XCTAssertTrue(app.tables["Analytics"].switches["Set Enabled"].boolValue);
-    app.buttons["App Center"].tap();
+    app.tables["App Center"].staticTexts["Analytics"].tap()
+    XCTAssertTrue(app.tables["Analytics"].switches["Set Enabled"].boolValue)
+    app.buttons["App Center"].tap()
 
     // Crashes.
-    app.tables["App Center"].staticTexts["Crashes"].tap();
-    XCTAssertTrue(app.tables["Crashes"].switches["Set Enabled"].boolValue);
-    app.buttons["App Center"].tap();
+    app.tables["App Center"].staticTexts["Crashes"].tap()
+    XCTAssertTrue(app.tables["Crashes"].switches["Set Enabled"].boolValue)
+    app.buttons["App Center"].tap()
 
     // Distribute.
-    app.tables["App Center"].staticTexts["Distribute"].tap();
-    XCTAssertTrue(app.tables["Distribute"].switches["Set Enabled"].boolValue);
-    app.buttons["App Center"].tap();
+    app.tables["App Center"].staticTexts["Distribute"].tap()
+    XCTAssertTrue(app.tables["Distribute"].switches["Set Enabled"].boolValue)
+    app.buttons["App Center"].tap()
     
     // Push.
-    app.tables["App Center"].staticTexts["Push"].tap();
-    XCTAssertTrue(app.tables["Push"].switches["Set Enabled"].boolValue);
-    app.buttons["App Center"].tap();
+    app.tables["App Center"].staticTexts["Push"].tap()
+    XCTAssertTrue(app.tables["Push"].switches["Set Enabled"].boolValue)
+    app.buttons["App Center"].tap()
   }
 
   /**
@@ -87,15 +87,15 @@ class AppCenterUITests: XCTestCase {
    */
   func testDisableSDKPersistance() {
     guard let `app` = app else {
-      XCTFail();
-      return;
+      XCTFail()
+      return
     }
-    var appCenterButton = app.switches["Set Enabled"];
-    XCTAssertTrue(appCenterButton.boolValue, "AppCenter doesn't enabled by default");
+    var appCenterButton = app.switches["Set Enabled"]
+    XCTAssertTrue(appCenterButton.boolValue, "AppCenter doesn't enabled by default")
     
     // Disable SDK.
-    appCenterButton.tap();
-    XCTAssertFalse(appCenterButton.boolValue);
+    appCenterButton.tap()
+    XCTAssertFalse(appCenterButton.boolValue)
     
     // Several attempts for sure.
     for i in 0..<10 {
@@ -106,13 +106,13 @@ class AppCenterUITests: XCTestCase {
       sleep(1)
       app.launch()
       
-      appCenterButton = app.switches["Set Enabled"];
-      XCTAssertFalse(appCenterButton.boolValue, "AppCenter doesn't disabled on next application run (\(i * 2 + 2) run)");
+      appCenterButton = app.switches["Set Enabled"]
+      XCTAssertFalse(appCenterButton.boolValue, "AppCenter doesn't disabled on next application run (\(i * 2 + 2) run)")
       
       // Enable SDK.
-      appCenterButton.tap();
+      appCenterButton.tap()
       
-      XCTAssertTrue(appCenterButton.boolValue);
+      XCTAssertTrue(appCenterButton.boolValue)
       
       // Restart application.
       sleep(1)
@@ -120,23 +120,23 @@ class AppCenterUITests: XCTestCase {
       sleep(1)
       app.launch()
       
-      appCenterButton = app.switches["Set Enabled"];
-      XCTAssertTrue(appCenterButton.boolValue, "AppCenter doesn't enabled on next application run (\(i * 2 + 3) run)");
+      appCenterButton = app.switches["Set Enabled"]
+      XCTAssertTrue(appCenterButton.boolValue, "AppCenter doesn't enabled on next application run (\(i * 2 + 3) run)")
       
       // Disable SDK.
-      appCenterButton.tap();
+      appCenterButton.tap()
       
-      XCTAssertFalse(appCenterButton.boolValue);
+      XCTAssertFalse(appCenterButton.boolValue)
     }
   }
 
   func testCustomProperties() {
     guard let `app` = app else {
-      return;
+      return
     }
     app.tables["App Center"].staticTexts["Custom Properties"].tap()
     
-    let customPropertiesTable = app.tables["Custom Properties"];
+    let customPropertiesTable = app.tables["Custom Properties"]
     
     customPropertiesTable.staticTexts["Add Property"].tap()
     let stringPropertyCell = customPropertiesTable.cells.element(boundBy: 0)
@@ -154,34 +154,34 @@ class AppCenterUITests: XCTestCase {
 
   func testMiscellaneousInfo() {
     guard let `app` = app else {
-      XCTFail();
-      return;
+      XCTFail()
+      return
     }
 
     // Go to device info page.
-    app.tables["App Center"].staticTexts["Device Info"].tap();
+    app.tables["App Center"].staticTexts["Device Info"].tap()
 
     // Check device info. Device info shouldn't contain an empty info.
     for cellIndex in 0..<app.cells.count {
-      let cell : XCUIElement = app.cells.element(boundBy: cellIndex);
-      let deviceInfo : String = cell.staticTexts.element(boundBy: 1).label;
-      XCTAssertNotNil(deviceInfo);
+      let cell : XCUIElement = app.cells.element(boundBy: cellIndex)
+      let deviceInfo : String = cell.staticTexts.element(boundBy: 1).label
+      XCTAssertNotNil(deviceInfo)
     }
-    app.buttons["App Center"].tap();
+    app.buttons["App Center"].tap()
 
     // Check install id.
-    let installIdCell : XCUIElement = app.tables["App Center"].cell(containing: "Install ID");
-    let installId : String = installIdCell.staticTexts.element(boundBy: 1).label;
-    XCTAssertNotNil(UUID(uuidString: installId));
+    let installIdCell : XCUIElement = app.tables["App Center"].cell(containing: "Install ID")
+    let installId : String = installIdCell.staticTexts.element(boundBy: 1).label
+    XCTAssertNotNil(UUID(uuidString: installId))
 
     // Check app secret.
-    let appSecretCell : XCUIElement = app.tables["App Center"].cell(containing: "App Secret");
-    let appSecret : String = appSecretCell.staticTexts.element(boundBy: 1).label;
-    XCTAssertNotNil(UUID(uuidString: appSecret));
+    let appSecretCell : XCUIElement = app.tables["App Center"].cell(containing: "App Secret")
+    let appSecret : String = appSecretCell.staticTexts.element(boundBy: 1).label
+    XCTAssertNotNil(UUID(uuidString: appSecret))
 
     // Check log url.
-    let logUrlCell : XCUIElement = app.tables["App Center"].cell(containing: "Log URL");
-    let logUrl : String = logUrlCell.staticTexts.element(boundBy: 1).label;
-    XCTAssertNotNil(URL(string: logUrl));
+    let logUrlCell : XCUIElement = app.tables["App Center"].cell(containing: "Log URL")
+    let logUrl : String = logUrlCell.staticTexts.element(boundBy: 1).label
+    XCTAssertNotNil(URL(string: logUrl))
   }
 }

--- a/Puppet/PuppetUITests/AppCenterUITests.swift
+++ b/Puppet/PuppetUITests/AppCenterUITests.swift
@@ -143,8 +143,7 @@ class AppCenterUITests: XCTestCase {
     customPropertiesTable.staticTexts["Add Property"].tap()
     let clearPropertyCell = customPropertiesTable.cells.element(boundBy: 0)
     XCTAssertEqual("Clear", clearPropertyCell.textFields["Type"].value as! String)
-    clearPropertyCell.textFields["Key"].tap()
-    clearPropertyCell.textFields["Key"].typeText("key0")
+    clearPropertyCell.textFields["Key"].clearAndTypeText("key0")
     
     // Add string property.
     customPropertiesTable.staticTexts["Add Property"].tap()
@@ -153,10 +152,8 @@ class AppCenterUITests: XCTestCase {
     app.pickerWheels.element.adjust(toPickerWheelValue: "String")
     app.toolbars.buttons["Done"].tap()
     XCTAssertEqual("String", stringPropertyCell.textFields["Type"].value as! String)
-    stringPropertyCell.textFields["Key"].tap()
-    stringPropertyCell.textFields["Key"].typeText("key1")
-    stringPropertyCell.textFields["Value"].tap()
-    stringPropertyCell.textFields["Value"].typeText("test1")
+    stringPropertyCell.textFields["Key"].clearAndTypeText("key1")
+    stringPropertyCell.textFields["Value"].clearAndTypeText("test1")
     
     // Add number property.
     customPropertiesTable.staticTexts["Add Property"].tap()
@@ -165,10 +162,8 @@ class AppCenterUITests: XCTestCase {
     app.pickerWheels.element.adjust(toPickerWheelValue: "Number")
     app.toolbars.buttons["Done"].tap()
     XCTAssertEqual("Number", numbarPropertyCell.textFields["Type"].value as! String)
-    numbarPropertyCell.textFields["Key"].tap()
-    numbarPropertyCell.textFields["Key"].typeText("key2")
-    numbarPropertyCell.textFields["Value"].tap()
-    numbarPropertyCell.textFields["Value"].typeText("-42.42")
+    numbarPropertyCell.textFields["Key"].clearAndTypeText("key2")
+    numbarPropertyCell.textFields["Value"].clearAndTypeText("-42.42")
     
     // Send properties.
     customPropertiesTable.buttons["Send Custom Properties"].tap()

--- a/Puppet/PuppetUITests/AppCenterUITests.swift
+++ b/Puppet/PuppetUITests/AppCenterUITests.swift
@@ -86,6 +86,53 @@ class AppCenterUITests: XCTestCase {
     app.buttons["App Center"].tap();
   }
 
+  /**
+   * There is a known bug with user defaults on iOS >= 10.
+   */
+  func testDisableSDKPersistance() {
+    guard let `app` = app else {
+      return;
+    }
+    var appCenterButton = app.switches["Set Enabled"];
+    XCTAssertTrue(appCenterButton.boolValue, "AppCenter doesn't enabled by default");
+    
+    // Disable SDK.
+    appCenterButton.tap();
+    XCTAssertFalse(appCenterButton.boolValue);
+    
+    // Several attempts for sure.
+    for i in 0..<10 {
+      
+      // Restart application.
+      sleep(1)
+      XCUIDevice().press(.home)
+      sleep(1)
+      app.launch()
+      
+      appCenterButton = app.switches["Set Enabled"];
+      XCTAssertFalse(appCenterButton.boolValue, "AppCenter doesn't disabled on next application run (\(i * 2 + 2) run)");
+      
+      // Enable SDK.
+      appCenterButton.tap();
+      
+      XCTAssertTrue(appCenterButton.boolValue);
+      
+      // Restart application.
+      sleep(1)
+      XCUIDevice().press(XCUIDeviceButton.home)
+      sleep(1)
+      app.launch()
+      
+      appCenterButton = app.switches["Set Enabled"];
+      XCTAssertTrue(appCenterButton.boolValue, "AppCenter doesn't enabled on next application run (\(i * 2 + 3) run)");
+      
+      // Disable SDK.
+      appCenterButton.tap();
+      
+      XCTAssertFalse(appCenterButton.boolValue);
+    }
+  }
+
   func testMiscellaneousInfo() {
     guard let `app` = app else {
       return;

--- a/Puppet/PuppetUITests/AppCenterUITests.swift
+++ b/Puppet/PuppetUITests/AppCenterUITests.swift
@@ -2,11 +2,6 @@ import XCTest
 
 class AppCenterUITests: XCTestCase {
   private var app : XCUIApplication?;
-  private let AnalyticsCellIndex : UInt = 0;
-
-  private let kDidSentEventText : String = "Sent event occurred";
-  private let kDidFailedToSendEventText : String = "Failed to send event occurred";
-  private let kDidSendingEventText : String = "Sending event occurred";
 
   override func setUp() {
     super.setUp()
@@ -30,6 +25,7 @@ class AppCenterUITests: XCTestCase {
 
   func testEnableDisableSDK() {
     guard let `app` = app else {
+      XCTFail();
       return;
     }
     let appCenterButton : XCUIElement = app.switches["Set Enabled"];
@@ -91,6 +87,7 @@ class AppCenterUITests: XCTestCase {
    */
   func testDisableSDKPersistance() {
     guard let `app` = app else {
+      XCTFail();
       return;
     }
     var appCenterButton = app.switches["Set Enabled"];
@@ -133,8 +130,31 @@ class AppCenterUITests: XCTestCase {
     }
   }
 
+  func testCustomProperties() {
+    guard let `app` = app else {
+      return;
+    }
+    app.tables["App Center"].staticTexts["Custom Properties"].tap()
+    
+    let customPropertiesTable = app.tables["Custom Properties"];
+    
+    customPropertiesTable.staticTexts["Add Property"].tap()
+    let stringPropertyCell = customPropertiesTable.cells.element(boundBy: 0)
+    stringPropertyCell.children(matching: .textField).element(boundBy: 0).tap()
+    app.pickerWheels.element.adjust(toPickerWheelValue: "String")
+    app.toolbars.buttons["Done"].tap()
+    stringPropertyCell.textFields["Key"].tap()
+    stringPropertyCell.textFields["Key"].typeText("key1")
+    stringPropertyCell.textFields["Value"].tap()
+    stringPropertyCell.textFields["Value"].typeText("test1")
+    
+    customPropertiesTable.buttons["Send Custom Properties"].tap()
+    app.alerts["The custom properties log is queued"].buttons["OK"].tap()
+  }
+
   func testMiscellaneousInfo() {
     guard let `app` = app else {
+      XCTFail();
       return;
     }
 

--- a/Puppet/PuppetUITests/AppCenterUITests.swift
+++ b/Puppet/PuppetUITests/AppCenterUITests.swift
@@ -15,9 +15,13 @@ class AppCenterUITests: XCTestCase {
     guard let `app` = app else {
       return
     }
+    
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    handleSystemAlert()
+
 
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
+    let appCenterButton = app.tables["App Center"].switches["Set Enabled"]
     if (!appCenterButton.boolValue) {
       appCenterButton.tap()
     }
@@ -28,7 +32,7 @@ class AppCenterUITests: XCTestCase {
       XCTFail()
       return
     }
-    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
+    let appCenterButton = app.tables["App Center"].switches["Set Enabled"]
 
     // SDK should be enabled.
     XCTAssertTrue(appCenterButton.boolValue)

--- a/Puppet/PuppetUITests/AppCenterUITests.swift
+++ b/Puppet/PuppetUITests/AppCenterUITests.swift
@@ -17,7 +17,7 @@ class AppCenterUITests: XCTestCase {
     }
 
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
+    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
     if (!appCenterButton.boolValue) {
       appCenterButton.tap()
     }
@@ -28,7 +28,7 @@ class AppCenterUITests: XCTestCase {
       XCTFail()
       return
     }
-    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
+    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
 
     // SDK should be enabled.
     XCTAssertTrue(appCenterButton.boolValue)
@@ -93,7 +93,7 @@ class AppCenterUITests: XCTestCase {
       XCTFail()
       return
     }
-    var appCenterButton = app.switches["Set Enabled"]
+    var appCenterButton = app.tables["App Center"].switches["Set Enabled"]
     XCTAssertTrue(appCenterButton.boolValue, "AppCenter doesn't enabled by default")
     
     // Disable SDK.
@@ -109,7 +109,7 @@ class AppCenterUITests: XCTestCase {
       sleep(1)
       app.launch()
       
-      appCenterButton = app.switches["Set Enabled"]
+      appCenterButton = app.tables["App Center"].switches["Set Enabled"]
       XCTAssertFalse(appCenterButton.boolValue, "AppCenter doesn't disabled on next application run (\(i * 2 + 2) run)")
       
       // Enable SDK.
@@ -123,7 +123,7 @@ class AppCenterUITests: XCTestCase {
       sleep(1)
       app.launch()
       
-      appCenterButton = app.switches["Set Enabled"]
+      appCenterButton = app.tables["App Center"].switches["Set Enabled"]
       XCTAssertTrue(appCenterButton.boolValue, "AppCenter doesn't enabled on next application run (\(i * 2 + 3) run)")
       
       // Disable SDK.

--- a/Puppet/PuppetUITests/CrashesUITests.swift
+++ b/Puppet/PuppetUITests/CrashesUITests.swift
@@ -1,8 +1,7 @@
 import XCTest
 
 class CrashesUITests: XCTestCase {
-  private var app : XCUIApplication?;
-  private let CrashesCellIndex : UInt = 1;
+  private var app : XCUIApplication?
 
   override func setUp() {
     super.setUp()
@@ -11,64 +10,66 @@ class CrashesUITests: XCTestCase {
     continueAfterFailure = false
 
     // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-    app = XCUIApplication();
-    app?.launch();
+    app = XCUIApplication()
+    app?.launch()
+    guard let `app` = app else {
+      return;
+    }
 
     // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
 
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    if let appCenterButton : XCUIElement = app?.switches["Set Enabled"] {
-      if (appCenterButton.value as! String == "0") {
-        appCenterButton.tap();
-      }
+    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
+    if (!appCenterButton.boolValue) {
+      appCenterButton.tap()
     }
   }
 
   func testCrashes() {
     guard let `app` = app else {
       XCTFail();
-      return;
+      return
     }
 
     // Go to crashes page and find "Set Enabled" button.
-    app.tables.cells.element(boundBy: CrashesCellIndex).tap();
-    let crashesButton : XCUIElement = app.switches.element(boundBy: 0);
+    app.tables["App Center"].staticTexts["Crashes"].tap()
+    let crashesButton : XCUIElement = app.tables["Crashes"].switches["Set Enabled"]
 
     // Service should be enabled by default.
-    XCTAssertEqual("1", crashesButton.value as! String);
+    XCTAssertTrue(crashesButton.boolValue)
 
     // Disable service.
-    crashesButton.tap();
+    crashesButton.tap()
 
     // Button is disabled.
-    XCTAssertEqual("0", crashesButton.value as! String);
+    XCTAssertFalse(crashesButton.boolValue)
 
     // Go back to start page.
-    app.buttons["App Center"].tap();
-    let appCenterButton : XCUIElement = app.switches.element(boundBy: 0);
+    app.buttons["App Center"].tap()
+    let appCenterButton : XCUIElement = app.switches.element(boundBy: 0)
 
     // SDK should be enabled.
-    XCTAssertEqual("1", appCenterButton.value as! String);
+    XCTAssertTrue(appCenterButton.boolValue)
 
     // Disable SDK.
-    appCenterButton.tap();
+    appCenterButton.tap()
 
     // Go to crash page again.
-    app.cells.element(boundBy: CrashesCellIndex).tap();
+    app.tables["App Center"].staticTexts["Crashes"].tap()
 
     // Button should be disabled.
-    XCTAssertEqual("0", crashesButton.value as! String);
+    XCTAssertFalse(crashesButton.boolValue)
 
     // Go back and enable SDK.
-    app.buttons["App Center"].tap();
+    app.buttons["App Center"].tap()
 
     // Enable SDK.
-    appCenterButton.tap();
+    appCenterButton.tap()
 
     // Go to crashes page.
-    app.tables.cells.element(boundBy: CrashesCellIndex).tap();
+    app.tables["App Center"].staticTexts["Crashes"].tap()
 
     // Service should be enabled.
-    XCTAssertEqual("1", crashesButton.value as! String);
+    XCTAssertTrue(crashesButton.boolValue)
   }
 }

--- a/Puppet/PuppetUITests/CrashesUITests.swift
+++ b/Puppet/PuppetUITests/CrashesUITests.swift
@@ -19,7 +19,7 @@ class CrashesUITests: XCTestCase {
     // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
 
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
+    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
     if (!appCenterButton.boolValue) {
       appCenterButton.tap()
     }

--- a/Puppet/PuppetUITests/CrashesUITests.swift
+++ b/Puppet/PuppetUITests/CrashesUITests.swift
@@ -15,11 +15,12 @@ class CrashesUITests: XCTestCase {
     guard let `app` = app else {
       return;
     }
-
+    
     // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    handleSystemAlert()
 
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
+    let appCenterButton = app.tables["App Center"].switches["Set Enabled"]
     if (!appCenterButton.boolValue) {
       appCenterButton.tap()
     }
@@ -33,7 +34,7 @@ class CrashesUITests: XCTestCase {
 
     // Go to crashes page and find "Set Enabled" button.
     app.tables["App Center"].staticTexts["Crashes"].tap()
-    let crashesButton : XCUIElement = app.tables["Crashes"].switches["Set Enabled"]
+    let crashesButton = app.tables["Crashes"].switches["Set Enabled"]
 
     // Service should be enabled by default.
     XCTAssertTrue(crashesButton.boolValue)
@@ -46,7 +47,7 @@ class CrashesUITests: XCTestCase {
 
     // Go back to start page.
     app.buttons["App Center"].tap()
-    let appCenterButton : XCUIElement = app.switches.element(boundBy: 0)
+    let appCenterButton = app.switches.element(boundBy: 0)
 
     // SDK should be enabled.
     XCTAssertTrue(appCenterButton.boolValue)

--- a/Puppet/PuppetUITests/DistributeUITests.swift
+++ b/Puppet/PuppetUITests/DistributeUITests.swift
@@ -17,9 +17,10 @@ class DistributeUITests: XCTestCase {
     }
 
     // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    handleSystemAlert()
 
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
+    let appCenterButton = app.tables["App Center"].switches["Set Enabled"]
     if (!appCenterButton.boolValue) {
       appCenterButton.tap()
     }
@@ -33,7 +34,7 @@ class DistributeUITests: XCTestCase {
 
     // Go to distribute page and find "Set Enabled" button.
     app.tables["App Center"].staticTexts["Distribute"].tap()
-    let distributeButton : XCUIElement = app.tables["Distribute"].switches["Set Enabled"]
+    let distributeButton = app.tables["Distribute"].switches["Set Enabled"]
 
     // Service should be enabled by default.
     XCTAssertTrue(distributeButton.boolValue)
@@ -46,7 +47,7 @@ class DistributeUITests: XCTestCase {
 
     // Go back to start page.
     app.buttons["App Center"].tap()
-    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
+    let appCenterButton = app.tables["App Center"].switches["Set Enabled"]
 
     // SDK should be enabled.
     XCTAssertTrue(appCenterButton.boolValue)

--- a/Puppet/PuppetUITests/DistributeUITests.swift
+++ b/Puppet/PuppetUITests/DistributeUITests.swift
@@ -1,8 +1,7 @@
 import XCTest
 
 class DistributeUITests: XCTestCase {
-  private var app : XCUIApplication?;
-  private let DistributeCellIndex : UInt = 2;
+  private var app : XCUIApplication?
 
   override func setUp() {
     super.setUp()
@@ -11,62 +10,64 @@ class DistributeUITests: XCTestCase {
     continueAfterFailure = false
 
     // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-    app = XCUIApplication();
-    app?.launch();
+    app = XCUIApplication()
+    app?.launch()
+    guard let `app` = app else {
+      return
+    }
 
     // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
 
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    if let appCenterButton : XCUIElement = app?.switches["Set Enabled"] {
-      if (appCenterButton.value as! String == "0") {
-        appCenterButton.tap();
-      }
+    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
+    if (!appCenterButton.boolValue) {
+      appCenterButton.tap()
     }
   }
 
   func testDistribute() {
     guard let `app` = app else {
-      XCTFail();
-      return;
+      XCTFail()
+      return
     }
 
     // Go to distribute page and find "Set Enabled" button.
-    app.tables.cells.element(boundBy: DistributeCellIndex).tap();
-    let distributeButton : XCUIElement = app.switches.element(matching: XCUIElementType.switch, identifier: "Set Enabled");
+    app.tables["App Center"].staticTexts["Distribute"].tap()
+    let distributeButton : XCUIElement = app.tables["Distribute"].switches["Set Enabled"]
 
     // Service should be enabled by default.
-    XCTAssertEqual("1", distributeButton.value as! String);
+    XCTAssertTrue(distributeButton.boolValue)
 
     // Disable service.
-    distributeButton.tap();
+    distributeButton.tap()
 
     // Button is disabled.
-    XCTAssertEqual("0", distributeButton.value as! String);
+    XCTAssertFalse(distributeButton.boolValue)
 
     // Go back to start page.
-    app.buttons["App Center"].tap();
-    let appCenterButton : XCUIElement = app.switches.element(boundBy: 0);
+    app.buttons["App Center"].tap()
+    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
 
     // SDK should be enabled.
-    XCTAssertEqual("1", appCenterButton.value as! String);
+    XCTAssertTrue(appCenterButton.boolValue)
 
     // Disable SDK.
-    appCenterButton.tap();
+    appCenterButton.tap()
 
     // Go to distribute page.
-    app.tables.cells.element(boundBy: DistributeCellIndex).tap();
+    app.tables["App Center"].staticTexts["Distribute"].tap()
 
     // Button should be disabled.
-    XCTAssertEqual("0", distributeButton.value as! String);
+    XCTAssertFalse(distributeButton.boolValue)
 
     // Go back and enable SDK.
-    app.buttons["App Center"].tap();
-    appCenterButton.tap();
+    app.buttons["App Center"].tap()
+    appCenterButton.tap()
 
     // Go to distribute page.
-    app.tables.cells.element(boundBy: DistributeCellIndex).tap();
+    app.tables["App Center"].staticTexts["Distribute"].tap()
     
     // Service should be enabled.
-    XCTAssertEqual("1", distributeButton.value as! String);
+    XCTAssertTrue(distributeButton.boolValue)
   }
 }

--- a/Puppet/PuppetUITests/DistributeUITests.swift
+++ b/Puppet/PuppetUITests/DistributeUITests.swift
@@ -19,7 +19,7 @@ class DistributeUITests: XCTestCase {
     // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
 
     // Enable SDK (we need it in case SDK was disabled by the test, which then failed and didn't enabled SDK back).
-    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
+    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
     if (!appCenterButton.boolValue) {
       appCenterButton.tap()
     }
@@ -46,7 +46,7 @@ class DistributeUITests: XCTestCase {
 
     // Go back to start page.
     app.buttons["App Center"].tap()
-    let appCenterButton : XCUIElement = app.switches["Set Enabled"]
+    let appCenterButton : XCUIElement = app.tables["App Center"].switches["Set Enabled"]
 
     // SDK should be enabled.
     XCTAssertTrue(appCenterButton.boolValue)

--- a/Puppet/PuppetUITests/Helpers.swift
+++ b/Puppet/PuppetUITests/Helpers.swift
@@ -1,0 +1,22 @@
+import XCTest
+
+extension XCUIElement {
+  var boolValue : Bool {
+    get {
+      return self.value as! String == "1"
+    }
+  }
+  
+  private func filterCells(containing labels: [String]) -> XCUIElementQuery {
+    var cells = self.cells
+    
+    for label in labels {
+      cells = cells.containing(NSPredicate(format: "label CONTAINS %@", label))
+    }
+    return cells
+  }
+  
+  func cell(containing labels: String...) -> XCUIElement {
+    return filterCells(containing: labels).element
+  }
+}

--- a/Puppet/PuppetUITests/Helpers.swift
+++ b/Puppet/PuppetUITests/Helpers.swift
@@ -9,7 +9,6 @@ extension XCUIElement {
   
   private func filterCells(containing labels: [String]) -> XCUIElementQuery {
     var cells = self.cells
-    
     for label in labels {
       cells = cells.containing(NSPredicate(format: "label CONTAINS %@", label))
     }
@@ -18,5 +17,18 @@ extension XCUIElement {
   
   func cell(containing labels: String...) -> XCUIElement {
     return filterCells(containing: labels).element
+  }
+  
+  /**
+   * Clear any current text in the field before typing in the new value.
+   */
+  func clearAndTypeText(_ text: String) {
+    guard let stringValue = self.value as? String else {
+      XCTFail("Tried to clear and type text into a non string value")
+      return
+    }
+    self.tap()
+    self.typeText(stringValue.characters.map { _ in XCUIKeyboardKeyDelete }.joined(separator: ""))
+    self.typeText(text)
   }
 }

--- a/Puppet/PuppetUITests/Helpers.swift
+++ b/Puppet/PuppetUITests/Helpers.swift
@@ -1,12 +1,19 @@
 import XCTest
 
 extension XCUIElement {
+  
+  /**
+   * Return bool value. Useful for switches.
+   */
   var boolValue : Bool {
     get {
       return self.value as! String == "1"
     }
   }
   
+  /**
+   * Filter cells by label.
+   */
   private func filterCells(containing labels: [String]) -> XCUIElementQuery {
     var cells = self.cells
     for label in labels {
@@ -15,6 +22,9 @@ extension XCUIElement {
     return cells
   }
   
+  /**
+   * Find cell with label contains the string.
+   */
   func cell(containing labels: String...) -> XCUIElement {
     return filterCells(containing: labels).element
   }

--- a/Puppet/PuppetUITests/Helpers.swift
+++ b/Puppet/PuppetUITests/Helpers.swift
@@ -33,12 +33,10 @@ extension XCUIElement {
    * Clear any current text in the field before typing in the new value.
    */
   func clearAndTypeText(_ text: String) {
-    guard let stringValue = self.value as? String else {
-      XCTFail("Tried to clear and type text into a non string value")
-      return
-    }
     self.tap()
-    self.typeText(stringValue.characters.map { _ in XCUIKeyboardKeyDelete }.joined(separator: ""))
+    if let stringValue = self.value as? String {
+      self.typeText(stringValue.characters.map { _ in XCUIKeyboardKeyDelete }.joined(separator: ""))
+    }
     self.typeText(text)
   }
 }

--- a/Puppet/PuppetUITests/Helpers.swift
+++ b/Puppet/PuppetUITests/Helpers.swift
@@ -42,3 +42,37 @@ extension XCUIElement {
     self.typeText(text)
   }
 }
+
+extension XCTestCase {
+  
+  /**
+   * Deal with system alerts.
+   */
+  func handleSystemAlert() {
+    
+    // Note: addUIInterruptionMonitor doesn't work.
+    // See https://forums.developer.apple.com/thread/86989
+    
+    // Use springboard.
+    let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+    let alert = springboard.alerts.element
+    
+    // There is some alert.
+    if (alert.exists) {
+      
+      // In case if this is some permission dialog, allow it.
+      let allow = alert.buttons["Allow"]
+      if (allow.exists) {
+        allow.tap()
+        return
+      }
+      
+      // "OK" button for allow in iOS 9.
+      let ok = alert.buttons["OK"]
+      if (ok.exists) {
+        ok.tap()
+        return
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Actualize existing tests (broken after UI changes);
- Simplify tests code using helpers and setting identifiers;
- Added test for settings persistence (failing on iOS 10 and later);
- Added simple test for custom properties;

PS I faced with [XCode 8.3 bug](https://forums.developer.apple.com/thread/75546), on other versions should work fine.