### PR TITLE
Add tracking of the distribution group ID to Analytics

### DIFF
--- a/AppCenter/AppCenter.xcodeproj/project.pbxproj
+++ b/AppCenter/AppCenter.xcodeproj/project.pbxproj
@@ -361,6 +361,8 @@
 		38E1B67A1DDE3FDF000EFED1 /* MSAppCenterPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 38E1B6791DDE3FDF000EFED1 /* MSAppCenterPrivate.h */; };
 		38F1944E1DADB93100D3E0FE /* MSHttpSenderPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 38F1944D1DADB93100D3E0FE /* MSHttpSenderPrivate.h */; };
 		38FD798F1EB7B0B800DE2FB3 /* MSAppCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E0401551D1C9AAA0051BCFA /* MSAppCenter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		58603633B718B7A2702C23CB /* MSAbstractLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 58603EA088552D6FBB8EBE6C /* MSAbstractLogTests.m */; };
+		58603867BA3B4B1CB87D0E5D /* MSAbstractLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 58603EA088552D6FBB8EBE6C /* MSAbstractLogTests.m */; };
 		5C7877921EA0CFF3002263CC /* MSLogDBStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C7877911EA0CFF3002263CC /* MSLogDBStorageTests.m */; };
 		6E0401571D1C9AAA0051BCFA /* MSAppCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E0401561D1C9AAA0051BCFA /* MSAppCenter.m */; };
 		6E04016B1D1C9E1F0051BCFA /* MSConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E04013F1D1C99AC0051BCFA /* MSConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -661,6 +663,7 @@
 		38C633C81FDF163D005F40C9 /* MSAppDelegateUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSAppDelegateUtil.h; sourceTree = "<group>"; };
 		38E1B6791DDE3FDF000EFED1 /* MSAppCenterPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSAppCenterPrivate.h; sourceTree = "<group>"; };
 		38F1944D1DADB93100D3E0FE /* MSHttpSenderPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSHttpSenderPrivate.h; sourceTree = "<group>"; };
+		58603EA088552D6FBB8EBE6C /* MSAbstractLogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSAbstractLogTests.m; sourceTree = "<group>"; };
 		5C7877911EA0CFF3002263CC /* MSLogDBStorageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSLogDBStorageTests.m; sourceTree = "<group>"; };
 		6E0401031D1C98220051BCFA /* libAppCenter.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAppCenter.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E04013F1D1C99AC0051BCFA /* MSConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSConstants.h; sourceTree = "<group>"; };
@@ -1137,6 +1140,7 @@
 				6E2395831D22EF5F00E543C8 /* Frameworks */,
 				04A140AB1ECE7F6F001CEE94 /* Support */,
 				6E363AEF1D2C84D60079043D /* Util */,
+				58603EA088552D6FBB8EBE6C /* MSAbstractLogTests.m */,
 			);
 			path = AppCenterTests;
 			sourceTree = "<group>";
@@ -1849,6 +1853,7 @@
 				046AEAEB1ECA562A00CBE511 /* MSMockLog.m in Sources */,
 				049378421FE4914D000ADBAF /* MSSessionContextTests.m in Sources */,
 				046AEAEC1ECA562A00CBE511 /* MSChannelGroupDefaultTests.m in Sources */,
+				58603633B718B7A2702C23CB /* MSAbstractLogTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1971,6 +1976,7 @@
 				E88D17061D35B6B500A5EA57 /* MSMockLog.m in Sources */,
 				049378411FE4914B000ADBAF /* MSSessionContextTests.m in Sources */,
 				6E48A5A71D383893006E8B5F /* MSChannelGroupDefaultTests.m in Sources */,
+				58603867BA3B4B1CB87D0E5D /* MSAbstractLogTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AppCenter/AppCenter/Internals/Model/MSAbstractLog.m
+++ b/AppCenter/AppCenter/Internals/Model/MSAbstractLog.m
@@ -5,6 +5,7 @@
 #import "MSUtility+Date.h"
 
 static NSString *const kMSSid = @"sid";
+static NSString *const kMSDistributionGroupId = @"distributionGroupId";
 static NSString *const kMSTimestamp = @"timestamp";
 static NSString *const kMSDevice = @"device";
 static NSString *const kMSType = @"type";
@@ -14,6 +15,7 @@ static NSString *const kMSType = @"type";
 @synthesize type = _type;
 @synthesize timestamp = _timestamp;
 @synthesize sid = _sid;
+@synthesize distributionGroupId = _distributionGroupId;
 @synthesize device = _device;
 
 - (NSMutableDictionary *)serializeToDictionary {
@@ -27,6 +29,9 @@ static NSString *const kMSType = @"type";
   }
   if (self.sid) {
     dict[kMSSid] = self.sid;
+  }
+  if (self.distributionGroupId) {
+    dict[kMSDistributionGroupId] = self.distributionGroupId;
   }
   if (self.device) {
     dict[kMSDevice] = [self.device serializeToDictionary];
@@ -46,6 +51,7 @@ static NSString *const kMSType = @"type";
   return ((!self.type && !log.type) || [self.type isEqualToString:log.type]) &&
          ((!self.timestamp && !log.timestamp) || [self.timestamp isEqualToDate:log.timestamp]) &&
          ((!self.sid && !log.sid) || [self.sid isEqualToString:log.sid]) &&
+         ((!self.distributionGroupId && !log.distributionGroupId) || [self.distributionGroupId isEqualToString:log.distributionGroupId]) &&
          ((!self.device && !log.device) || [self.device isEqual:log.device]);
 }
 
@@ -57,6 +63,7 @@ static NSString *const kMSType = @"type";
     _type = [coder decodeObjectForKey:kMSType];
     _timestamp = [coder decodeObjectForKey:kMSTimestamp];
     _sid = [coder decodeObjectForKey:kMSSid];
+    _distributionGroupId = [coder decodeObjectForKey:kMSDistributionGroupId];
     _device = [coder decodeObjectForKey:kMSDevice];
   }
   return self;
@@ -66,6 +73,7 @@ static NSString *const kMSType = @"type";
   [coder encodeObject:self.type forKey:kMSType];
   [coder encodeObject:self.timestamp forKey:kMSTimestamp];
   [coder encodeObject:self.sid forKey:kMSSid];
+  [coder encodeObject:self.distributionGroupId forKey:kMSDistributionGroupId];
   [coder encodeObject:self.device forKey:kMSDevice];
 }
 

--- a/AppCenter/AppCenter/Internals/Model/MSLog.h
+++ b/AppCenter/AppCenter/Internals/Model/MSLog.h
@@ -21,6 +21,11 @@
 @property(nonatomic, copy) NSString *sid;
 
 /**
+ * Optional distribution group ID value.
+ */
+@property(nonatomic, copy) NSString *distributionGroupId;
+
+/**
  * Device properties associated to this log.
  */
 @property(nonatomic) MSDevice *device;

--- a/AppCenter/AppCenter/MSConstants.h
+++ b/AppCenter/AppCenter/MSConstants.h
@@ -60,5 +60,6 @@ static short const kMSPriorityCount = MSPriorityHigh + 1;
  */
 typedef NS_ENUM(NSInteger, MSInitializationPriority) {
   MSInitializationPriorityDefault = 500,
+  MSInitializationPriorityHigh = 750,
   MSInitializationPriorityMax = 999
 };

--- a/AppCenter/AppCenterTests/MSAbstractLogTests.m
+++ b/AppCenter/AppCenterTests/MSAbstractLogTests.m
@@ -1,0 +1,174 @@
+#import "MSAbstractLogInternal.h"
+#import "MSDevice.h"
+#import "MSTestFrameworks.h"
+
+@interface MSAbstractLogTests : XCTestCase
+
+@property(nonatomic, strong) MSAbstractLog *sut;
+
+@end
+
+@implementation MSAbstractLogTests
+
+@synthesize sut = _sut;
+
+#pragma mark - Setup
+
+- (void)setUp {
+  [super setUp];
+  self.sut = [MSAbstractLog new];
+}
+
+#pragma mark - Tests
+
+- (void)testSerializingToDictionaryWorks {
+
+  // If
+  self.sut.type = @"fake";
+  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:0];
+  self.sut.sid = @"FAKE-SESSION-ID";
+  self.sut.distributionGroupId = @"FAKE-GROUP-ID";
+  self.sut.device = [MSDevice new];
+
+  // When
+  NSMutableDictionary *actual = [self.sut serializeToDictionary];
+
+  // Then
+  assertThat(actual, notNilValue());
+  assertThat(actual[@"type"], equalTo(@"fake"));
+  assertThat(actual[@"timestamp"], equalTo(@"1970-01-01T00:00:00.000Z"));
+  assertThat(actual[@"sid"], equalTo(@"FAKE-SESSION-ID"));
+  assertThat(actual[@"distributionGroupId"], equalTo(@"FAKE-GROUP-ID"));
+  assertThat(actual[@"device"], equalTo(@{}));
+}
+
+- (void)testNSCodingSerializationAndDeserializationWorks {
+
+  // If
+  NSString *type = @"fake";
+  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:0];
+  NSString *sid = @"FAKE-SESSION-ID";
+  NSString *distributionGroupId = @"FAKE-GROUP-ID";
+  MSDevice *device = [MSDevice new];
+
+  self.sut.type = type;
+  self.sut.timestamp = timestamp;
+  self.sut.sid = sid;
+  self.sut.distributionGroupId = distributionGroupId;
+  self.sut.device = device;
+
+  // When
+  NSData *serializedLog = [NSKeyedArchiver archivedDataWithRootObject:self.sut];
+  id actual = [NSKeyedUnarchiver unarchiveObjectWithData:serializedLog];
+
+  // Then
+  assertThat(actual, notNilValue());
+  assertThat(actual, instanceOf([MSAbstractLog class]));
+
+  MSAbstractLog *actualLog = actual;
+  assertThat(actualLog.type, equalTo(type));
+  assertThat(actualLog.timestamp, equalTo(timestamp));
+  assertThat(actualLog.sid, equalTo(sid));
+  assertThat(actualLog.distributionGroupId, equalTo(distributionGroupId));
+  assertThat(actualLog.device, equalTo(device));
+}
+
+- (void)testIsValid {
+
+  // If
+  id device = OCMClassMock([MSDevice class]);
+  OCMStub([device isValid]).andReturn(YES);
+  self.sut.type = @"fake";
+  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  self.sut.device = device;
+
+  // Then
+  XCTAssertTrue([self.sut isValid]);
+
+  // When
+  self.sut.type = nil;
+  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  self.sut.device = device;
+
+  // Then
+  XCTAssertFalse([self.sut isValid]);
+
+  // When
+  self.sut.type = @"fake";
+  self.sut.timestamp = nil;
+  self.sut.device = device;
+
+  // Then
+  XCTAssertFalse([self.sut isValid]);
+
+  // When
+  self.sut.type = @"fake";
+  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  self.sut.device = nil;
+
+  // Then
+  XCTAssertFalse([self.sut isValid]);
+}
+
+- (void)testIsEqual {
+
+  // If
+  NSString *type = @"fake";
+  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:0];
+  NSString *sid = @"FAKE-SESSION-ID";
+  NSString *distributionGroupId = @"FAKE-GROUP-ID";
+  MSDevice *device = [MSDevice new];
+
+  self.sut.type = type;
+  self.sut.timestamp = timestamp;
+  self.sut.sid = sid;
+  self.sut.distributionGroupId = distributionGroupId;
+  self.sut.device = device;
+
+  // When
+  NSData *serializedEvent = [NSKeyedArchiver archivedDataWithRootObject:self.sut];
+  id actual = [NSKeyedUnarchiver unarchiveObjectWithData:serializedEvent];
+  MSAbstractLog *actualLog = actual;
+
+  // Then
+  XCTAssertTrue([self.sut isEqual:actualLog]);
+
+  // When
+  self.sut.type = @"new-fake";
+
+  // Then
+  XCTAssertFalse([self.sut isEqual:actualLog]);
+
+  // When
+  self.sut.type = @"fake";
+  self.sut.distributionGroupId = @"FAKE-NEW-GROUP-ID";
+
+  // Then
+  XCTAssertFalse([self.sut isEqual:actualLog]);
+}
+
+- (void)testSerializingToJsonWorks {
+
+  // If
+  self.sut.type = @"fake";
+  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:0];
+  self.sut.sid = @"FAKE-SESSION-ID";
+  self.sut.distributionGroupId = @"FAKE-GROUP-ID";
+  self.sut.device = [MSDevice new];
+
+  // When
+  NSString *actual = [self.sut serializeLogWithPrettyPrinting:false];
+  NSData *actualData = [actual dataUsingEncoding:NSUTF8StringEncoding];
+  id actualDict = [NSJSONSerialization JSONObjectWithData:actualData options:0 error:nil];
+
+  // Then
+  assertThat(actualDict, instanceOf([NSDictionary class]));
+  assertThat([actualDict objectForKey:@"type"], equalTo(@"fake"));
+  assertThat([actualDict objectForKey:@"timestamp"], equalTo(@"1970-01-01T00:00:00.000Z"));
+  assertThat([actualDict objectForKey:@"sid"], equalTo(@"FAKE-SESSION-ID"));
+  assertThat([actualDict objectForKey:@"distributionGroupId"], equalTo(@"FAKE-GROUP-ID"));
+  assertThat([actualDict objectForKey:@"device"], equalTo(@{}));
+}
+
+@end
+

--- a/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
+++ b/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		38E3FB1F1FD8A2A500779293 /* MSDistributeDataMigrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 386A69EF1FD88A9B0057B316 /* MSDistributeDataMigrationTests.m */; };
 		586032CABA2AC5DAA00BAB53 /* MSDistributeInfoTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 586031A5F44AF875F6226F45 /* MSDistributeInfoTracker.m */; };
 		5860330D3F7DC07BC2E141A2 /* MSDistributeInfoTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 5860311B1C15B2BE9ED430A1 /* MSDistributeInfoTracker.h */; };
+		58603D3986EEE50CBFAFD4BC /* MSDistributeInfoTrackerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 586030B2AAEEE6A568D37CE9 /* MSDistributeInfoTrackerTests.m */; };
 		80324E301F4DC81F005F4E11 /* MSDistributeAppDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 80324E2F1F4DC81E005F4E11 /* MSDistributeAppDelegateTests.m */; };
 		848860451E6EC32B003A9B96 /* MSBasicMachOParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 848860441E6EC32B003A9B96 /* MSBasicMachOParserTests.m */; };
 		B20DE7B71E5F97330023075C /* MSDistributeUtilTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DE7B61E5F97330023075C /* MSDistributeUtilTests.m */; };
@@ -203,6 +204,7 @@
 		38A683621E774DCE00A63BC8 /* MSSemVerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSSemVerTests.m; sourceTree = "<group>"; };
 		38A683631E774DCE00A63BC8 /* MSSemVerPreReleaseIdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSSemVerPreReleaseIdTest.m; sourceTree = "<group>"; };
 		38C9C56B1E565BF600B0FA0D /* MSDistributePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSDistributePrivate.h; path = ../MSDistributePrivate.h; sourceTree = "<group>"; };
+		586030B2AAEEE6A568D37CE9 /* MSDistributeInfoTrackerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDistributeInfoTrackerTests.m; sourceTree = "<group>"; };
 		5860311B1C15B2BE9ED430A1 /* MSDistributeInfoTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSDistributeInfoTracker.h; sourceTree = "<group>"; };
 		586031A5F44AF875F6226F45 /* MSDistributeInfoTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDistributeInfoTracker.m; sourceTree = "<group>"; };
 		80324E2F1F4DC81E005F4E11 /* MSDistributeAppDelegateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDistributeAppDelegateTests.m; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 				04A140BE1ECE84B7001CEE94 /* Model */,
 				04A140BF1ECE84C9001CEE94 /* Support */,
 				389638A21E79F557007C3809 /* Util */,
+				586030B2AAEEE6A568D37CE9 /* MSDistributeInfoTrackerTests.m */,
 			);
 			path = AppCenterDistributeTests;
 			sourceTree = "<group>";
@@ -761,6 +764,7 @@
 				389638A41E79F59D007C3809 /* MSDistributeTestUtil.m in Sources */,
 				0415974B1E9D639D00EC6BDA /* MSDistributionGroupTests.m in Sources */,
 				38A683641E774DCE00A63BC8 /* MSSemVerTests.m in Sources */,
+				58603D3986EEE50CBFAFD4BC /* MSDistributeInfoTrackerTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
+++ b/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		38C9C56C1E565BF600B0FA0D /* MSDistributePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 38C9C56B1E565BF600B0FA0D /* MSDistributePrivate.h */; };
 		38D25E391E7B0AAC00033FC4 /* OCHamcrestIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 380304421E7B007E006A55FB /* OCHamcrestIOS.framework */; };
 		38E3FB1F1FD8A2A500779293 /* MSDistributeDataMigrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 386A69EF1FD88A9B0057B316 /* MSDistributeDataMigrationTests.m */; };
+		586032CABA2AC5DAA00BAB53 /* MSDistributeInfoTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 586031A5F44AF875F6226F45 /* MSDistributeInfoTracker.m */; };
+		5860330D3F7DC07BC2E141A2 /* MSDistributeInfoTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 5860311B1C15B2BE9ED430A1 /* MSDistributeInfoTracker.h */; };
 		80324E301F4DC81F005F4E11 /* MSDistributeAppDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 80324E2F1F4DC81E005F4E11 /* MSDistributeAppDelegateTests.m */; };
 		848860451E6EC32B003A9B96 /* MSBasicMachOParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 848860441E6EC32B003A9B96 /* MSBasicMachOParserTests.m */; };
 		B20DE7B71E5F97330023075C /* MSDistributeUtilTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DE7B61E5F97330023075C /* MSDistributeUtilTests.m */; };
@@ -201,6 +203,8 @@
 		38A683621E774DCE00A63BC8 /* MSSemVerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSSemVerTests.m; sourceTree = "<group>"; };
 		38A683631E774DCE00A63BC8 /* MSSemVerPreReleaseIdTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSSemVerPreReleaseIdTest.m; sourceTree = "<group>"; };
 		38C9C56B1E565BF600B0FA0D /* MSDistributePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSDistributePrivate.h; path = ../MSDistributePrivate.h; sourceTree = "<group>"; };
+		5860311B1C15B2BE9ED430A1 /* MSDistributeInfoTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSDistributeInfoTracker.h; sourceTree = "<group>"; };
+		586031A5F44AF875F6226F45 /* MSDistributeInfoTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDistributeInfoTracker.m; sourceTree = "<group>"; };
 		80324E2F1F4DC81E005F4E11 /* MSDistributeAppDelegateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDistributeAppDelegateTests.m; sourceTree = "<group>"; };
 		807432C31EE20731003295BA /* MSBasicMachOParserPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MSBasicMachOParserPrivate.h; path = ../MSBasicMachOParserPrivate.h; sourceTree = "<group>"; };
 		848860441E6EC32B003A9B96 /* MSBasicMachOParserTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSBasicMachOParserTests.m; sourceTree = "<group>"; };
@@ -281,6 +285,7 @@
 				383A2FE51EBA30B300817742 /* MSDistributeAppDelegate.m */,
 				384135BD1FD99B5400FC7836 /* MSDistributeDataMigration.h */,
 				384135BF1FD99EB400FC7836 /* MSDistributeDataMigration.m */,
+				58603973F1018280F6E91D3E /* Channel */,
 			);
 			path = Internals;
 			sourceTree = "<group>";
@@ -468,6 +473,15 @@
 			path = Version;
 			sourceTree = "<group>";
 		};
+		58603973F1018280F6E91D3E /* Channel */ = {
+			isa = PBXGroup;
+			children = (
+				5860311B1C15B2BE9ED430A1 /* MSDistributeInfoTracker.h */,
+				586031A5F44AF875F6226F45 /* MSDistributeInfoTracker.m */,
+			);
+			path = Channel;
+			sourceTree = "<group>";
+		};
 		B2C070A71E5E62440076D6A9 /* Util */ = {
 			isa = PBXGroup;
 			children = (
@@ -541,6 +555,7 @@
 				046EF5891EAEB524002F6436 /* MSDistributeDelegate.h in Headers */,
 				04A0820A1F74BBB100DC776D /* MSService.h in Headers */,
 				BA682AC831677E0806CA2359 /* MSErrorDetails.h in Headers */,
+				5860330D3F7DC07BC2E141A2 /* MSDistributeInfoTracker.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -724,6 +739,7 @@
 				383A2FE61EBA30B300817742 /* MSDistributeAppDelegate.m in Sources */,
 				048BB3081E60A40D009D92C2 /* MSDistributeSender.m in Sources */,
 				BA682C81BA750CA5FCB63A51 /* MSErrorDetails.m in Sources */,
+				586032CABA2AC5DAA00BAB53 /* MSDistributeInfoTracker.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AppCenterDistribute/AppCenterDistribute/Internals/Channel/MSDistributeInfoTracker.h
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/Channel/MSDistributeInfoTracker.h
@@ -1,0 +1,24 @@
+#import <Foundation/Foundation.h>
+
+#import "AppCenter+Internal.h"
+
+@interface MSDistributeInfoTracker : NSObject <MSChannelDelegate>
+
+/**
+ * Distribution group ID that is added to logs (if exists).
+ */
+@property(nonatomic, copy) NSString *distributionGroupId;
+
+/**
+ * Update the distribution group ID value that is added to logs.
+ *
+ * @param distributionGroupId The distribution group ID value that is added to logs.
+ */
+- (void) updateDistributionGroupId:(NSString *)distributionGroupId;
+
+/**
+ * Don't add the distribution group ID value to logs.
+ */
+- (void) removeDistributionGroupId;
+
+@end

--- a/AppCenterDistribute/AppCenterDistribute/Internals/Channel/MSDistributeInfoTracker.m
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/Channel/MSDistributeInfoTracker.m
@@ -1,0 +1,27 @@
+#import "MSDistributeInfoTracker.h"
+
+@implementation MSDistributeInfoTracker
+
+- (void)onEnqueuingLog:(id<MSLog>)log withInternalId:(NSString *)internalId {
+  (void)internalId;
+  if (self.distributionGroupId == nil) {
+    return;
+  }
+
+  // Set current distribution group ID.
+  log.distributionGroupId = self.distributionGroupId;
+}
+
+- (void) updateDistributionGroupId:(NSString *)distributionGroupId {
+  @synchronized(self) {
+    self.distributionGroupId = distributionGroupId;
+  }
+}
+
+- (void)removeDistributionGroupId {
+  @synchronized(self) {
+    self.distributionGroupId = nil;
+  }
+}
+
+@end

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -104,6 +104,12 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
   return kMSGroupId;
 }
 
+- (MSInitializationPriority)initializationPriority {
+
+  // Initialize Distribute before Analytics to add distributionGroupId field to the first startSession event after app start.
+  return MSInitializationPriorityHigh;
+}
+
 #pragma mark - MSServiceAbstract
 
 - (void)applyEnabledState:(BOOL)isEnabled {

--- a/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
@@ -10,6 +10,7 @@
 #import "MSAlertController.h"
 #import "MSCustomApplicationDelegate.h"
 #import "MSDistribute.h"
+#import "MSDistributeInfoTracker.h"
 #import <SafariServices/SafariServices.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -112,6 +113,11 @@ static NSString *const kMSUpdateSetupFailedPackageHashKey = @"MSUpdateSetupFaile
 @property(nonatomic) id<MSCustomApplicationDelegate> appDelegate;
 
 @property(nonatomic) id _Nullable authenticationSession;
+
+/**
+ * Distribute info tracking component which adds extra fields to logs.
+ */
+@property(nonatomic) MSDistributeInfoTracker *distributeInfoTracker;
 
 /**
  * Returns the singleton instance. Meant for testing/demo apps only.

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeInfoTrackerTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeInfoTrackerTests.m
@@ -1,0 +1,64 @@
+#import "MSAbstractLog.h"
+#import "MSDistributeInfoTracker.h"
+#import "MSTestFrameworks.h"
+
+@interface MSDistributeInfoTrackerTests : XCTestCase
+
+@property (nonatomic) MSDistributeInfoTracker *sut;
+
+@end
+
+@implementation MSDistributeInfoTrackerTests
+
+- (void)setUp {
+  [super setUp];
+  self.sut = [[MSDistributeInfoTracker alloc] init];
+}
+
+- (void)testAddDistributionGroupIdToLogs {
+  // If
+  NSString *expectedDistributionGroupId = @"GROUP-ID";
+  MSAbstractLog *log = [MSAbstractLog new];
+
+  // When
+  [self.sut updateDistributionGroupId:expectedDistributionGroupId];
+  [self.sut onEnqueuingLog:log withInternalId:nil];
+
+  // Then
+  XCTAssertEqual(log.distributionGroupId, expectedDistributionGroupId);
+}
+
+- (void)testSetNewDistributionGroupId {
+
+  // If
+  MSAbstractLog *log1 = [MSAbstractLog new];
+
+  // When
+  [self.sut onEnqueuingLog:log1 withInternalId:nil];
+
+  // Then
+  XCTAssertNil(log1.distributionGroupId);
+
+  // If
+  NSString *expectedDistributionGroupId = @"GROUP-ID";
+  MSAbstractLog *log2 = [MSAbstractLog new];
+
+  // When
+  [self.sut updateDistributionGroupId:expectedDistributionGroupId];
+  [self.sut onEnqueuingLog:log2 withInternalId:nil];
+
+  // Then
+  XCTAssertEqual(log2.distributionGroupId, expectedDistributionGroupId);
+
+  // If
+  MSAbstractLog *log3 = [MSAbstractLog new];
+
+  // When
+  [self.sut removeDistributionGroupId];
+  [self.sut onEnqueuingLog:log3 withInternalId:nil];
+
+  // Then
+  XCTAssertNil(log3.distributionGroupId);
+}
+
+@end

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -23,6 +23,7 @@
 #import "MSUtility+Date.h"
 #import "MSUtility+Environment.h"
 #import "MSUtility+StringFormatting.h"
+#import "MSDistributeInfoTracker.h"
 
 static NSString *const kMSTestAppSecret = @"IAMSECRET";
 static NSString *const kMSTestReleaseHash = @"RELEASEHASH";
@@ -80,6 +81,7 @@ static NSURL *sfURL;
 @property(nonatomic) id settingsMock;
 @property(nonatomic) id bundleMock;
 @property(nonatomic) id alertControllerMock;
+@property(nonatomic) id distributeInfoTrackerMock;
 
 @end
 
@@ -113,6 +115,10 @@ static NSURL *sfURL;
   self.alertControllerMock = OCMClassMock([MSAlertController class]);
   OCMStub([self.alertControllerMock alertControllerWithTitle:OCMOCK_ANY message:OCMOCK_ANY])
       .andReturn(self.alertControllerMock);
+
+  // Mock DistributeInfoTracker.
+  self.distributeInfoTrackerMock = OCMClassMock([MSDistributeInfoTracker class]);
+  self.sut.distributeInfoTracker = self.distributeInfoTrackerMock;
 }
 
 - (void)tearDown {
@@ -132,6 +138,7 @@ static NSURL *sfURL;
   [self.settingsMock stopMocking];
   [self.bundleMock stopMocking];
   [self.alertControllerMock stopMocking];
+  [self.distributeInfoTrackerMock stopMocking];
   [MSDistributeTestUtil unMockUpdatesAllowedConditions];
 }
 
@@ -820,6 +827,7 @@ static NSURL *sfURL;
                                  OCMVerify([self.settingsMock removeObjectForKey:kMSUpdateTokenRequestIdKey]);
                                  OCMVerify([self.settingsMock removeObjectForKey:kMSPostponedTimestampKey]);
                                  OCMVerify([self.settingsMock removeObjectForKey:kMSDistributionGroupIdKey]);
+                                 OCMVerify([self.distributeInfoTrackerMock removeDistributionGroupId]);
                                  XCTAssertNil([self.settingsMock objectForKey:kMSSDKHasLaunchedWithDistribute]);
                                  XCTAssertNil([self.settingsMock objectForKey:kMSUpdateTokenRequestIdKey]);
                                  XCTAssertNil([self.settingsMock objectForKey:kMSPostponedTimestampKey]);
@@ -1062,6 +1070,7 @@ static NSURL *sfURL;
   assertThatBool(result, isTrue());
   OCMVerify(
       [distributeMock checkLatestRelease:nil distributionGroupId:distributionGroupId releaseHash:kMSTestReleaseHash]);
+  OCMVerify([self.distributeInfoTrackerMock updateDistributionGroupId:distributionGroupId]);
 
   // Not allow checkLatestRelease more.
   OCMReject([distributeMock checkLatestRelease:OCMOCK_ANY distributionGroupId:OCMOCK_ANY releaseHash:OCMOCK_ANY]);


### PR DESCRIPTION
This PR:
- Adds `distributionGroupId` field to sent logs (if exists).
- Adds a tracker in the AppCenterDistribute module which sets the `distributionGroupId` value.
- Changes Distribute initialization order: start Distribute before Analytics to add `distributionGroupId` field to the first startSession event after app start.

Similar PR for Android SDK: Microsoft/AppCenter-SDK-Android#615.
