### PR TITLE
Feature/tester app in app updates

### DIFF
--- a/AppCenter/AppCenter/Internals/Util/MSUtility+Application.h
+++ b/AppCenter/AppCenter/Internals/Util/MSUtility+Application.h
@@ -79,6 +79,17 @@ typedef NS_ENUM(NSInteger, MSOpenURLState) {
 @interface MSUtility (Application)
 
 /**
+ * Get the Shared Application from either NSApplication (MacOS) or UIApplication.
+ *
+ * @return The shared application.
+ */
+#if TARGET_OS_OSX
++ (NSApplication *)sharedApp;
+#else
++ (UIApplication *)sharedApp;
+#endif
+
+/**
  * Get the App Delegate.
  *
  * @return The delegate of the app object or nil if not accessible.

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -248,7 +248,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
     dispatch_async(dispatch_get_main_queue(), ^{
       NSURL *url;
       
-      BOOL shouldUseTesterAppForUpdateSetup = [MS_USER_DEFAULTS objectForKey:kMSTesterAppUpdateSetupFailedKey] != NULL;
+      BOOL shouldUseTesterAppForUpdateSetup = [MS_USER_DEFAULTS objectForKey:kMSTesterAppUpdateSetupFailedKey] == NULL;
       BOOL testerAppOpened = NO;
       if (shouldUseTesterAppForUpdateSetup) {
         // Attempt to open the native iOS tester app to enable in-app updates

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -244,10 +244,6 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
 
     MSLogInfo([MSDistribute logTag], @"Request information of initial installation.");
     
-    // Use swizzling to get [UIApplication sharedApplication]
-    SEL sharedAppSel = NSSelectorFromString(@"sharedApplication");
-    UIApplication* sharedApp = ((UIApplication * (*)(id, SEL))[[UIApplication class] methodForSelector:sharedAppSel])([UIApplication class], sharedAppSel);
-    
     // Don't run on the UI thread, or else the app may be slow to startup
     NSURL *testerAppUrl = [self buildTokenRequestURLWithAppSecret:self.appSecret releaseHash:releaseHash isTesterApp:true];
     NSURL *installUrl = [self buildTokenRequestURLWithAppSecret:self.appSecret releaseHash:releaseHash isTesterApp:false];
@@ -258,7 +254,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
       if (shouldUseTesterAppForUpdateSetup) {
         // Attempt to open the native iOS tester app to enable in-app updates
         if (testerAppUrl) {
-          testerAppOpened = (BOOL)[sharedApp performSelector:@selector(openURL:) withObject:testerAppUrl];
+          testerAppOpened = [self openUrlUsingSharedApp:testerAppUrl];
         }
       }
       
@@ -485,6 +481,11 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
     return nil;
   }
   return components.URL;
+}
+
+- (BOOL)openUrlUsingSharedApp:(NSURL *)url {
+  UIApplication *sharedApp = [MSUtility sharedApp];
+  return (BOOL)[sharedApp performSelector:@selector(openURL:) withObject:url];
 }
 
 - (void)openUrlInAuthenticationSessionOrSafari:(NSURL *)url {

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -237,6 +237,10 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
         [MS_USER_DEFAULTS removeObjectForKey:kMSTesterAppUpdateSetupFailedKey];
       }
     }
+    
+    // Create the request ID string and persist it.
+    NSString *requestId = MS_UUID_STRING;
+    [MS_USER_DEFAULTS setObject:requestId forKey:kMSUpdateTokenRequestIdKey];
 
     MSLogInfo([MSDistribute logTag], @"Request information of initial installation.");
     
@@ -458,9 +462,13 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
     MSLogError([MSDistribute logTag], kMSUpdateTokenURLInvalidErrorDescFormat, urlString);
     return nil;
   }
-
-  // Create the request ID string.
-  NSString *requestId = MS_UUID_STRING;
+  
+  // Get the stored request ID, or create one if it doesn't exist yet.
+  NSString *requestId = [MS_USER_DEFAULTS objectForKey:kMSUpdateTokenRequestIdKey];
+  if (!requestId) {
+    requestId = MS_UUID_STRING;
+    [MS_USER_DEFAULTS setObject:requestId forKey:kMSUpdateTokenRequestIdKey];
+  }
   
   // Set URL query parameters.
   NSMutableArray *items = [NSMutableArray array];
@@ -472,11 +480,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
   components.queryItems = items;
 
   // Check URL validity.
-  if (components.URL) {
-
-    // Persist the request ID.
-    [MS_USER_DEFAULTS setObject:requestId forKey:kMSUpdateTokenRequestIdKey];
-  } else {
+  if (!components.URL) {
     MSLogError([MSDistribute logTag], kMSUpdateTokenURLInvalidErrorDescFormat, components);
     return nil;
   }

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -248,10 +248,11 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
     NSURL *testerAppUrl = [self buildTokenRequestURLWithAppSecret:self.appSecret releaseHash:releaseHash isTesterApp:true];
     NSURL *installUrl = [self buildTokenRequestURLWithAppSecret:self.appSecret releaseHash:releaseHash isTesterApp:false];
     dispatch_async(dispatch_get_main_queue(), ^{
-      
       BOOL shouldUseTesterAppForUpdateSetup = [MS_USER_DEFAULTS objectForKey:kMSTesterAppUpdateSetupFailedKey] == NULL;
       BOOL testerAppOpened = NO;
       if (shouldUseTesterAppForUpdateSetup) {
+        MSLogInfo([MSDistribute logTag], @"Attempting to use tester app for update setup.");
+        
         // Attempt to open the native iOS tester app to enable in-app updates
         if (testerAppUrl) {
           testerAppOpened = [self openUrlUsingSharedApp:testerAppUrl];
@@ -259,10 +260,8 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
       }
       
       // If the native app could not be opened (not installed), fall back to the browser update setup
-      if (!shouldUseTesterAppForUpdateSetup || !testerAppOpened) {
-        if (installUrl) {
-          [self openUrlInAuthenticationSessionOrSafari:installUrl];
-        }
+      if ((!shouldUseTesterAppForUpdateSetup || !testerAppOpened) && installUrl) {
+        [self openUrlInAuthenticationSessionOrSafari:installUrl];
       }
     });
   } else {

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -245,24 +245,23 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
     UIApplication* sharedApp = ((UIApplication * (*)(id, SEL))[[UIApplication class] methodForSelector:sharedAppSel])([UIApplication class], sharedAppSel);
     
     // Don't run on the UI thread, or else the app may be slow to startup
+    NSURL *testerAppUrl = [self buildTokenRequestURLWithAppSecret:self.appSecret releaseHash:releaseHash isTesterApp:true];
+    NSURL *installUrl = [self buildTokenRequestURLWithAppSecret:self.appSecret releaseHash:releaseHash isTesterApp:false];
     dispatch_async(dispatch_get_main_queue(), ^{
-      NSURL *url;
       
       BOOL shouldUseTesterAppForUpdateSetup = [MS_USER_DEFAULTS objectForKey:kMSTesterAppUpdateSetupFailedKey] == NULL;
       BOOL testerAppOpened = NO;
       if (shouldUseTesterAppForUpdateSetup) {
         // Attempt to open the native iOS tester app to enable in-app updates
-        url = [self buildTokenRequestURLWithAppSecret:self.appSecret releaseHash:releaseHash isTesterApp:true];
-        if (url) {
-          testerAppOpened = [sharedApp performSelector:@selector(openURL:) withObject:url];
+        if (testerAppUrl) {
+          testerAppOpened = [sharedApp performSelector:@selector(openURL:) withObject:testerAppUrl];
         }
       }
       
       // If the native app could not be opened (not installed), fall back to the browser update setup
       if (!shouldUseTesterAppForUpdateSetup || !testerAppOpened) {
-        url = [self buildTokenRequestURLWithAppSecret:self.appSecret releaseHash:releaseHash isTesterApp:false];
-        if (url) {
-          [self openUrlInAuthenticationSessionOrSafari:url];
+        if (installUrl) {
+          [self openUrlInAuthenticationSessionOrSafari:installUrl];
         }
       }
     });

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -256,6 +256,11 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
         // Attempt to open the native iOS tester app to enable in-app updates
         if (testerAppUrl) {
           testerAppOpened = [self openUrlUsingSharedApp:testerAppUrl];
+          if (testerAppOpened) {
+            MSLogInfo([MSDistribute logTag], @"Tester app was successfully opened to enable in-app updates.");
+          } else {
+            MSLogInfo([MSDistribute logTag], @"Tester app could not be opened to enable in-app updates (not installed?)");
+          }
         }
       }
       

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -123,6 +123,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
     [MS_USER_DEFAULTS removeObjectForKey:kMSPostponedTimestampKey];
     [MS_USER_DEFAULTS removeObjectForKey:kMSMandatoryReleaseKey];
     [MS_USER_DEFAULTS removeObjectForKey:kMSUpdateSetupFailedPackageHashKey];
+    [MS_USER_DEFAULTS removeObjectForKey:kMSTesterAppUpdateSetupFailedKey];
     MSLogInfo([MSDistribute logTag], @"Distribute service has been disabled.");
   }
 }
@@ -233,6 +234,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
         MSLogDebug([MSDistribute logTag],
                    @"Re-attempting in-app updates setup and cleaning up failure info from storage.");
         [MS_USER_DEFAULTS removeObjectForKey:kMSUpdateSetupFailedPackageHashKey];
+        [MS_USER_DEFAULTS removeObjectForKey:kMSTesterAppUpdateSetupFailedKey];
       }
     }
 
@@ -806,6 +808,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
                               [self openUrlInAuthenticationSessionOrSafari:installUrl];
 
                               // Clear the update setup failure info from storage, to re-attempt setup on reinstall
+                              [MS_USER_DEFAULTS removeObjectForKey:kMSTesterAppUpdateSetupFailedKey];
                               [MS_USER_DEFAULTS removeObjectForKey:kMSUpdateSetupFailedPackageHashKey];
                             }];
 

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -254,7 +254,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
       if (shouldUseTesterAppForUpdateSetup) {
         // Attempt to open the native iOS tester app to enable in-app updates
         if (testerAppUrl) {
-          testerAppOpened = [sharedApp performSelector:@selector(openURL:) withObject:testerAppUrl];
+          testerAppOpened = (BOOL)[sharedApp performSelector:@selector(openURL:) withObject:testerAppUrl];
         }
       }
       

--- a/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
@@ -138,6 +138,15 @@ static NSString *const kMSTesterAppUpdateSetupFailedKey = @"MSTesterAppUpdateSet
 - (nullable NSURL *)buildTokenRequestURLWithAppSecret:(NSString *)appSecret releaseHash:(NSString *)releaseHash isTesterApp:(BOOL)isTesterApp;
 
 /**
+ * Open the given URL using the openURL method in the Shared Application.
+ *
+ * @param url URL to open.
+ *
+ * @return Whether the URL was opened or not.
+ */
+- (BOOL)openUrlUsingSharedApp:(NSURL *)url;
+
+/**
  * Open the given URL using either SFAuthenticationSession, SFSafariViewController, or the Safari app
  * based on which iOS version is used.
  *

--- a/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
@@ -43,6 +43,7 @@ static NSString *const kMSURLQueryUpdateTokenKey = @"update_token";
 static NSString *const kMSURLQueryDistributionGroupIdKey = @"distribution_group_id";
 static NSString *const kMSURLQueryEnableUpdateSetupFailureRedirectKey = @"enable_failure_redirect";
 static NSString *const kMSURLQueryUpdateSetupFailedKey = @"update_setup_failed";
+static NSString *const kMSURLQueryTesterAppUpdateSetupFailedKey = @"tester_app_update_setup_failed";
 
 /**
  * Distribute url query parameter value strings.

--- a/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
@@ -85,6 +85,11 @@ static NSString *const kMSDistributionGroupIdKey = @"MSDistributionGroupId";
  */
 static NSString *const kMSUpdateSetupFailedPackageHashKey = @"MSUpdateSetupFailedPackageHash";
 
+/**
+ * The storage key for tester app update setup failure.
+ */
+static NSString *const kMSTesterAppUpdateSetupFailedKey = @"MSTesterAppUpdateSetupFailed";
+
 @interface MSDistribute ()
 
 /**
@@ -122,14 +127,15 @@ static NSString *const kMSUpdateSetupFailedPackageHashKey = @"MSUpdateSetupFaile
 + (instancetype)sharedInstance;
 
 /**
- * Build the install URL for token request with the given application secret.
+ * Build the URL for token request with the given application secret.
  *
  * @param appSecret Application secret.
  * @param releaseHash The release hash of the current version.
+ * @param isTesterApp Whether the URL should be constructed to link to the tester app.
  *
- * @return The finale install URL to request the token or nil if an error occurred.
+ * @return The final URL to request the token or nil if an error occurred.
  */
-- (nullable NSURL *)buildTokenRequestURLWithAppSecret:(NSString *)appSecret releaseHash:(NSString *)releaseHash;
+- (nullable NSURL *)buildTokenRequestURLWithAppSecret:(NSString *)appSecret releaseHash:(NSString *)releaseHash isTesterApp:(BOOL)isTesterApp;
 
 /**
  * Open the given URL using either SFAuthenticationSession, SFSafariViewController, or the Safari app

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -158,7 +158,7 @@ static NSURL *sfURL;
   dispatch_async(dispatch_get_main_queue(), ^{
     [openURLCalledExpectation fulfill];
   });
-  NSURL *url = [distributeMock buildTokenRequestURLWithAppSecret:kMSTestAppSecret releaseHash:kMSTestReleaseHash];
+  NSURL *url = [distributeMock buildTokenRequestURLWithAppSecret:kMSTestAppSecret releaseHash:kMSTestReleaseHash isTesterApp:false];
   NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
   NSMutableDictionary<NSString *, NSString *> *queryStrings = [NSMutableDictionary<NSString *, NSString *> new];
   [components.queryItems
@@ -196,7 +196,7 @@ static NSURL *sfURL;
   NSString *badAppSecret = @"weird\\app\\secret";
 
   // When
-  NSURL *url = [self.sut buildTokenRequestURLWithAppSecret:badAppSecret releaseHash:kMSTestReleaseHash];
+  NSURL *url = [self.sut buildTokenRequestURLWithAppSecret:badAppSecret releaseHash:kMSTestReleaseHash isTesterApp:false];
 
   // Then
   assertThat(url, nilValue());
@@ -245,7 +245,7 @@ static NSURL *sfURL;
   // When
   [MSDistribute setInstallUrl:testUrl];
   MSDistribute *distribute = [MSDistribute sharedInstance];
-  NSURL *url = [distribute buildTokenRequestURLWithAppSecret:kMSTestAppSecret releaseHash:kMSTestReleaseHash];
+  NSURL *url = [distribute buildTokenRequestURLWithAppSecret:kMSTestAppSecret releaseHash:kMSTestReleaseHash isTesterApp:false];
 
   // Then
   XCTAssertTrue([[distribute installUrl] isEqualToString:testUrl]);
@@ -262,7 +262,7 @@ static NSURL *sfURL;
 
   // When
   NSString *instalURL = [self.sut installUrl];
-  NSURL *tokenRequestURL = [self.sut buildTokenRequestURLWithAppSecret:kMSTestAppSecret releaseHash:kMSTestReleaseHash];
+  NSURL *tokenRequestURL = [self.sut buildTokenRequestURLWithAppSecret:kMSTestAppSecret releaseHash:kMSTestReleaseHash isTesterApp:false];
 
   // Then
   XCTAssertNotNil(instalURL);
@@ -1292,7 +1292,7 @@ static NSURL *sfURL;
 
   // Then
   OCMVerify([distributeMock requestInstallInformationWith:kMSTestReleaseHash]);
-  OCMReject([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:kMSTestReleaseHash]);
+  OCMReject([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:kMSTestReleaseHash isTesterApp:false]);
   XCTAssertEqual([self.settingsMock objectForKey:kMSUpdateSetupFailedPackageHashKey], kMSTestReleaseHash);
 
   // Clear
@@ -1333,7 +1333,7 @@ static NSURL *sfURL;
 
   // Then
   OCMVerify([distributeMock requestInstallInformationWith:kMSTestReleaseHash]);
-  OCMVerify([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:kMSTestReleaseHash]);
+  OCMVerify([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:kMSTestReleaseHash isTesterApp:false]);
   XCTAssertNil([self.settingsMock objectForKey:kMSUpdateSetupFailedPackageHashKey]);
 
   // Clear
@@ -1379,7 +1379,7 @@ static NSURL *sfURL;
   OCMStub([reachabilityMock reachabilityForInternetConnection]).andReturn(reachabilityMock);
   OCMStub([reachabilityMock currentReachabilityStatus]).andReturn(NotReachable);
   id distributeMock = OCMPartialMock(self.sut);
-  OCMReject([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:kMSTestReleaseHash]);
+  OCMReject([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:kMSTestReleaseHash isTesterApp:false]);
 
   // We should not touch UI in a unit testing environment.
   OCMStub([distributeMock openURLInSafariViewControllerWith:OCMOCK_ANY fromClass:OCMOCK_ANY]).andDo(nil);
@@ -1651,7 +1651,7 @@ static NSURL *sfURL;
   OCMStub([self.bundleMock objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(bundleArray);
 
   // When
-  NSURL *url = [self.sut buildTokenRequestURLWithAppSecret:kMSTestAppSecret releaseHash:kMSTestReleaseHash];
+  NSURL *url = [self.sut buildTokenRequestURLWithAppSecret:kMSTestAppSecret releaseHash:kMSTestReleaseHash isTesterApp:false];
 
   // Then
   assertThat(url, nilValue());

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -1342,6 +1342,57 @@ static NSURL *sfURL;
   [utilityMock stopMocking];
 }
 
+- (void)testBrowserNotOpenedWhenTesterAppUsedForUpdateSetup {
+  
+  // If
+  id reachabilityMock = OCMClassMock([MS_Reachability class]);
+  OCMStub([reachabilityMock reachabilityForInternetConnection]).andReturn(reachabilityMock);
+  OCMStub([reachabilityMock currentReachabilityStatus]).andReturn(ReachableViaWiFi);
+  [MSDistributeTestUtil unMockUpdatesAllowedConditions];
+  id appCenterMock = OCMClassMock([MSAppCenter class]);
+  id distributeMock = OCMPartialMock(self.sut);
+  id utilityMock = [self mockMSPackageHash];
+  OCMStub([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:OCMOCK_ANY isTesterApp:false]).andReturn([NSURL URLWithString:@"https://some_url"]);
+  OCMStub([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:OCMOCK_ANY isTesterApp:true]).andReturn([NSURL URLWithString:@"some_url://"]);
+  OCMStub([distributeMock openUrlUsingSharedApp:OCMOCK_ANY]).andReturn(YES);
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Start update processed"];
+
+  // When
+  OCMStub([appCenterMock isDebuggerAttached]).andReturn(NO);
+  OCMStub([utilityMock currentAppEnvironment]).andReturn(MSEnvironmentOther);
+  
+  // Then
+  XCTAssertTrue([self.sut checkForUpdatesAllowed]);
+  
+  // When
+  [self.sut applyEnabledState:YES];
+  [distributeMock startUpdate];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [expectation fulfill];
+  });
+  
+  // Then
+  OCMVerify([distributeMock requestInstallInformationWith:kMSTestReleaseHash]);
+  OCMVerify([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:kMSTestReleaseHash isTesterApp:true]);
+  OCMVerify([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:kMSTestReleaseHash isTesterApp:false]);
+  [self waitForExpectationsWithTimeout:1
+                               handler:^(NSError *error) {
+                                 
+                                 // Then
+                                 OCMVerify([distributeMock openUrlUsingSharedApp:OCMOCK_ANY]);
+                                 OCMReject([distributeMock openUrlInAuthenticationSessionOrSafari:OCMOCK_ANY]);
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                               }];
+  
+  
+  // Clear
+  [distributeMock stopMocking];
+  [appCenterMock stopMocking];
+  [utilityMock stopMocking];
+}
+
 - (void)testNotDeleteUpdateToken {
 
   // If


### PR DESCRIPTION
The related Android PR is here: https://github.com/Microsoft/AppCenter-SDK-Android/pull/613

> Apps installed using the native tester app currently aren't able to successfully enable in-app updates, because the cookies stored on install aren't there. This is part of the work to fix that.
> 
> When enabling in-app updates, the Android SDK should check if an app with the ms-actesterapp:// scheme (belongs to the App Center tester app) is installed. If it is, then it should try to enable in-app updates by redirecting to that scheme instead of the update-setup page on the install portal. If for some reason enabling in-app updates fails, then the SDK should fall back to attempting to enable in-app updates using the update-setup page. This could happen if someone has the native tester app installed, but for some reason they still install an app from the install portal. The user will see two attempts to enable in-app updates in this case, but hopefully this is rare. We will track telemetry for how often this happens.