### PR TITLE
Implement reporting to Distribution beacon for proper download counts

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
@@ -43,6 +43,8 @@ static NSString *const kMSURLQueryUpdateTokenKey = @"update_token";
 static NSString *const kMSURLQueryDistributionGroupIdKey = @"distribution_group_id";
 static NSString *const kMSURLQueryEnableUpdateSetupFailureRedirectKey = @"enable_failure_redirect";
 static NSString *const kMSURLQueryUpdateSetupFailedKey = @"update_setup_failed";
+static NSString *const kMSURLQueryDownloadedReleaseIdKey = @"downloaded_release_id";
+static NSString *const kMSURLQueryInstallIdKey = @"install_id";
 
 /**
  * Distribute url query parameter value strings.
@@ -83,6 +85,16 @@ static NSString *const kMSDistributionGroupIdKey = @"MSDistributionGroupId";
  * The storage key for update setup failure package hash.
  */
 static NSString *const kMSUpdateSetupFailedPackageHashKey = @"MSUpdateSetupFailedPackageHash";
+
+/**
+ * The storage key for latest downloaded release hash.
+ */
+static NSString *const kMSDownloadedReleaseHashKey = @"MSDownloadedReleaseHash";
+
+/**
+ * The storage key for latest downloaded release The storage key for latest downloaded release ID.
+ */
+static NSString *const kMSDownloadedReleaseIdKey = @"MSDownloadedReleaseId";
 
 @interface MSDistribute ()
 
@@ -189,6 +201,33 @@ static NSString *const kMSUpdateSetupFailedPackageHashKey = @"MSUpdateSetupFaile
  * @return `YES` if this update is handled or `NO` otherwise.
  */
 - (BOOL)handleUpdate:(MSReleaseDetails *)details;
+
+/**
+ * Store details about downloaded release to report it after installation.
+ *
+ * @param details Release details.
+ */
+- (void)storeDownloadedReleaseDetails:(nullable MSReleaseDetails *)details;
+
+/**
+ * Remove details about downloaded release after it was installed.
+ *
+ * @param currentInstalledReleaseHash The release hash of the current version.
+ */
+- (void)removeDownloadedReleaseDetailsIfUpdated:(NSString *)currentInstalledReleaseHash;
+
+/**
+ * Get reporting parameters for updated release.
+ *
+ * @param updateToken The update token stored in keychain. This value can be nil if it is public distribution.
+ * @param currentInstalledReleaseHash The release hash of the current version.
+ * @param distributionGroupId The distribution group Id in keychain.
+ *
+ * @return Reporting parameters dictionary.
+ */
+- (NSMutableDictionary *)getReportingParametersForUpdatedRelease:(NSString *)updateToken
+                                     currentInstalledReleaseHash:(NSString *)currentInstalledReleaseHash
+                                             distributionGroupId:(NSString *)distributionGroupId;
 
 /**
  * Show a dialog to ask a user to confirm update for a new release.

--- a/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
@@ -93,7 +93,7 @@ static NSString *const kMSUpdateSetupFailedPackageHashKey = @"MSUpdateSetupFaile
 static NSString *const kMSDownloadedReleaseHashKey = @"MSDownloadedReleaseHash";
 
 /**
- * The storage key for latest downloaded release The storage key for latest downloaded release ID.
+ * The storage key for latest downloaded release ID.
  */
 static NSString *const kMSDownloadedReleaseIdKey = @"MSDownloadedReleaseId";
 


### PR DESCRIPTION
This PR implements reporting of these parameters to Distribution beacon:
- Release id and distribution id for private groups.
- Release id and install id for public groups.

Similar PR for Android SDK: Microsoft/AppCenter-SDK-Android#614.