### PR TITLE
Update distribution group ID if a new release with different group ID was in-app updated

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/Internals/Model/MSReleaseDetails.m
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/Model/MSReleaseDetails.m
@@ -18,6 +18,7 @@ static NSString *const kMSDownloadUrl = @"download_url";
 static NSString *const kMSAppIconUrl = @"app_icon_url";
 static NSString *const kMSInstallUrl = @"install_url";
 static NSString *const kMSReleaseNotesUrl = @"release_notes_url";
+static NSString *const kMSDistributionGroupId = @"distribution_group_id";
 static NSString *const kMSDistributionGroups = @"distribution_groups";
 static NSString *const kMSPackageHashes = @"package_hashes";
 
@@ -101,6 +102,9 @@ static NSString *const kMSPackageHashes = @"package_hashes";
         self.releaseNotesUrl = [NSURL URLWithString:releaseNotesUrl];
       }
     }
+    if (dictionary[kMSDistributionGroupId]) {
+      self.distributionGroupId = dictionary[kMSDistributionGroupId];
+    }
     if (dictionary[kMSDistributionGroups]) {
 
       // TODO: DistributionGroup has no properties so skip it until it has properties.
@@ -161,6 +165,9 @@ static NSString *const kMSPackageHashes = @"package_hashes";
   }
   if (self.releaseNotesUrl) {
     dictionary[kMSReleaseNotesUrl] = [self.releaseNotesUrl absoluteString];
+  }
+  if (self.distributionGroupId) {
+    dictionary[kMSDistributionGroupId] = self.distributionGroupId;
   }
   if (self.distributionGroups) {
 

--- a/AppCenterDistribute/AppCenterDistribute/Internals/Model/MSReleaseDetailsPrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/Model/MSReleaseDetailsPrivate.h
@@ -65,6 +65,11 @@
 @property(nonatomic) NSURL *installUrl;
 
 /**
+ * Distribution group identifier.
+ */
+@property(nonatomic) NSString *distributionGroupId;
+
+/**
  * A list of distribution groups that are associated with this release.
  */
 @property(nonatomic) NSArray<MSDistributionGroup *> *distributionGroups;

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -810,24 +810,24 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
 }
 
 - (void)changeDistributionGroupIdAfterAppUpdateIfNeeded:(NSString *)currentInstalledReleaseHash {
-  NSString *lastDownloadedDistributionGroupId = [MS_USER_DEFAULTS objectForKey:kMSDownloadedDistributionGroupIdKey];
-  if (lastDownloadedDistributionGroupId == nil) {
+  NSString *updatedReleaseDistributionGroupId = [MS_USER_DEFAULTS objectForKey:kMSDownloadedDistributionGroupIdKey];
+  if (updatedReleaseDistributionGroupId == nil) {
     return;
   }
 
   // Skip if the current release was not updated.
-  NSString *lastDownloadedReleaseHashes = [MS_USER_DEFAULTS objectForKey:kMSDownloadedReleaseHashKey];
-  if ((lastDownloadedReleaseHashes == nil) || ([lastDownloadedReleaseHashes rangeOfString:currentInstalledReleaseHash].location == NSNotFound)) {
+  NSString *updatedReleaseHashes = [MS_USER_DEFAULTS objectForKey:kMSDownloadedReleaseHashKey];
+  if ((updatedReleaseHashes == nil) || ([updatedReleaseHashes rangeOfString:currentInstalledReleaseHash].location == NSNotFound)) {
     return;
   }
 
-  // Skip if the group ID of an updated release is the same as the current one.
-  NSString *currentDistributionGroupId = [MS_USER_DEFAULTS objectForKey:kMSDistributionGroupIdKey];
-  if ((currentDistributionGroupId == nil) || ([lastDownloadedDistributionGroupId isEqualToString:currentDistributionGroupId] == NO)) {
+  // Skip if the group ID of an updated release is the same as the stored one.
+  NSString *storedDistributionGroupId = [MS_USER_DEFAULTS objectForKey:kMSDistributionGroupIdKey];
+  if ((storedDistributionGroupId == nil) || ([updatedReleaseDistributionGroupId isEqualToString:storedDistributionGroupId] == NO)) {
 
     // Set group ID from downloaded release details if an updated release was downloaded from another distribution group.
-    MSLogDebug([MSDistribute logTag], @"Current group ID doesn't match the group ID of downloaded release, updating current group id: %@", lastDownloadedDistributionGroupId);
-    [MS_USER_DEFAULTS setObject:lastDownloadedDistributionGroupId forKey:kMSDistributionGroupIdKey];
+    MSLogDebug([MSDistribute logTag], @"Stored group ID doesn't match the group ID of the updated release, updating group id: %@", updatedReleaseDistributionGroupId);
+    [MS_USER_DEFAULTS setObject:updatedReleaseDistributionGroupId forKey:kMSDistributionGroupIdKey];
   }
 
   // Remove saved downloaded group ID.

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -810,23 +810,25 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
 }
 
 - (void)changeDistributionGroupIdAfterAppUpdateIfNeeded:(NSString *)currentInstalledReleaseHash {
-  NSString *lastDownloadedReleaseHashes = [MS_USER_DEFAULTS objectForKey:kMSDownloadedReleaseHashKey];
   NSString *lastDownloadedDistributionGroupId = [MS_USER_DEFAULTS objectForKey:kMSDownloadedDistributionGroupIdKey];
+  if (lastDownloadedDistributionGroupId == nil) {
+    return;
+  }
 
   // Skip if the current release was not updated.
-  if ((lastDownloadedDistributionGroupId == nil) || ([lastDownloadedReleaseHashes rangeOfString:currentInstalledReleaseHash].location == NSNotFound)) {
+  NSString *lastDownloadedReleaseHashes = [MS_USER_DEFAULTS objectForKey:kMSDownloadedReleaseHashKey];
+  if ((lastDownloadedReleaseHashes == nil) || ([lastDownloadedReleaseHashes rangeOfString:currentInstalledReleaseHash].location == NSNotFound)) {
     return;
   }
 
   // Skip if the group ID of an updated release is the same as the current one.
   NSString *currentDistributionGroupId = [MS_USER_DEFAULTS objectForKey:kMSDistributionGroupIdKey];
-  if ((currentDistributionGroupId != nil) && ([lastDownloadedDistributionGroupId isEqualToString:currentDistributionGroupId])) {
-    return;
-  }
+  if ((currentDistributionGroupId == nil) || ([lastDownloadedDistributionGroupId isEqualToString:currentDistributionGroupId] == NO)) {
 
-  // Set group ID from downloaded release details.
-  MSLogDebug([MSDistribute logTag], @"Current group ID doesn't match the group ID of downloaded release, updating current group id: %@", lastDownloadedDistributionGroupId);
-  [MS_USER_DEFAULTS setObject:lastDownloadedDistributionGroupId forKey:kMSDistributionGroupIdKey];
+    // Set group ID from downloaded release details if an updated release was downloaded from another distribution group.
+    MSLogDebug([MSDistribute logTag], @"Current group ID doesn't match the group ID of downloaded release, updating current group id: %@", lastDownloadedDistributionGroupId);
+    [MS_USER_DEFAULTS setObject:lastDownloadedDistributionGroupId forKey:kMSDistributionGroupIdKey];
+  }
 
   // Remove saved downloaded group ID.
   [MS_USER_DEFAULTS removeObjectForKey:kMSDownloadedDistributionGroupIdKey];

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -732,11 +732,11 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
   NSString *releaseHashes = [details.packageHashes count] > 0
           ? [details.packageHashes componentsJoinedByString:@","]
           : nil;
-  MSLogDebug([MSDistribute logTag], @"Store downloaded release details, group id: %@, release hashes: %@, release id: %@.",
-                  groupId, releaseHashes, releaseId);
   [MS_USER_DEFAULTS setObject:groupId forKey:kMSDownloadedDistributionGroupIdKey];
   [MS_USER_DEFAULTS setObject:releaseId forKey:kMSDownloadedReleaseIdKey];
   [MS_USER_DEFAULTS setObject:releaseHashes forKey:kMSDownloadedReleaseHashKey];
+  MSLogDebug([MSDistribute logTag], @"Stored downloaded release hash(es) (%@) and id (%@) for later reporting.",
+                  releaseHashes, releaseId);
 }
 
 - (void)removeDownloadedReleaseDetailsIfUpdated:(NSString *)currentInstalledReleaseHash {

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -744,7 +744,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
   if (lastDownloadedReleaseHashes == nil) {
     return;
   }
-  if (![self isCurrentReleaseWasUpdated:lastDownloadedReleaseHashes]) {
+  if ([self isCurrentReleaseWasUpdated:lastDownloadedReleaseHashes] == NO) {
     MSLogDebug([MSDistribute logTag], @"Stored release hash(es) doesn't match current installation hash, probably downloaded but not installed yet, keep in store.");
     return;
   }
@@ -767,7 +767,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
   }
 
   // Skip if downloaded release not installed yet.
-  if (![self isCurrentReleaseWasUpdated:lastDownloadedReleaseHashes]) {
+  if ([self isCurrentReleaseWasUpdated:lastDownloadedReleaseHashes] == NO) {
     MSLogDebug([MSDistribute logTag], @"New release was downloaded but not installed yet, skip reporting.");
     return nil;
   }
@@ -788,11 +788,11 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
 - (void)changeDistributionGroupIdAfterAppUpdateIfNeeded {
   NSString *lastDownloadedReleaseHashes = [MS_USER_DEFAULTS objectForKey:kMSDownloadedReleaseHashKey];
   NSString *lastDownloadedDistributionGroupId = [MS_USER_DEFAULTS objectForKey:kMSDownloadedDistributionGroupIdKey];
-  if (lastDownloadedDistributionGroupId == nil || ![self isCurrentReleaseWasUpdated:lastDownloadedReleaseHashes]) {
+  if ((lastDownloadedDistributionGroupId == nil) || ([self isCurrentReleaseWasUpdated:lastDownloadedReleaseHashes] == NO)) {
     return;
   }
   NSString *currentDistributionGroupId = [MS_USER_DEFAULTS objectForKey:kMSDistributionGroupIdKey];
-  if (currentDistributionGroupId != nil && [lastDownloadedDistributionGroupId isEqualToString:currentDistributionGroupId]) {
+  if ((currentDistributionGroupId != nil) && ([lastDownloadedDistributionGroupId isEqualToString:currentDistributionGroupId])) {
     return;
   }
 

--- a/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
@@ -230,8 +230,9 @@ static NSString *const kMSTesterAppUpdateSetupFailedKey = @"MSTesterAppUpdateSet
 - (BOOL)handleUpdate:(MSReleaseDetails *)details;
 
 /**
- * Store details about downloaded release.
- * After app update and restart, this info is used to report new download and to update group ID (if it's changed).
+ * Save details about a downloaded release.
+ * After an app is updated and restarted, this info will be used to report a download and to update the group ID
+ * (if it was changed).
  *
  * @param details Release details.
  */

--- a/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
@@ -245,6 +245,8 @@ static NSString *const kMSTesterAppUpdateSetupFailedKey = @"MSTesterAppUpdateSet
 
 /**
  * Remove details about downloaded release after it was installed.
+ *
+ * @param currentInstalledReleaseHash The release hash of the current version.
  */
 - (void)removeDownloadedReleaseDetailsIfUpdated:(NSString *)currentInstalledReleaseHash;
 
@@ -266,6 +268,8 @@ static NSString *const kMSTesterAppUpdateSetupFailedKey = @"MSTesterAppUpdateSet
  * group ID if needed.
  * Group ID may change if one user is added to different distribution groups and a new release
  * was updated from another group.
+ *
+ * @param currentInstalledReleaseHash The release hash of the current version.
 */
 - (void)changeDistributionGroupIdAfterAppUpdateIfNeeded:(NSString *)currentInstalledReleaseHash;
 

--- a/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
@@ -99,6 +99,11 @@ static NSString *const kMSDownloadedReleaseHashKey = @"MSDownloadedReleaseHash";
 static NSString *const kMSDownloadedReleaseIdKey = @"MSDownloadedReleaseId";
 
 /**
+ * The storage key for distribution group ID of latest downloaded release.
+ */
+static NSString *const kMSDownloadedDistributionGroupIdKey = @"MSDownloadedDistributionGroupId";
+
+/**
  * The storage key for tester app update setup failure.
  */
 static NSString *const kMSTesterAppUpdateSetupFailedKey = @"MSTesterAppUpdateSetupFailed";
@@ -225,7 +230,8 @@ static NSString *const kMSTesterAppUpdateSetupFailedKey = @"MSTesterAppUpdateSet
 - (BOOL)handleUpdate:(MSReleaseDetails *)details;
 
 /**
- * Store details about downloaded release to report it after installation.
+ * Store details about downloaded release.
+ * After app update and restart, this info is used to report new download and to update group ID (if it's changed).
  *
  * @param details Release details.
  */
@@ -233,23 +239,35 @@ static NSString *const kMSTesterAppUpdateSetupFailedKey = @"MSTesterAppUpdateSet
 
 /**
  * Remove details about downloaded release after it was installed.
- *
- * @param currentInstalledReleaseHash The release hash of the current version.
  */
-- (void)removeDownloadedReleaseDetailsIfUpdated:(NSString *)currentInstalledReleaseHash;
+- (void)removeDownloadedReleaseDetailsIfUpdated;
 
 /**
  * Get reporting parameters for updated release.
  *
  * @param updateToken The update token stored in keychain. This value can be nil if it is public distribution.
- * @param currentInstalledReleaseHash The release hash of the current version.
  * @param distributionGroupId The distribution group Id in keychain.
  *
  * @return Reporting parameters dictionary.
  */
 - (NSMutableDictionary *)getReportingParametersForUpdatedRelease:(NSString *)updateToken
-                                     currentInstalledReleaseHash:(NSString *)currentInstalledReleaseHash
                                              distributionGroupId:(NSString *)distributionGroupId;
+
+/**
+ * Check if an updated release has different group ID and update current group ID if needed.
+ * Group ID may change if one user is added to different distribution groups and a new release
+ * was distributed to another group.
+*/
+- (void)changeDistributionGroupIdAfterAppUpdateIfNeeded;
+
+/**
+ * Check if latest downloaded release was installed (app was updated).
+ *
+ * @param lastDownloadedReleaseHashes Hash of the last downloaded release.
+ *
+ * @return `YES` if current release was updated.
+ */
+- (bool)isCurrentReleaseWasUpdated:(NSString *)lastDownloadedReleaseHashes;
 
 /**
  * Show a dialog to ask a user to confirm update for a new release.

--- a/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
@@ -241,34 +241,28 @@ static NSString *const kMSTesterAppUpdateSetupFailedKey = @"MSTesterAppUpdateSet
 /**
  * Remove details about downloaded release after it was installed.
  */
-- (void)removeDownloadedReleaseDetailsIfUpdated;
+- (void)removeDownloadedReleaseDetailsIfUpdated:(NSString *)currentInstalledReleaseHash;
 
 /**
  * Get reporting parameters for updated release.
  *
  * @param updateToken The update token stored in keychain. This value can be nil if it is public distribution.
+ * @param currentInstalledReleaseHash The release hash of the current version.
  * @param distributionGroupId The distribution group Id in keychain.
  *
  * @return Reporting parameters dictionary.
  */
 - (NSMutableDictionary *)getReportingParametersForUpdatedRelease:(NSString *)updateToken
+                                     currentInstalledReleaseHash:(NSString *)currentInstalledReleaseHash
                                              distributionGroupId:(NSString *)distributionGroupId;
 
 /**
- * Check if an updated release has different group ID and update current group ID if needed.
+ * After an app is updated and restarted, check if an updated release has different group ID and update current
+ * group ID if needed.
  * Group ID may change if one user is added to different distribution groups and a new release
- * was distributed to another group.
+ * was updated from another group.
 */
-- (void)changeDistributionGroupIdAfterAppUpdateIfNeeded;
-
-/**
- * Check if latest downloaded release was installed (app was updated).
- *
- * @param lastDownloadedReleaseHashes Hash of the last downloaded release.
- *
- * @return `YES` if current release was updated.
- */
-- (bool)isCurrentReleaseWasUpdated:(NSString *)lastDownloadedReleaseHashes;
+- (void)changeDistributionGroupIdAfterAppUpdateIfNeeded:(NSString *)currentInstalledReleaseHash;
 
 /**
  * Show a dialog to ask a user to confirm update for a new release.

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -2277,7 +2277,7 @@ static NSURL *sfURL;
   // Then
   OCMVerify([distributeMock changeDistributionGroupIdAfterAppUpdateIfNeeded:kMSTestReleaseHash]);
   assertThat([self.settingsMock objectForKey:kMSDistributionGroupIdKey], equalTo(kMSTestDistributionGroupId));
-  assertThat([self.settingsMock objectForKey:kMSDownloadedDistributionGroupIdKey], equalTo(kMSTestDistributionGroupId));
+  assertThat([self.settingsMock objectForKey:kMSDownloadedDistributionGroupIdKey], equalTo(nil));
 
   // Stop mocking
   [distributeMock stopMocking];

--- a/AppCenterDistribute/AppCenterDistributeTests/MSReleaseDetailsTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSReleaseDetailsTests.m
@@ -41,6 +41,7 @@
   assertThat(details.releaseNotesUrl,
              equalTo([NSURL URLWithString:@"https://contoso.com/path/release/notes?skip_registration=true"]));
   assertThat(details.packageHashes, equalTo(@[ @"buildId1", @"buildId2" ]));
+  assertThat(details.distributionGroupId, equalTo(@"1379041b-0de4-471b-a46b-04b4f754684f"));
   assertThat(details.distributionGroups, equalTo(nil));
 }
 
@@ -66,6 +67,7 @@
       [NSURL URLWithString:@"itms-service://?action=download-manifest&url=contoso.com/release/filename"];
   details.releaseNotesUrl = [NSURL URLWithString:@"https://contoso.com/path/release/notes?skip_registration=true"];
   details.packageHashes = @[ @"buildId1", @"buildId2" ];
+  details.distributionGroupId = @"1379041b-0de4-471b-a46b-04b4f754684f";
   details.distributionGroups = @[];
 
   // When


### PR DESCRIPTION
This PR implements updating of distribution group ID if in-app updated release has different distribution group.

Group ID may change if one user is added to different distribution groups and a new release was distributed to another group.