### PR TITLE
Don't start services which requires app secret when no app secret

### DIFF
--- a/AppCenter/AppCenter/Internals/MSServiceCommon.h
+++ b/AppCenter/AppCenter/Internals/MSServiceCommon.h
@@ -94,6 +94,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup appSecret:(nullable NSString *)appSecret transmissionTargetToken:(nullable NSString *)token;
 
+/**
+ * Checks if the service needs the application secret.
+ *
+ * @return `YES` if the application secret is required, `NO` otherwise.
+ */
+-(BOOL)isAppSecretRequired;
+
 NS_ASSUME_NONNULL_END
 
 @end

--- a/AppCenter/AppCenter/Internals/MSServiceCommon.h
+++ b/AppCenter/AppCenter/Internals/MSServiceCommon.h
@@ -92,14 +92,16 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion Note that this is defined both here and in MSServiceAbstract.h. This is intentional, and due to
  * the way the classes are factored.
  */
-- (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup appSecret:(nullable NSString *)appSecret transmissionTargetToken:(nullable NSString *)token;
+- (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup
+                    appSecret:(nullable NSString *)appSecret
+      transmissionTargetToken:(nullable NSString *)token;
 
 /**
  * Checks if the service needs the application secret.
  *
  * @return `YES` if the application secret is required, `NO` otherwise.
  */
--(BOOL)isAppSecretRequired;
+- (BOOL)isAppSecretRequired;
 
 NS_ASSUME_NONNULL_END
 

--- a/AppCenter/AppCenter/MSAppCenter.m
+++ b/AppCenter/AppCenter/MSAppCenter.m
@@ -289,15 +289,18 @@ static NSString *const kMSGroupId = @"AppCenter";
       return NO;
     }
     if (service.isAppSecretRequired && ![self.appSecret length]) {
-      
+
       // Service requires an app secret but none is provided.
-      MSLogError([MSAppCenter logTag], @"Cannot start service %@. App Center was started without app secret, but the service requires it.", clazz);
+      MSLogError([MSAppCenter logTag],
+                 @"Cannot start service %@. App Center was started without app secret, but the service requires it.",
+                 clazz);
       return NO;
     }
 
     // Check if service should be disabled
     if ([self shouldDisable:[clazz serviceName]]) {
-      MSLogDebug([MSAppCenter logTag], @"Environment variable to disable service has been set; not starting service %@", clazz);
+      MSLogDebug([MSAppCenter logTag], @"Environment variable to disable service has been set; not starting service %@",
+                 clazz);
       return NO;
     }
 
@@ -305,8 +308,10 @@ static NSString *const kMSGroupId = @"AppCenter";
     [self.services addObject:service];
 
     // Start service with channel group.
-    [service startWithChannelGroup:self.channelGroup appSecret:self.appSecret transmissionTargetToken:self.defaultTransmissionTargetToken];
-    
+    [service startWithChannelGroup:self.channelGroup
+                         appSecret:self.appSecret
+           transmissionTargetToken:self.defaultTransmissionTargetToken];
+
     // Disable service if AppCenter is disabled.
     if ([clazz isEnabled] && !self.isEnabled) {
       self.enabledStateUpdating = YES;
@@ -349,7 +354,7 @@ static NSString *const kMSGroupId = @"AppCenter";
 
     // Persist the enabled status.
     [MS_USER_DEFAULTS setObject:@(isEnabled) forKey:kMSAppCenterIsEnabledKey];
-    
+
     // Enable/disable pipeline.
     [self applyPipelineEnabledState:isEnabled];
   }
@@ -412,16 +417,17 @@ static NSString *const kMSGroupId = @"AppCenter";
   // Construct channel group.
   if (self.appSecret) {
     self.channelGroup =
-    [[MSChannelGroupDefault alloc] initWithAppSecret:self.appSecret installId:self.installId logUrl:self.logUrl];
+        [[MSChannelGroupDefault alloc] initWithAppSecret:self.appSecret installId:self.installId logUrl:self.logUrl];
   } else {
-    
+
     // If there is no app secret, create a channel group without sender or storage.
     self.channelGroup = [[MSChannelGroupDefault alloc] initWithSender:nil storage:nil];
   }
 
   // Initialize a channel unit for start service logs.
   self.channelUnit = [self.channelGroup
-      addChannelUnitWithConfiguration:[[MSChannelUnitConfiguration alloc] initDefaultConfigurationWithGroupId:[MSAppCenter groupId]]];
+      addChannelUnitWithConfiguration:[[MSChannelUnitConfiguration alloc]
+                                          initDefaultConfigurationWithGroupId:[MSAppCenter groupId]]];
 }
 
 - (NSString *)appSecret {
@@ -512,13 +518,14 @@ static NSString *const kMSGroupId = @"AppCenter";
  *
  * @return YES if the service should be disabled.
  */
-- (BOOL)shouldDisable:(NSString*)serviceName {
+- (BOOL)shouldDisable:(NSString *)serviceName {
   NSDictionary *environmentVariables = [[NSProcessInfo processInfo] environment];
   NSString *disabledServices = environmentVariables[kMSDisableVariable];
   if (!disabledServices) {
     return NO;
   }
-  NSMutableArray* disabledServicesList = [NSMutableArray arrayWithArray:[disabledServices componentsSeparatedByString:@","]];
+  NSMutableArray *disabledServicesList =
+      [NSMutableArray arrayWithArray:[disabledServices componentsSeparatedByString:@","]];
 
   // Trim whitespace characters.
   for (NSUInteger i = 0; i < [disabledServicesList count]; ++i) {

--- a/AppCenter/AppCenter/MSAppCenter.m
+++ b/AppCenter/AppCenter/MSAppCenter.m
@@ -288,6 +288,12 @@ static NSString *const kMSGroupId = @"AppCenter";
       // Service already works, we shouldn't send log with this service name
       return NO;
     }
+    if (service.isAppSecretRequired && ![self.appSecret length]) {
+      
+      // Service requires an app secret but none is provided.
+      MSLogError([MSAppCenter logTag], @"Cannot start service %@. App Center was started without app secret, but the service requires it.", clazz);
+      return NO;
+    }
 
     // Check if service should be disabled
     if ([self shouldDisable:[clazz serviceName]]) {

--- a/AppCenter/AppCenter/MSServiceAbstract.h
+++ b/AppCenter/AppCenter/MSServiceAbstract.h
@@ -17,14 +17,15 @@
  * @param appSecret app secret for the SDK.
  * @param token default transmission target token for this service.
  */
-- (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup appSecret:(NSString *)appSecret transmissionTargetToken:(NSString *)token;
+- (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup
+                    appSecret:(NSString *)appSecret
+      transmissionTargetToken:(NSString *)token;
 
 /**
  * Checks if the service needs the application secret.
  *
  * @return `YES` if the application secret is required, `NO` otherwise.
  */
--(BOOL)isAppSecretRequired;
+- (BOOL)isAppSecretRequired;
 
 @end
-

--- a/AppCenter/AppCenter/MSServiceAbstract.h
+++ b/AppCenter/AppCenter/MSServiceAbstract.h
@@ -19,5 +19,12 @@
  */
 - (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup appSecret:(NSString *)appSecret transmissionTargetToken:(NSString *)token;
 
+/**
+ * Checks if the service needs the application secret.
+ *
+ * @return `YES` if the application secret is required, `NO` otherwise.
+ */
+-(BOOL)isAppSecretRequired;
+
 @end
 

--- a/AppCenter/AppCenter/MSServiceAbstract.m
+++ b/AppCenter/AppCenter/MSServiceAbstract.m
@@ -70,13 +70,15 @@
   return MSInitializationPriorityDefault;
 }
 
--(BOOL)isAppSecretRequired {
+- (BOOL)isAppSecretRequired {
   return YES;
 }
 
 #pragma mark : - MSService
 
-- (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup appSecret:(NSString *)appSecret transmissionTargetToken:(NSString *)token {
+- (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup
+                    appSecret:(NSString *)appSecret
+      transmissionTargetToken:(NSString *)token {
   self.channelGroup = channelGroup;
   self.appSecret = appSecret;
   self.defaultTransmissionTargetToken = token;

--- a/AppCenter/AppCenter/MSServiceAbstract.m
+++ b/AppCenter/AppCenter/MSServiceAbstract.m
@@ -70,6 +70,10 @@
   return MSInitializationPriorityDefault;
 }
 
+-(BOOL)isAppSecretRequired {
+  return YES;
+}
+
 #pragma mark : - MSService
 
 - (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup appSecret:(NSString *)appSecret transmissionTargetToken:(NSString *)token {

--- a/AppCenter/AppCenterTests/MSAppCenterTests.m
+++ b/AppCenter/AppCenterTests/MSAppCenterTests.m
@@ -67,11 +67,11 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 }
 
 - (void)testStartWithAppSecretOnly {
-  
+
   // When
   NSString *appSecret = MS_UUID_STRING;
-  [MSAppCenter start:appSecret withServices:@[MSMockService.class, MSMockSecondService.class]];
-  
+  [MSAppCenter start:appSecret withServices:@[ MSMockService.class, MSMockSecondService.class ]];
+
   // Then
   XCTAssertNil([[MSAppCenter sharedInstance] defaultTransmissionTargetToken]);
   XCTAssertTrue([[[MSAppCenter sharedInstance] appSecret] isEqualToString:appSecret]);
@@ -80,38 +80,41 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 }
 
 - (void)testStartWithAppSecretAndTransmissionToken {
-  
+
   // If
   NSString *appSecret = MS_UUID_STRING;
   NSString *transmissionTargetKey = @"target=";
   NSString *transmissionTargetString = @"transmissionTargetToken";
   NSString *secret = [NSString stringWithFormat:@"%@;%@%@", appSecret, transmissionTargetKey, transmissionTargetString];
-  
+
   // When
-  [MSAppCenter start:secret withServices:@[MSMockService.class, MSMockSecondService.class]];
-  
+  [MSAppCenter start:secret withServices:@[ MSMockService.class, MSMockSecondService.class ]];
+
   // Then
   XCTAssertTrue([[[MSAppCenter sharedInstance] appSecret] isEqualToString:appSecret]);
-  XCTAssertTrue([[[MSAppCenter sharedInstance] defaultTransmissionTargetToken] isEqualToString:transmissionTargetString]);
+  XCTAssertTrue(
+      [[[MSAppCenter sharedInstance] defaultTransmissionTargetToken] isEqualToString:transmissionTargetString]);
   XCTAssertTrue([MSMockService sharedInstance].started);
   XCTAssertTrue([MSMockSecondService sharedInstance].started);
 }
 
 - (void)testStartWithTransmissionTokenOnly {
-  
+
   // If
   NSString *transmissionTargetKey = @"target=";
   NSString *transmissionTargetString = @"transmissionTargetToken";
   NSString *secret = [NSString stringWithFormat:@"%@%@", transmissionTargetKey, transmissionTargetString];
-  
+
   // When
-  [MSAppCenter start:secret withServices:@[MSMockService.class, MSMockSecondService.class]];
-  
+  [MSAppCenter start:secret withServices:@[ MSMockService.class, MSMockSecondService.class ]];
+
   // Then
   XCTAssertNil([[MSAppCenter sharedInstance] appSecret]);
-  XCTAssertTrue([[[MSAppCenter sharedInstance] defaultTransmissionTargetToken] isEqualToString:transmissionTargetString]);
+  XCTAssertTrue(
+      [[[MSAppCenter sharedInstance] defaultTransmissionTargetToken] isEqualToString:transmissionTargetString]);
   XCTAssertFalse([MSMockService sharedInstance].started);
-  XCTAssertTrue([MSMockSecondService sharedInstance].started);}
+  XCTAssertTrue([MSMockSecondService sharedInstance].started);
+}
 
 - (void)testGetInstallIdFromStorage {
 
@@ -187,33 +190,33 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 }
 
 - (void)testSetEnabled {
-  
+
   // If
-  [MSAppCenter start:MS_UUID_STRING withServices:@[MSMockService.class]];
-  
+  [MSAppCenter start:MS_UUID_STRING withServices:@[ MSMockService.class ]];
+
   // When
   [self.settingsMock setObject:@NO forKey:kMSAppCenterIsEnabledKey];
-  
+
   // Then
   XCTAssertFalse([MSAppCenter isEnabled]);
-  
+
   // When
   [self.settingsMock setObject:@YES forKey:kMSAppCenterIsEnabledKey];
-  
+
   // Then
   XCTAssertTrue([MSAppCenter isEnabled]);
-  
+
   // When
   [MSAppCenter setEnabled:NO];
-  
+
   // Then
   XCTAssertFalse([MSAppCenter isEnabled]);
   XCTAssertFalse([MSMockService isEnabled]);
   XCTAssertFalse(((NSNumber *)[self.settingsMock objectForKey:kMSAppCenterIsEnabledKey]).boolValue);
-  
+
   // When
   [MSAppCenter setEnabled:YES];
-  
+
   // Then
   XCTAssertTrue([MSAppCenter isEnabled]);
   XCTAssertTrue([MSMockService isEnabled]);
@@ -238,16 +241,16 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 }
 
 - (void)testDisableServicesWithEnvironmentVariable {
-  const char* disableVariableCstr = [kMSDisableVariable UTF8String];
-  const char* disableAllCstr = [kMSDisableAll UTF8String];
-  
+  const char *disableVariableCstr = [kMSDisableVariable UTF8String];
+  const char *disableAllCstr = [kMSDisableAll UTF8String];
+
   // If
   setenv(disableVariableCstr, disableAllCstr, 1);
   [[MSMockService sharedInstance] setStarted:NO];
   [[MSMockSecondService sharedInstance] setStarted:NO];
 
   // When
-  [MSAppCenter start:@"AppSecret" withServices:@[MSMockService.class, MSMockSecondService.class]];
+  [MSAppCenter start:@"AppSecret" withServices:@[ MSMockService.class, MSMockSecondService.class ]];
 
   // Then
   XCTAssertFalse([[MSMockService sharedInstance] started]);
@@ -260,21 +263,22 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
   [MSAppCenter resetSharedInstance];
 
   // When
-  [MSAppCenter start:@"AppSecret" withServices:@[MSMockService.class, MSMockSecondService.class]];
+  [MSAppCenter start:@"AppSecret" withServices:@[ MSMockService.class, MSMockSecondService.class ]];
 
   // Then
   XCTAssertFalse([[MSMockService sharedInstance] started]);
   XCTAssertTrue([[MSMockSecondService sharedInstance] started]);
-  
+
   // If
-  NSString* disableList = [NSString stringWithFormat:@"%@,SomeService,%@", [MSMockService serviceName], [MSMockSecondService serviceName]];
+  NSString *disableList =
+      [NSString stringWithFormat:@"%@,SomeService,%@", [MSMockService serviceName], [MSMockSecondService serviceName]];
   setenv(disableVariableCstr, [disableList UTF8String], 1);
   [[MSMockService sharedInstance] setStarted:NO];
   [[MSMockSecondService sharedInstance] setStarted:NO];
   [MSAppCenter resetSharedInstance];
 
   // When
-  [MSAppCenter start:@"AppSecret" withServices:@[MSMockService.class, MSMockSecondService.class]];
+  [MSAppCenter start:@"AppSecret" withServices:@[ MSMockService.class, MSMockSecondService.class ]];
 
   // Then
   XCTAssertFalse([[MSMockService sharedInstance] started]);
@@ -282,31 +286,31 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 
   // Repeat previous test but with some whitespace.
   // If
-  disableList = [NSString stringWithFormat:@" %@ , SomeService,%@ ", [MSMockService serviceName], [MSMockSecondService serviceName]];
+  disableList = [NSString
+      stringWithFormat:@" %@ , SomeService,%@ ", [MSMockService serviceName], [MSMockSecondService serviceName]];
   setenv(disableVariableCstr, [disableList UTF8String], 1);
   [[MSMockService sharedInstance] setStarted:NO];
   [[MSMockSecondService sharedInstance] setStarted:NO];
   [MSAppCenter resetSharedInstance];
-  
+
   // When
-  [MSAppCenter start:@"AppSecret" withServices:@[MSMockService.class, MSMockSecondService.class]];
-  
+  [MSAppCenter start:@"AppSecret" withServices:@[ MSMockService.class, MSMockSecondService.class ]];
+
   // Then
   XCTAssertFalse([[MSMockService sharedInstance] started]);
   XCTAssertFalse([[MSMockSecondService sharedInstance] started]);
-  
+
   // Special tear down.
   setenv(disableVariableCstr, "", 1);
 }
-      
+
 #if !TARGET_OS_TV
 - (void)testSetCustomProperties {
 
   // If
   [MSAppCenter start:MS_UUID_STRING withServices:nil];
   id channelUnit = OCMProtocolMock(@protocol(MSChannelUnitProtocol));
-  OCMStub([channelUnit enqueueItem:[OCMArg isKindOfClass:[MSCustomPropertiesLog class]]])
-      .andDo(nil);
+  OCMStub([channelUnit enqueueItem:[OCMArg isKindOfClass:[MSCustomPropertiesLog class]]]).andDo(nil);
   [MSAppCenter sharedInstance].channelUnit = channelUnit;
 
   // When
@@ -386,11 +390,11 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 }
 
 - (void)testDisabledCoreStatus {
-  
+
   // When
-  [MSAppCenter start:MS_UUID_STRING withServices:@[MSMockService.class]];
+  [MSAppCenter start:MS_UUID_STRING withServices:@[ MSMockService.class ]];
   [MSAppCenter setEnabled:NO];
-  
+
   // Then
   MSChannelGroupDefault *channelGroup = (MSChannelGroupDefault *)[MSAppCenter sharedInstance].channelGroup;
   XCTAssertFalse(channelGroup.sender.enabled);
@@ -398,13 +402,13 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 }
 
 - (void)testDisabledCorePersistedStatus {
-  
+
   // If
   [self.settingsMock setObject:@NO forKey:kMSAppCenterIsEnabledKey];
-  
+
   // When
-  [MSAppCenter start:MS_UUID_STRING withServices:@[MSMockService.class]];
- 
+  [MSAppCenter start:MS_UUID_STRING withServices:@[ MSMockService.class ]];
+
   // Then
   MSChannelGroupDefault *channelGroup = (MSChannelGroupDefault *)[MSAppCenter sharedInstance].channelGroup;
   XCTAssertFalse(channelGroup.sender.enabled);
@@ -412,7 +416,7 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 }
 
 - (void)testStartServiceLogWithDisabledCore {
-  
+
   // If
   id channelGroup = OCMClassMock([MSChannelGroupDefault class]);
   id channelUnit = OCMProtocolMock(@protocol(MSChannelUnitProtocol));
@@ -426,28 +430,28 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
         [invocation getArgument:&log atIndex:2];
         logsProcessed++;
       });
-  
+
   // When
   [MSAppCenter start:MS_UUID_STRING withServices:nil];
   [MSAppCenter setEnabled:NO];
   [MSAppCenter startService:MSMockService.class];
   [MSAppCenter startService:MSMockSecondService.class];
-  
+
   // Then
   assertThatInteger(logsProcessed, equalToInteger(0));
   XCTAssertFalse([MSMockService isEnabled]);
   XCTAssertFalse([MSMockSecondService isEnabled]);
   XCTAssertNil(log);
-  
+
   // When
   [MSAppCenter setEnabled:YES];
-  
+
   // Then
   assertThatInteger(logsProcessed, equalToInteger(1));
   XCTAssertNotNil(log);
-  NSArray *expected = @[@"MSMockService", @"MSMockSecondService"];
+  NSArray *expected = @[ @"MSMockService", @"MSMockSecondService" ];
   XCTAssertTrue([log.services isEqual:expected]);
-  
+
   // Clear
   [channelGroup stopMocking];
 }

--- a/AppCenter/AppCenterTests/MSServiceAbstractTests.m
+++ b/AppCenter/AppCenterTests/MSServiceAbstractTests.m
@@ -29,10 +29,10 @@
 - (instancetype)init {
   if ((self = [super init])) {
     _channelUnitConfiguration = [[MSChannelUnitConfiguration alloc] initWithGroupId:[self groupId]
-                                                                   priority:MSPriorityDefault
-                                                              flushInterval:3.0
-                                                             batchSizeLimit:50
-                                                        pendingBatchesLimit:3];
+                                                                           priority:MSPriorityDefault
+                                                                      flushInterval:3.0
+                                                                     batchSizeLimit:50
+                                                                pendingBatchesLimit:3];
   }
   return self;
 }
@@ -285,11 +285,10 @@
   OCMStub([channelGroup initWithAppSecret:OCMOCK_ANY installId:OCMOCK_ANY logUrl:OCMOCK_ANY]).andReturn(channelGroup);
   OCMStub([channelGroup addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnit);
 
-  OCMStub([channelUnit setEnabled:NO andDeleteDataOnDisabled:YES])
-      .andDo(^(NSInvocation *invocation) {
-        [invocation getArgument:&deleteLogs atIndex:3];
-        [invocation getArgument:&forwardedEnabled atIndex:2];
-      });
+  OCMStub([channelUnit setEnabled:NO andDeleteDataOnDisabled:YES]).andDo(^(NSInvocation *invocation) {
+    [invocation getArgument:&deleteLogs atIndex:3];
+    [invocation getArgument:&forwardedEnabled atIndex:2];
+  });
   self.abstractService.channelGroup = channelGroup;
   self.abstractService.channelUnit = channelUnit;
   [self.settingsMock setObject:@YES forKey:self.abstractService.isEnabledKey];
@@ -297,7 +296,7 @@
   // When
   [self.abstractService setEnabled:NO];
 
-  //Then
+  // Then
 
   // Check that log deletion has been triggered.
   OCMVerify([channelUnit setEnabled:NO andDeleteDataOnDisabled:YES]);

--- a/AppCenter/AppCenterTests/MSServiceAbstractTests.m
+++ b/AppCenter/AppCenterTests/MSServiceAbstractTests.m
@@ -332,4 +332,8 @@
   XCTAssertTrue([self.abstractService initializationPriority] == MSInitializationPriorityDefault);
 }
 
+- (void)testEmptyAppSecretRequiredByDefault {
+  XCTAssertTrue([self.abstractService isAppSecretRequired]);
+}
+
 @end

--- a/AppCenter/AppCenterTests/MSServiceAbstractTests.m
+++ b/AppCenter/AppCenterTests/MSServiceAbstractTests.m
@@ -331,7 +331,7 @@
   XCTAssertTrue([self.abstractService initializationPriority] == MSInitializationPriorityDefault);
 }
 
-- (void)testEmptyAppSecretRequiredByDefault {
+- (void)testAppSecretRequiredByDefault {
   XCTAssertTrue([self.abstractService isAppSecretRequired]);
 }
 

--- a/AppCenter/AppCenterTests/Util/MSMockSecondService.h
+++ b/AppCenter/AppCenterTests/Util/MSMockSecondService.h
@@ -5,4 +5,6 @@
 
 @property BOOL started;
 
++ (void)resetSharedInstance;
+
 @end

--- a/AppCenter/AppCenterTests/Util/MSMockSecondService.m
+++ b/AppCenter/AppCenterTests/Util/MSMockSecondService.m
@@ -31,6 +31,10 @@ static MSMockSecondService *sharedInstance = nil;
   return sharedInstance;
 }
 
++ (void)resetSharedInstance {
+  sharedInstance = nil;
+}
+
 + (NSString *)serviceName {
   return kMSServiceName;
 }
@@ -48,6 +52,10 @@ static MSMockSecondService *sharedInstance = nil;
 }
 
 - (void)applyEnabledState:(BOOL)__unused isEnabled {
+}
+
+- (BOOL)isAppSecretRequired {
+  return NO;
 }
 
 @end

--- a/AppCenter/AppCenterTests/Util/MSMockService.h
+++ b/AppCenter/AppCenterTests/Util/MSMockService.h
@@ -5,4 +5,6 @@
 
 @property BOOL started;
 
++ (void)resetSharedInstance;
+
 @end

--- a/AppCenter/AppCenterTests/Util/MSMockService.m
+++ b/AppCenter/AppCenterTests/Util/MSMockService.m
@@ -30,6 +30,10 @@ static MSMockService *sharedInstance = nil;
   return sharedInstance;
 }
 
++ (void)resetSharedInstance {
+  sharedInstance = nil;
+}
+
 + (NSString *)serviceName {
   return kMSServiceName;
 }

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -121,6 +121,10 @@ static const int maxPropertyValueLength = 64;
   }
 }
 
+-(BOOL)isAppSecretRequired {
+  return NO;
+}
+
 #pragma mark - Service methods
 
 + (void)trackEvent:(NSString *)eventName {

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -69,7 +69,9 @@ static const int maxPropertyValueLength = 64;
   return kMSServiceName;
 }
 
-- (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup appSecret:(nullable NSString *)appSecret transmissionTargetToken:(nullable NSString *)token  {
+- (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup
+                    appSecret:(nullable NSString *)appSecret
+      transmissionTargetToken:(nullable NSString *)token {
   [super startWithChannelGroup:channelGroup appSecret:appSecret transmissionTargetToken:token];
   if (token) {
     self.defaultTransmissionTarget = [self transmissionTargetFor:(NSString *)token];
@@ -121,7 +123,7 @@ static const int maxPropertyValueLength = 64;
   }
 }
 
--(BOOL)isAppSecretRequired {
+- (BOOL)isAppSecretRequired {
   return NO;
 }
 
@@ -152,7 +154,9 @@ static const int maxPropertyValueLength = 64;
  * @param properties dictionary of properties.
  * @param transmissionTarget  the transmission target to associate to this event.
  */
-+ (void)trackEvent:(NSString *)eventName withProperties:(nullable NSDictionary<NSString *, NSString *> *)properties forTransmissionTarget:(nullable MSAnalyticsTransmissionTarget *)transmissionTarget {
++ (void)trackEvent:(NSString *)eventName
+           withProperties:(nullable NSDictionary<NSString *, NSString *> *)properties
+    forTransmissionTarget:(nullable MSAnalyticsTransmissionTarget *)transmissionTarget {
   @synchronized(self) {
     if ([[self sharedInstance] canBeUsed]) {
       [[self sharedInstance] trackEvent:eventName withProperties:properties forTransmissionTarget:transmissionTarget];
@@ -246,7 +250,9 @@ static const int maxPropertyValueLength = 64;
   return validProperties;
 }
 
-- (void)trackEvent:(NSString *)eventName withProperties:(NSDictionary<NSString *, NSString *> *)properties forTransmissionTarget:(MSAnalyticsTransmissionTarget *)transmissionTarget {
+- (void)trackEvent:(NSString *)eventName
+           withProperties:(NSDictionary<NSString *, NSString *> *)properties
+    forTransmissionTarget:(MSAnalyticsTransmissionTarget *)transmissionTarget {
   if (![self isEnabled])
     return;
 
@@ -330,7 +336,7 @@ static const int maxPropertyValueLength = 64;
  * @returns The transmission target object.
  */
 - (MSAnalyticsTransmissionTarget *)transmissionTargetFor:(NSString *)transmissionTargetToken {
-  MSAnalyticsTransmissionTarget *transmissionTarget= [self.transmissionTargets objectForKey:transmissionTargetToken];
+  MSAnalyticsTransmissionTarget *transmissionTarget = [self.transmissionTargets objectForKey:transmissionTargetToken];
   if (transmissionTarget) {
     MSLogDebug([MSAnalytics logTag], @"Returning transmission target found with id %@.", transmissionTargetToken);
     return transmissionTarget;

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
@@ -653,7 +653,7 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   XCTAssertEqual(transmissionTarget1, transmissionTarget2);
 }
 
-- (void)testEmptyAppSecretNotRequired {
+- (void)testAppSecretNotRequired {
   XCTAssertFalse([[MSAnalytics sharedInstance] isAppSecretRequired]);
 }
 

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
@@ -740,5 +740,9 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   XCTAssertEqual(transmissionTarget1, transmissionTarget2);
 }
 
+- (void)testEmptyAppSecretNotRequired {
+  XCTAssertFalse([[MSAnalytics sharedInstance] isAppSecretRequired]);
+}
+
 @end
 

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
@@ -61,21 +61,22 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   NSString *validEventName = @"validEventName";
   NSString *shortEventName = @"e";
   NSString *eventName256 =
-[@"" stringByPaddingToLength:maxEventNameLength withString:@"eventName256" startingAtIndex:0];
+      [@"" stringByPaddingToLength:maxEventNameLength withString:@"eventName256" startingAtIndex:0];
   NSString *nullableEventName = nil;
   NSString *emptyEventName = @"";
-  NSString *tooLongEventName = [@"" stringByPaddingToLength:(maxEventNameLength+1) withString:@"tooLongEventName" startingAtIndex:0];
+  NSString *tooLongEventName =
+      [@"" stringByPaddingToLength:(maxEventNameLength + 1) withString:@"tooLongEventName" startingAtIndex:0];
   // When
   NSString *valid = [[MSAnalytics sharedInstance] validateEventName:validEventName forLogType:kMSTypeEvent];
   NSString *validShortEventName =
-  [[MSAnalytics sharedInstance] validateEventName:shortEventName forLogType:kMSTypeEvent];
+      [[MSAnalytics sharedInstance] validateEventName:shortEventName forLogType:kMSTypeEvent];
   NSString *validEventName256 = [[MSAnalytics sharedInstance] validateEventName:eventName256 forLogType:kMSTypeEvent];
   NSString *validNullableEventName =
-  [[MSAnalytics sharedInstance] validateEventName:nullableEventName forLogType:kMSTypeEvent];
+      [[MSAnalytics sharedInstance] validateEventName:nullableEventName forLogType:kMSTypeEvent];
   NSString *validEmptyEventName =
-  [[MSAnalytics sharedInstance] validateEventName:emptyEventName forLogType:kMSTypeEvent];
+      [[MSAnalytics sharedInstance] validateEventName:emptyEventName forLogType:kMSTypeEvent];
   NSString *validTooLongEventName =
-  [[MSAnalytics sharedInstance] validateEventName:tooLongEventName forLogType:kMSTypeEvent];
+      [[MSAnalytics sharedInstance] validateEventName:tooLongEventName forLogType:kMSTypeEvent];
 
   // Then
   XCTAssertNotNil(valid);
@@ -91,21 +92,22 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   const int maxPropertriesPerEvent = 5;
   const int maxPropertyKeyLength = 64;
   const int maxPropertyValueLength = 64;
-  NSString *longStringValue = [@"" stringByPaddingToLength:(maxPropertyValueLength+1) withString:@"value" startingAtIndex:0];
-  NSString *stringValue64 =[@"" stringByPaddingToLength:maxPropertyValueLength withString:@"value" startingAtIndex:0];
+  NSString *longStringValue =
+      [@"" stringByPaddingToLength:(maxPropertyValueLength + 1) withString:@"value" startingAtIndex:0];
+  NSString *stringValue64 = [@"" stringByPaddingToLength:maxPropertyValueLength withString:@"value" startingAtIndex:0];
 
   // Test valid properties
   // If
   NSDictionary *validProperties =
-  @{ @"Key1" : @"Value1",
-     stringValue64 : @"Value2",
-     @"Key3" : stringValue64,
-     @"Key4" : @"Value4",
-     @"Key5" : @"" };
+      @{ @"Key1" : @"Value1",
+         stringValue64 : @"Value2",
+         @"Key3" : stringValue64,
+         @"Key4" : @"Value4",
+         @"Key5" : @"" };
 
   // When
   NSDictionary *validatedProperties =
-  [[MSAnalytics sharedInstance] validateProperties:validProperties forLogName:kMSTypeEvent andType:kMSTypeEvent];
+      [[MSAnalytics sharedInstance] validateProperties:validProperties forLogName:kMSTypeEvent andType:kMSTypeEvent];
 
   // Then
   XCTAssertTrue([validatedProperties count] == [validProperties count]);
@@ -113,18 +115,18 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   // Test too many properties in one event
   // If
   NSDictionary *tooManyProperties = @{
-                                      @"Key1" : @"Value1",
-                                      @"Key2" : @"Value2",
-                                      @"Key3" : @"Value3",
-                                      @"Key4" : @"Value4",
-                                      @"Key5" : @"Value5",
-                                      @"Key6" : @"Value6",
-                                      @"Key7" : @"Value7"
-                                      };
+    @"Key1" : @"Value1",
+    @"Key2" : @"Value2",
+    @"Key3" : @"Value3",
+    @"Key4" : @"Value4",
+    @"Key5" : @"Value5",
+    @"Key6" : @"Value6",
+    @"Key7" : @"Value7"
+  };
 
   // When
   validatedProperties =
-  [[MSAnalytics sharedInstance] validateProperties:tooManyProperties forLogName:kMSTypeEvent andType:kMSTypeEvent];
+      [[MSAnalytics sharedInstance] validateProperties:tooManyProperties forLogName:kMSTypeEvent andType:kMSTypeEvent];
 
   // Then
   XCTAssertTrue([validatedProperties count] == maxPropertriesPerEvent);
@@ -172,14 +174,14 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   // Test mixed variant
   // If
   NSDictionary *mixedEventProperties = @{
-                                         @"Key1" : @"Value1",
-                                         @(2) : @"Value2",
-                                         stringValue64 : @"Value3",
-                                         @"Key4" : stringValue64,
-                                         @"Key5" : @"Value5",
-                                         @"Key6" : @(2),
-                                         @"Key7" : longStringValue,
-                                         };
+    @"Key1" : @"Value1",
+    @(2) : @"Value2",
+    stringValue64 : @"Value3",
+    @"Key4" : stringValue64,
+    @"Key5" : @"Value5",
+    @"Key6" : @(2),
+    @"Key7" : longStringValue,
+  };
 
   // When
   validatedProperties = [[MSAnalytics sharedInstance] validateProperties:mixedEventProperties
@@ -199,7 +201,7 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 - (void)testApplyEnabledStateWorks {
   [[MSAnalytics sharedInstance] startWithChannelGroup:OCMProtocolMock(@protocol(MSChannelGroupProtocol))
                                             appSecret:kMSTestAppSecret
-                                             transmissionTargetToken:nil];
+                              transmissionTargetToken:nil];
 
   MSServiceAbstract *service = [MSAnalytics sharedInstance];
 
@@ -230,13 +232,13 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   // When
   [[MSAnalytics sharedInstance] startWithChannelGroup:OCMProtocolMock(@protocol(MSChannelGroupProtocol))
                                             appSecret:kMSTestAppSecret
-                                             transmissionTargetToken:nil];
-
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
 
-  XCTestExpectation *expection = [self expectationWithDescription:@"Wait for block in applyEnabledState to be dispatched"];
+  XCTestExpectation *expection =
+      [self expectationWithDescription:@"Wait for block in applyEnabledState to be dispatched"];
   dispatch_async(dispatch_get_main_queue(), ^{
     [expection fulfill];
   });
@@ -270,7 +272,8 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   OCMReject([delegateMock analytics:[MSAnalytics sharedInstance] didFailSendingEventLog:eventLog withError:nil]);
   [MSAppCenter sharedInstance].sdkConfigured = NO;
   [MSAppCenter start:kMSTestAppSecret withServices:@[ [MSAnalytics class] ]];
-  MSChannelUnitDefault *channelMock = [MSAnalytics sharedInstance].channelUnit = OCMPartialMock([MSAnalytics sharedInstance].channelUnit);
+  MSChannelUnitDefault *channelMock = [MSAnalytics sharedInstance].channelUnit =
+      OCMPartialMock([MSAnalytics sharedInstance].channelUnit);
   OCMStub([channelMock enqueueItem:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     id<MSLog> log = nil;
     [invocation getArgument:&log atIndex:2];
@@ -297,7 +300,8 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   id<MSAnalyticsDelegate> delegateMock = OCMProtocolMock(@protocol(MSAnalyticsDelegate));
   [MSAppCenter sharedInstance].sdkConfigured = NO;
   [MSAppCenter start:kMSTestAppSecret withServices:@[ [MSAnalytics class] ]];
-  MSChannelUnitDefault *channelMock = [MSAnalytics sharedInstance].channelUnit = OCMPartialMock([MSAnalytics sharedInstance].channelUnit);
+  MSChannelUnitDefault *channelMock = [MSAnalytics sharedInstance].channelUnit =
+      OCMPartialMock([MSAnalytics sharedInstance].channelUnit);
   OCMStub([channelMock enqueueItem:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     id<MSLog> log = nil;
     [invocation getArgument:&log atIndex:2];
@@ -331,14 +335,16 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
   OCMStub([channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSLogWithProperties class]]])
-  .andDo(^(NSInvocation *invocation) {
-    MSEventLog *log;
-    [invocation getArgument:&log atIndex:2];
-    type = log.type;
-    name = log.name;
-  });
+      .andDo(^(NSInvocation *invocation) {
+        MSEventLog *log;
+        [invocation getArgument:&log atIndex:2];
+        type = log.type;
+        name = log.name;
+      });
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
-  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock appSecret:kMSTestAppSecret transmissionTargetToken:nil];
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
@@ -360,7 +366,9 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   id channelUnitMock = OCMProtocolMock(@protocol(MSChannelUnitProtocol));
   id channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
-  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock appSecret:kMSTestAppSecret transmissionTargetToken:nil];
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
@@ -384,7 +392,9 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   id channelUnitMock = OCMProtocolMock(@protocol(MSChannelUnitProtocol));
   id channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
-  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock appSecret:kMSTestAppSecret transmissionTargetToken:nil];
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
@@ -412,15 +422,17 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   id channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
   OCMStub([channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSLogWithProperties class]]])
-  .andDo(^(NSInvocation *invocation) {
-    MSEventLog *log;
-    [invocation getArgument:&log atIndex:2];
-    type = log.type;
-    name = log.name;
-    properties = log.properties;
-  });
+      .andDo(^(NSInvocation *invocation) {
+        MSEventLog *log;
+        [invocation getArgument:&log atIndex:2];
+        type = log.type;
+        name = log.name;
+        properties = log.properties;
+      });
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
-  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock appSecret:kMSTestAppSecret transmissionTargetToken:nil];
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
@@ -444,14 +456,16 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
   OCMStub([channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSLogWithProperties class]]])
-  .andDo(^(NSInvocation *invocation) {
-    MSEventLog *log;
-    [invocation getArgument:&log atIndex:2];
-    type = log.type;
-    name = log.name;
-  });
+      .andDo(^(NSInvocation *invocation) {
+        MSEventLog *log;
+        [invocation getArgument:&log atIndex:2];
+        type = log.type;
+        name = log.name;
+      });
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
-  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock appSecret:kMSTestAppSecret transmissionTargetToken:nil];
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
@@ -476,15 +490,17 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
   OCMStub([channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSLogWithProperties class]]])
-  .andDo(^(NSInvocation *invocation) {
-    MSEventLog *log;
-    [invocation getArgument:&log atIndex:2];
-    type = log.type;
-    name = log.name;
-    properties = log.properties;
-  });
+      .andDo(^(NSInvocation *invocation) {
+        MSEventLog *log;
+        [invocation getArgument:&log atIndex:2];
+        type = log.type;
+        name = log.name;
+        properties = log.properties;
+      });
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
-  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock appSecret:kMSTestAppSecret transmissionTargetToken:nil];
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
@@ -508,7 +524,9 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
 
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
-  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock appSecret:kMSTestAppSecret transmissionTargetToken:nil];
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
@@ -533,7 +551,9 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   id channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
-  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock appSecret:kMSTestAppSecret transmissionTargetToken:nil];
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
@@ -575,7 +595,7 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   XCTAssertEqual([MSAnalytics serviceName], kMSAnalyticsServiceName);
 }
 
-- (void) testViewWillAppearSwizzlingWithAnalyticsAvailable {
+- (void)testViewWillAppearSwizzlingWithAnalyticsAvailable {
 
   // If
   id analyticsMock = OCMPartialMock([MSAnalytics sharedInstance]);
@@ -584,12 +604,12 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
   [[MSAnalytics sharedInstance] startWithChannelGroup:OCMProtocolMock(@protocol(MSChannelGroupProtocol))
                                             appSecret:kMSTestAppSecret
-                                             transmissionTargetToken:nil];
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
 
-  // When
+// When
 #if TARGET_OS_OSX
   NSViewController *viewController = [[NSViewController alloc] init];
 #pragma clang diagnostic push
@@ -600,7 +620,7 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 #pragma clang diagnostic pop
 #else
   UIViewController *viewController = [[UIViewController alloc] init];
-  [viewController viewWillAppear: NO];
+  [viewController viewWillAppear:NO];
 #endif
 
   // Then
@@ -608,7 +628,7 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   XCTAssertNil([MSAnalyticsCategory missedPageViewName]);
 }
 
-- (void) testViewWillAppearSwizzlingWithAnalyticsNotAvailable {
+- (void)testViewWillAppearSwizzlingWithAnalyticsNotAvailable {
 
   // If
   id analyticsMock = OCMPartialMock([MSAnalytics sharedInstance]);
@@ -617,12 +637,12 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
   [[MSAnalytics sharedInstance] startWithChannelGroup:OCMProtocolMock(@protocol(MSChannelGroupProtocol))
                                             appSecret:kMSTestAppSecret
-                                             transmissionTargetToken:nil];
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
 
-  // When
+// When
 #if TARGET_OS_OSX
   NSViewController *viewController = [[NSViewController alloc] init];
 #pragma clang diagnostic push
@@ -633,7 +653,7 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 #pragma clang diagnostic pop
 #else
   UIViewController *viewController = [[UIViewController alloc] init];
-  [viewController viewWillAppear: NO];
+  [viewController viewWillAppear:NO];
 #endif
 
   // Then
@@ -641,14 +661,14 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   XCTAssertNotNil([MSAnalyticsCategory missedPageViewName]);
 }
 
-- (void) testViewWillAppearSwizzlingWithShouldTrackPageDisabled {
+- (void)testViewWillAppearSwizzlingWithShouldTrackPageDisabled {
 
   // If
   id analyticsMock = OCMPartialMock([MSAnalytics sharedInstance]);
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
   [[MSAnalytics sharedInstance] startWithChannelGroup:OCMProtocolMock(@protocol(MSChannelGroupProtocol))
                                             appSecret:kMSTestAppSecret
-                                             transmissionTargetToken:nil];
+                              transmissionTargetToken:nil];
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
@@ -666,14 +686,14 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 #pragma clang diagnostic pop
 #else
   UIPageViewController *containerController = [[UIPageViewController alloc] init];
-  [containerController viewWillAppear: NO];
+  [containerController viewWillAppear:NO];
 #endif
 
   // Then
   OCMVerifyAll(analyticsMock);
 }
 
-- (void)testStartWithTransmissionTargetAndAppSecretUsesTransmissionTarget  {
+- (void)testStartWithTransmissionTargetAndAppSecretUsesTransmissionTarget {
 
   // If
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
@@ -683,13 +703,13 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   __block int invocations = 0;
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
   OCMStub([channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSLogWithProperties class]]])
-  .andDo(^(NSInvocation *invocation) {
-    ++invocations;
-    [invocation getArgument:&log atIndex:2];
-  });
+      .andDo(^(NSInvocation *invocation) {
+        ++invocations;
+        [invocation getArgument:&log atIndex:2];
+      });
   [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
                                             appSecret:kMSTestAppSecret
-                                             transmissionTargetToken:kMSTestTransmissionToken];
+                              transmissionTargetToken:kMSTestTransmissionToken];
 
   // When
   [MSAnalytics trackEvent:@"eventName"];
@@ -711,13 +731,13 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   __block int invocations = 0;
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
   OCMStub([channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSLogWithProperties class]]])
-  .andDo(^(NSInvocation *invocation) {
-    ++invocations;
-    [invocation getArgument:&log atIndex:2];
-  });
+      .andDo(^(NSInvocation *invocation) {
+        ++invocations;
+        [invocation getArgument:&log atIndex:2];
+      });
   [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
                                             appSecret:nil
-                                             transmissionTargetToken:kMSTestTransmissionToken];
+                              transmissionTargetToken:kMSTestTransmissionToken];
 
   // When
   [MSAnalytics trackEvent:@"eventName"];
@@ -732,8 +752,10 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 - (void)testGetTransmissionTargetCreatesTransmissionTargetOnce {
 
   // When
-  MSAnalyticsTransmissionTarget *transmissionTarget1 = [MSAnalytics transmissionTargetForToken:kMSTestTransmissionToken];
-  MSAnalyticsTransmissionTarget *transmissionTarget2 = [MSAnalytics transmissionTargetForToken:kMSTestTransmissionToken];
+  MSAnalyticsTransmissionTarget *transmissionTarget1 =
+      [MSAnalytics transmissionTargetForToken:kMSTestTransmissionToken];
+  MSAnalyticsTransmissionTarget *transmissionTarget2 =
+      [MSAnalytics transmissionTargetForToken:kMSTestTransmissionToken];
 
   // Then
   XCTAssertNotNil(transmissionTarget1);
@@ -745,4 +767,3 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 }
 
 @end
-


### PR DESCRIPTION
Services requiring an app secret won't start if none is provided on start.