### PR TITLE
Flush stored logs on channel init

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -43,6 +43,7 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
                                              configuration:configuration
                                          logsDispatchQueue:self.logsDispatchQueue];
     [channel addDelegate:(id<MSChannelDelegate>)self];
+    [channel flushQueue];
     [self.channels addObject:channel];
   }
   return channel;

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.h
@@ -28,6 +28,11 @@ NS_ASSUME_NONNULL_BEGIN
              logsDispatchQueue:(dispatch_queue_t)logsDispatchQueue;
 
 /**
+ * Flush pending logs.
+ */
+- (void)flushQueue;
+
+/**
  * Queue used to process logs.
  */
 @property(nonatomic) dispatch_queue_t logsDispatchQueue;

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -198,7 +198,7 @@
   dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC*1));
 }
 
-- (void)testDelegateIsAddedToAddedUnit {
+- (void)testChannelUnitIsCorrectlyInitialized {
 
   // If
   NSString *groupId = @"AppCenter";
@@ -212,9 +212,9 @@
   id channelUnitMock = OCMClassMock([MSChannelUnitDefault class]);
   OCMStub([channelUnitMock alloc]).andReturn(channelUnitMock);
   OCMStub([channelUnitMock initWithSender:OCMOCK_ANY
-                                       storage:OCMOCK_ANY
-                                 configuration:OCMOCK_ANY
-                             logsDispatchQueue:OCMOCK_ANY]).andReturn(channelUnitMock);
+                                  storage:OCMOCK_ANY
+                            configuration:OCMOCK_ANY
+                        logsDispatchQueue:OCMOCK_ANY]).andReturn(channelUnitMock);
 
   // When
   [sut addChannelUnitWithConfiguration:[[MSChannelUnitConfiguration alloc] initWithGroupId:groupId
@@ -225,6 +225,7 @@
 
   // Then
   OCMVerify([channelUnitMock addDelegate:sut]);
+  OCMVerify([channelUnitMock flushQueue]);
 
   // Clear
   [channelUnitMock stopMocking];


### PR DESCRIPTION
1. Enqueue the log without network;
2. Restart the application and enable network;
3. The log will not send until you don't enqueue another one to the same channel;