### PR TITLE
When a module is disabled, clear its logs.

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelDelegate.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelDelegate.h
@@ -41,11 +41,20 @@
 /**
  * A callback that is called when a log has been enqueued, before a log has been forwarded to persistence, etc.
  *
- * @param channel The channel
+ * @param channel The channel.
  * @param log The log.
  * @param internalId An internal Id that can be used to keep track of logs.
  */
 - (void)channel:(id<MSChannelUnitProtocol>)channel didEnqueueLog:(id<MSLog>)log withInternalId:(NSString *)internalId;
+
+/**
+ * A callback that is called when setEnabled has been invoked.
+ *
+ * @param channel The channel.
+ * @param isEnabled The boolean that indicates enabled.
+ * @param deletedData The boolean that indicates deleting data on disabled.
+ */
+- (void)channel:(id<MSChannelUnitProtocol>)channel didSetEnabled:(BOOL)isEnabled andDeleteDataOnDisabled:(BOOL)deletedData;
 
 /**
  * Callback method that will determine if a log should be filtered out from the

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -114,6 +114,15 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
                             }];
 }
 
+- (void)channel:(id<MSChannelUnitProtocol>)channel
+              didSetEnabled:(BOOL)isEnabled
+    andDeleteDataOnDisabled:(BOOL)deletedData {
+  [self enumerateDelegatesForSelector:@selector(channel:didSetEnabled:andDeleteDataOnDisabled:)
+                            withBlock:^(id<MSChannelDelegate> delegate) {
+                              [delegate channel:channel didSetEnabled:isEnabled andDeleteDataOnDisabled:deletedData];
+                            }];
+}
+
 - (void)onFinishedPersistingLog:(id<MSLog>)log withInternalId:(NSString *)internalId {
   [self enumerateDelegatesForSelector:@selector(onFinishedPersistingLog:withInternalId:)
                             withBlock:^(id<MSChannelDelegate> delegate) {

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -350,6 +350,11 @@
       // Allow logs to be persisted.
       self.discardLogs = NO;
     }
+
+    [self enumerateDelegatesForSelector:@selector(channel:didSetEnabled:andDeleteDataOnDisabled:)
+                              withBlock:^(id<MSChannelDelegate> delegate) {
+                                [delegate channel:self didSetEnabled:isEnabled andDeleteDataOnDisabled:deleteData];
+                              }];
   });
 }
 

--- a/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
@@ -41,6 +41,15 @@ static NSString *const kMSOneCollectorGroupIdSuffix = @"/one";
   (void)channel;
 }
 
+- (void)channel:(id<MSChannelUnitProtocol>)channel
+              didSetEnabled:(BOOL)isEnabled
+    andDeleteDataOnDisabled:(BOOL)deletedData {
+  NSString *groupId = channel.configuration.groupId;
+  if (![self isOneCollectorGroup:groupId]) {
+    [self.oneCollectorChannels[groupId] setEnabled:isEnabled andDeleteDataOnDisabled:deletedData];
+  }
+}
+
 - (BOOL)isOneCollectorGroup:(NSString *)groupId {
   return [groupId hasSuffix:kMSOneCollectorGroupIdSuffix];
 }

--- a/AppCenter/AppCenterTests/MSOneCollectorChannelDelegateTests.m
+++ b/AppCenter/AppCenterTests/MSOneCollectorChannelDelegateTests.m
@@ -3,11 +3,19 @@
 #import "MSChannelUnitDefault.h"
 #import "MSChannelGroupProtocol.h"
 #import "MSOneCollectorChannelDelegatePrivate.h"
+#import "MSStorage.h"
+#import "MSSender.h"
 #import "MSTestFrameworks.h"
+
+static NSString *const kMSBaseGroupId = @"baseGroupId";
 
 @interface MSOneCollectorChannelDelegateTests : XCTestCase
 
 @property(nonatomic) MSOneCollectorChannelDelegate *sut;
+@property(nonatomic) id<MSSender> senderMock;
+@property(nonatomic) id<MSStorage> storageMock;
+@property(nonatomic) dispatch_queue_t logsDispatchQueue;
+@property(nonatomic) MSChannelUnitConfiguration *baseUnitConfigMock;
 
 @end
 
@@ -16,22 +24,25 @@
 - (void)setUp {
   [super setUp];
   self.sut = [MSOneCollectorChannelDelegate new];
+  self.senderMock = OCMProtocolMock(@protocol(MSSender));
+  self.storageMock = OCMProtocolMock(@protocol(MSStorage));
+  self.logsDispatchQueue = dispatch_get_main_queue();
+  self.baseUnitConfigMock = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSBaseGroupId
+                                                                       priority:MSPriorityDefault
+                                                                  flushInterval:3.0
+                                                                 batchSizeLimit:1024
+                                                            pendingBatchesLimit:60];
 }
 
 - (void)testDidAddChannelUnitWithBaseGroupId {
 
-  // Test adding an base channel unit on MSChannelGroupDefault will also add a One Collector channel unit.
+  // Test adding a base channel unit on MSChannelGroupDefault will also add a One Collector channel unit.
 
   // If
   id<MSChannelUnitProtocol> channelUnitMock = OCMProtocolMock(@protocol(MSChannelUnitProtocol));
-  NSString *groupId = @"baseGroupId";
   NSString *expectedGroupId = @"baseGroupId/one";
-  MSChannelUnitConfiguration *unitConfig = [[MSChannelUnitConfiguration alloc] initWithGroupId:groupId
-                                                                                      priority:MSPriorityDefault
-                                                                                 flushInterval:3.0
-                                                                                batchSizeLimit:1024
-                                                                           pendingBatchesLimit:60];
-  OCMStub([channelUnitMock configuration]).andReturn(unitConfig);
+
+  OCMStub([channelUnitMock configuration]).andReturn(self.baseUnitConfigMock);
   id channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
   __block id<MSChannelUnitProtocol> expectedChannelUnitMock = OCMProtocolMock(@protocol(MSChannelUnitProtocol));
   __block MSChannelUnitConfiguration *oneCollectorChannelConfig = nil;
@@ -45,9 +56,9 @@
   [self.sut channelGroup:channelGroupMock didAddChannelUnit:channelUnitMock];
 
   // Then
-  XCTAssertNotNil(self.sut.oneCollectorChannels[groupId]);
+  XCTAssertNotNil(self.sut.oneCollectorChannels[kMSBaseGroupId]);
   XCTAssertTrue([self.sut.oneCollectorChannels count] == 1);
-  XCTAssertEqual(expectedChannelUnitMock, self.sut.oneCollectorChannels[groupId]);
+  XCTAssertEqual(expectedChannelUnitMock, self.sut.oneCollectorChannels[kMSBaseGroupId]);
   XCTAssertTrue([oneCollectorChannelConfig.groupId isEqualToString:expectedGroupId]);
   OCMVerifyAll(channelGroupMock);
 }
@@ -79,6 +90,88 @@
   XCTAssertNotNil(self.sut.oneCollectorChannels);
   XCTAssertTrue([self.sut.oneCollectorChannels count] == 0);
   OCMVerifyAll(channelGroupMock);
+}
+
+- (void)testDidSetEnabledAndDeleteDataOnDisabledWithBaseGroupId {
+
+  /*
+   * Test base channel unit's logs are cleared when the base channel unit is disabled.
+   * First, add a base channel unit to the channel group.
+   * Then, disable the base channel unit.
+   * Lastly, verify the storage deletion is called for the base channel group id.
+   */
+
+  // If
+  MSChannelUnitDefault *channelUnitMock = [[MSChannelUnitDefault alloc] initWithSender:self.senderMock
+                                                                               storage:self.storageMock
+                                                                         configuration:self.baseUnitConfigMock
+                                                                     logsDispatchQueue:self.logsDispatchQueue];
+  id channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
+  OCMStub([channelGroupMock addChannelUnitWithConfiguration:self.baseUnitConfigMock]);
+  OCMStub([channelUnitMock setEnabled:NO andDeleteDataOnDisabled:YES]);
+
+  // When
+  [self.sut channelGroup:channelGroupMock didAddChannelUnit:channelUnitMock];
+  [self.sut channel:channelUnitMock didSetEnabled:NO andDeleteDataOnDisabled:YES];
+
+  // Then
+  [self enqueueChannelEndJobExpectation];
+  [self waitForExpectationsWithTimeout:1
+                               handler:^(NSError *error) {
+                                 OCMVerify([self.storageMock deleteLogsWithGroupId:kMSBaseGroupId]);
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                               }];
+}
+
+- (void)testDidSetEnabledAndDeleteDataOnDisabledWithOneCollectorGroupId {
+
+  /*
+   * Test One Collector channel unit's logs are cleared when the One Collector channel unit is disabled.
+   * Disable One Collector channel unit.
+   * Verify the storage deletion is called for the One Collector channel group id.
+   */
+
+  // If
+  NSString *oneCollectorGroupId = @"baseGroupId/one";
+  MSChannelUnitConfiguration *oneCollectorUnitConfig =
+      [[MSChannelUnitConfiguration alloc] initWithGroupId:oneCollectorGroupId
+                                                 priority:MSPriorityDefault
+                                            flushInterval:3.0
+                                           batchSizeLimit:1024
+                                      pendingBatchesLimit:60];
+
+  MSChannelUnitDefault *oneCollectorChannelUnitMock =
+      [[MSChannelUnitDefault alloc] initWithSender:self.senderMock
+                                           storage:self.storageMock
+                                     configuration:oneCollectorUnitConfig
+                                 logsDispatchQueue:self.logsDispatchQueue];
+  id channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
+  OCMReject([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]);
+  OCMStub([oneCollectorChannelUnitMock setEnabled:NO andDeleteDataOnDisabled:YES]);
+
+  // When
+  [self.sut channel:oneCollectorChannelUnitMock didSetEnabled:NO andDeleteDataOnDisabled:YES];
+
+  // Then
+  XCTAssertTrue(self.sut.oneCollectorChannels.count == 0);
+  [self enqueueChannelEndJobExpectation];
+  [self waitForExpectationsWithTimeout:1
+                               handler:^(NSError *error) {
+                                 OCMVerify([self.storageMock deleteLogsWithGroupId:oneCollectorGroupId]);
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                               }];
+}
+
+// A helper method to initialize the test expectation
+- (void)enqueueChannelEndJobExpectation {
+  XCTestExpectation *channelEndJobExpectation = [self expectationWithDescription:@"Channel job should be finished"];
+  dispatch_async(self.logsDispatchQueue, ^{
+    [channelEndJobExpectation fulfill];
+  });
 }
 
 @end


### PR DESCRIPTION
 * Add a new delegate method called channel:didSetEnabled:andDeleteDataOnDisabled: in MSChannelDelegate
 * Add channel:didSetEnabled:andDeleteDataOnDisabled: in MSChannelGroupDefault
 * Invoke channel:didSetEnabled:andDeleteDataOnDisabled: at the end of method call setEnabled in MSChannelUnitDefault
 * Implement channel:didSetEnabled:andDeleteDataOnDisabled: in MSOneCollectorChannelDelegate
 * Add unit tests in MSOneCollectorChannelDelegateTests