### PR TITLE
Fix App Center validation

### DIFF
--- a/AppCenterAnalytics/AppCenterAnalytics/Internals/MSAnalytics+Validation.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/Internals/MSAnalytics+Validation.m
@@ -14,7 +14,7 @@ NSString *MSAnalyticsValidationCategory;
 
 @implementation MSAnalytics (Validation)
 
-- (BOOL)shouldFilterLog:(id<MSLog>)log {
+- (BOOL)channelUnit:(id<MSChannelUnitProtocol>)__unused channelUnit shouldFilterLog:(id<MSLog>)log {
   NSObject *logObject = (NSObject *)log;
   if ([logObject isKindOfClass:[MSEventLog class]]) {
     return ![self validateLog:(MSEventLog *)log];
@@ -25,14 +25,14 @@ NSString *MSAnalyticsValidationCategory;
 }
 
 - (BOOL)validateLog:(MSLogWithNameAndProperties *)log {
-  
+
   // Validate event name.
   NSString *validName = [self validateEventName:log.name forLogType:log.type];
   if (!validName) {
     return NO;
   }
   log.name = validName;
-  
+
   // Send only valid properties.
   log.properties = [self validateProperties:log.properties forLogName:log.name andType:log.type];
   return YES;
@@ -55,7 +55,7 @@ NSString *MSAnalyticsValidationCategory;
 - (NSDictionary<NSString *, NSString *> *)validateProperties:(NSDictionary<NSString *, NSString *> *)properties
                                                   forLogName:(NSString *)logName
                                                      andType:(NSString *)logType {
-  
+
   // Keeping this method body in MSAnalytics to use it in unit tests.
   return [MSUtility validateProperties:properties forLogName:logName type:logType];
 }

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
@@ -37,7 +37,7 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 
 @interface MSAnalytics ()
 
-- (void)shouldFilterLog:(id<MSLog>)log;
+- (BOOL)channelUnit:(id<MSChannelUnitProtocol>)channelUnit shouldFilterLog:(id<MSLog>)log;
 
 @end
 
@@ -221,11 +221,11 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 }
 
 - (void)testAnalyticsLogsVerificationIsCalled {
-  
+
   // If
   MSEventLog *eventLog = [MSEventLog new];
   eventLog.name = @"test";
-  eventLog.properties = @{ @"test": @"test" };
+  eventLog.properties = @{ @"test" : @"test" };
   MSPageLog *pageLog = [MSPageLog new];
   MSLogWithNameAndProperties *analyticsLog = [MSLogWithNameAndProperties new];
   id analyticsMock = OCMPartialMock([MSAnalytics sharedInstance]);
@@ -236,12 +236,12 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   OCMExpect([analyticsMock validateEventName:OCMOCK_ANY forLogType:@"page"]).andForwardToRealObject();
   OCMReject([analyticsMock validateProperties:OCMOCK_ANY forLogName:OCMOCK_ANY andType:@"page"]);
   OCMReject([analyticsMock validateLog:analyticsLog]);
-  
+
   // When
-  [[MSAnalytics sharedInstance] shouldFilterLog:eventLog];
-  [[MSAnalytics sharedInstance] shouldFilterLog:pageLog];
-  [[MSAnalytics sharedInstance] shouldFilterLog:analyticsLog];
-  
+  [[MSAnalytics sharedInstance] channelUnit:nil shouldFilterLog:eventLog];
+  [[MSAnalytics sharedInstance] channelUnit:nil shouldFilterLog:pageLog];
+  [[MSAnalytics sharedInstance] channelUnit:nil shouldFilterLog:analyticsLog];
+
   // Then
   OCMVerifyAll(analyticsMock);
 }
@@ -320,7 +320,7 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 
   // When
   OCMExpect([channelUnitMock enqueueItem:OCMOCK_ANY]);
-  
+
   // Will be validated in shouldFilterLog callback instead.
   OCMReject([analyticsMock validateEventName:OCMOCK_ANY forLogType:OCMOCK_ANY]);
   OCMReject([analyticsMock validateProperties:OCMOCK_ANY forLogName:OCMOCK_ANY andType:OCMOCK_ANY]);

--- a/TestApps/Sasquatch/Sasquatch/EventFilter/MSEventFilter.m
+++ b/TestApps/Sasquatch/Sasquatch/EventFilter/MSEventFilter.m
@@ -60,7 +60,7 @@ static NSString *const kMSEventTypeName = @"event";
 
 #pragma mark - MSChannelDelegate
 
-- (BOOL)shouldFilterLog:(id<MSLog>)log {
+- (BOOL)channelUnit:(id<MSChannelUnitProtocol>)__unused channelUnit shouldFilterLog:(id<MSLog>)log {
   if (![MSEventFilter isEnabled]) {
     return NO;
   }

--- a/TestApps/SasquatchMac/SasquatchMac/EventFilter/MSEventFilter.m
+++ b/TestApps/SasquatchMac/SasquatchMac/EventFilter/MSEventFilter.m
@@ -56,7 +56,7 @@ static NSString *const kMSEventTypeName = @"event";
 
 #pragma mark - MSChannelDelegate
 
-- (BOOL)shouldFilterLog:(id<MSLog>)log {
+- (BOOL)channelUnit:(id<MSChannelUnitProtocol>)__unused channelUnit shouldFilterLog:(id<MSLog>)log {
   if (![MSEventFilter isEnabled]) {
     return NO;
   }

--- a/TestApps/SasquatchTV/SasquatchTV/EventFilter/MSEventFilter.m
+++ b/TestApps/SasquatchTV/SasquatchTV/EventFilter/MSEventFilter.m
@@ -56,7 +56,7 @@ static NSString *const kMSEventTypeName = @"event";
 
 #pragma mark - MSChannelDelegate
 
-- (BOOL)shouldFilterLog:(id<MSLog>)log {
+- (BOOL)channelUnit:(id<MSChannelUnitProtocol>)__unused channelUnit shouldFilterLog:(id<MSLog>)log {
   if (![MSEventFilter isEnabled]) {
     return NO;
   }


### PR DESCRIPTION
App Center validation was ignored because delegate method got renamed at some point but analytics channel delegate wasn't updated.