### PR TITLE
Fix/transmission bugs

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.h
@@ -32,11 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)flushQueue;
 
 /**
- * Queue used to process logs.
- */
-@property(nonatomic) dispatch_queue_t logsDispatchQueue;
-
-/**
  * Hash table of channel delegate.
  */
 @property(nonatomic) NSHashTable<id<MSChannelDelegate>> *delegates;

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -11,6 +11,7 @@
 @implementation MSChannelUnitDefault
 
 @synthesize configuration = _configuration;
+@synthesize logsDispatchQueue = _logsDispatchQueue;
 
 #pragma mark - Initialization
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -133,12 +133,20 @@
     // If sender is nil, there is nothing to do at this point.
     if (shouldFilter) {
       MSLogDebug([MSAppCenter logTag], @"Log of type '%@' was filtered out by delegate(s)", item.type);
+      [self enumerateDelegatesForSelector:@selector(channel:didCompleteEnqueueingLog:withInternalId:)
+                                withBlock:^(id<MSChannelDelegate> delegate) {
+                                  [delegate channel:self didCompleteEnqueueingLog:item withInternalId:internalLogId];
+                                }];
       return;
     }
     if (!self.sender) {
       MSLogDebug([MSAppCenter logTag], @"Log of type '%@' was not filtered out by delegate(s) but no app secret was "
                                        @"provided. Not persisting/sending the log.",
                  item.type);
+      [self enumerateDelegatesForSelector:@selector(channel:didCompleteEnqueueingLog:withInternalId:)
+                                withBlock:^(id<MSChannelDelegate> delegate) {
+                                  [delegate channel:self didCompleteEnqueueingLog:item withInternalId:internalLogId];
+                                }];
       return;
     }
     if (self.discardLogs) {

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitProtocol.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitProtocol.h
@@ -20,6 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) MSChannelUnitConfiguration *configuration;
 
 /**
+ * Queue used to process logs.
+ */
+@property(nonatomic) dispatch_queue_t logsDispatchQueue;
+
+/**
  * Enqueues a new log item.
  *
  * @param item The log item that should be enqueued.

--- a/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
@@ -91,7 +91,9 @@ NSString *const kMSLogNameRegex = @"^[a-zA-Z0-9]((\\.(?!(\\.|$)))|[_a-zA-Z0-9]){
   id<MSLogConversion> logConversion = (id<MSLogConversion>)log;
   NSArray<MSCommonSchemaLog *> *commonSchemaLogs = [logConversion toCommonSchemaLogs];
   for (MSCommonSchemaLog *commonSchemaLog in commonSchemaLogs) {
-    [oneCollectorChannelUnit enqueueItem:commonSchemaLog];
+    dispatch_async(oneCollectorChannelUnit.logsDispatchQueue, ^{
+      [oneCollectorChannelUnit enqueueItem:commonSchemaLog];
+    });
   }
 }
 

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -777,8 +777,8 @@ static NSString *const kMSTestGroupId = @"GroupId";
   OCMExpect([delegateMock2 channel:sut prepareLog:log]);
   OCMExpect([delegateMock channel:sut didPrepareLog:log withInternalId:OCMOCK_ANY]);
   OCMExpect([delegateMock2 channel:sut didPrepareLog:log withInternalId:OCMOCK_ANY]);
-  OCMReject([delegateMock channel:sut didCompleteEnqueueingLog:log withInternalId:OCMOCK_ANY]);
-  OCMReject([delegateMock2 channel:sut didCompleteEnqueueingLog:log withInternalId:OCMOCK_ANY]);
+  OCMExpect([delegateMock channel:sut didCompleteEnqueueingLog:log withInternalId:OCMOCK_ANY]);
+  OCMExpect([delegateMock2 channel:sut didCompleteEnqueueingLog:log withInternalId:OCMOCK_ANY]);
   [sut addDelegate:delegateMock];
   [sut addDelegate:delegateMock2];
 

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -422,11 +422,11 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 
   // FIXME: Rejecting MSCommonSchemaLog in the buffer for now.
   /*
-   * Don't buffer logs that are MSCommonSchemaLogs or contain one or more transmissiontargetTokens for now. The reason
+   * Don't buffer logs that contain one or more transmissiontargetTokens for now. The reason
    * is that the crash buffer currently cannot handle MSCommonSchemaLogs. It needs significant work, e.g. for
    * encrypting/decrypting the target tokens. Putting this in a separate paragraph for visibility.
    */
-  if ([logObject isKindOfClass:[MSCommonSchemaLog class]] || log.transmissionTargetTokens) {
+  if (log.transmissionTargetTokens) {
     return;
   }
 

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -3,6 +3,7 @@
 #import "MSChannelGroupProtocol.h"
 #import "MSChannelUnitConfiguration.h"
 #import "MSChannelUnitProtocol.h"
+#import "MSConstants+Internal.h"
 #import "MSCrashesCXXExceptionWrapperException.h"
 #import "MSCrashesDelegate.h"
 #import "MSCrashesInternal.h"
@@ -18,7 +19,6 @@
 #import "MSUtility+File.h"
 #import "MSWrapperExceptionManagerInternal.h"
 #import "MSWrapperCrashesHelper.h"
-#import "MSConstants+Internal.h"
 
 /**
  * Service name for initialization.
@@ -417,6 +417,16 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
   NSObject *logObject = static_cast<NSObject *>(log);
   if (!log || ![self isEnabled] || [logObject isKindOfClass:[MSAppleErrorLog class]] ||
       [logObject isKindOfClass:[MSErrorAttachmentLog class]]) {
+    return;
+  }
+
+  // FIXME: Rejecting MSCommonSchemaLog in the buffer for now.
+  /*
+   * Don't buffer logs that are MSCommonSchemaLogs or contain one or more transmissiontargetTokens for now. The reason
+   * is that the crash buffer currently cannot handle MSCommonSchemaLogs. It needs significant work, e.g. for
+   * encrypting/decrypting the target tokens. Putting this in a separate paragraph for visibility.
+   */
+  if ([logObject isKindOfClass:[MSCommonSchemaLog class]] || log.transmissionTargetTokens) {
     return;
   }
 


### PR DESCRIPTION
- makes sure `channel:didCompleteEnqueueingLog:withInternalId` gets called even if a sender is nil or a log gets filtered. This makes sure events are removed from the logbuffer correctly
- Don't re-enqueue the CommonSchemaLog from the main thread but from a background thread to avoid blocking the UI thread*



* the side effect of this is that the logbuffer is less effective for common schema logs
