### PR TITLE
Fix .a files having MSCSModelConstants.o twice with a suffix

### DIFF
--- a/AppCenter/AppCenter.xcodeproj/project.pbxproj
+++ b/AppCenter/AppCenter.xcodeproj/project.pbxproj
@@ -2298,7 +2298,6 @@
 				B2CD74881F22BD910070E7DF /* MSLogDBStorage.m in Sources */,
 				E7D23C7720B6549E00A47D62 /* MSCSModelConstants.m in Sources */,
 				8087362920C134AC004C4157 /* MSEncrypter.m in Sources */,
-				E7D23C7720B6549E00A47D62 /* MSCSModelConstants.m in Sources */,
 				E84B8E361D235226006FD231 /* MSHttpSender.m in Sources */,
 				D38024061E7126F500466558 /* MSServiceAbstract.m in Sources */,
 				B2CD74C41F22BE270070E7DF /* MSUtility+StringFormatting.m in Sources */,


### PR DESCRIPTION
<img width="644" alt="screen shot 2018-06-14 at 5 20 44 pm" src="https://user-images.githubusercontent.com/623672/41445938-9a79ba9e-7001-11e8-9b01-7ca4a1a19e69.png">

Because the .m file was twice in the project, it generated 2 o files with a suffix causing xamarin to failed linking with duplicate objects.

With this fix, the numeric suffix is gone and there is only 1 .o file now.