### PR TITLE
Don’t use checkResourceIsReachableAndReturnError in unnecessary places

### DIFF
--- a/AppCenter/AppCenter/Internals/Util/MSUtility+File.m
+++ b/AppCenter/AppCenter/Internals/Util/MSUtility+File.m
@@ -31,7 +31,10 @@ static NSString *const kMSAppCenterBundleIdentifier = @"com.microsoft.appcenter"
 
       // Create parent directories as needed.
       NSURL *directoryURL = [fileURL URLByDeletingLastPathComponent];
-      [self createDirectoryAtURL:directoryURL];
+      BOOL success = [self createDirectoryAtURL:directoryURL];
+      if(!success) {
+        return nil;
+      }
 
       // Create the file.
       NSData *theData = (data != nil) ? data : [NSData data];
@@ -171,6 +174,10 @@ static NSString *const kMSAppCenterBundleIdentifier = @"com.microsoft.appcenter"
     dirURL = [baseDirUrl URLByAppendingPathComponent:kMSAppCenterBundleIdentifier];
 #endif
     [self createDirectoryAtURL:dirURL];
+    BOOL success = [self createDirectoryAtURL:dirURL];
+    if(!success) {
+      MSLogError([MSAppCenter logTag], @"Unable to create directory for AppCenter SDK.");
+    }
   });
 
   return dirURL;

--- a/AppCenter/AppCenter/Internals/Util/MSUtility+File.m
+++ b/AppCenter/AppCenter/Internals/Util/MSUtility+File.m
@@ -31,10 +31,7 @@ static NSString *const kMSAppCenterBundleIdentifier = @"com.microsoft.appcenter"
 
       // Create parent directories as needed.
       NSURL *directoryURL = [fileURL URLByDeletingLastPathComponent];
-      BOOL success = [self createDirectoryAtURL:directoryURL];
-      if(!success) {
-        return nil;
-      }
+      [self createDirectoryAtURL:directoryURL];
 
       // Create the file.
       NSData *theData = (data != nil) ? data : [NSData data];
@@ -174,10 +171,6 @@ static NSString *const kMSAppCenterBundleIdentifier = @"com.microsoft.appcenter"
     dirURL = [baseDirUrl URLByAppendingPathComponent:kMSAppCenterBundleIdentifier];
 #endif
     [self createDirectoryAtURL:dirURL];
-    BOOL success = [self createDirectoryAtURL:dirURL];
-    if(!success) {
-      MSLogError([MSAppCenter logTag], @"Unable to create directory for AppCenter SDK.");
-    }
   });
 
   return dirURL;


### PR DESCRIPTION
On testing, I found that MSUtility+File.m was polluting the console with log statements about failing to delete files.
My first approach was to just change the log level - most cases where deletion fails is about non-existing files in the first place.
So first, I revisited the logging statements in the class and changed a few from the error to the debug level. So far, so good.
Then I noticed that we're checking for file existence quite a lot. This is expensive (as it's synchronous) and not necessary, so I've changed that.