### PR TITLE
Rename internal configure: to configureWith: and remove a // FIXME

### DIFF
--- a/AppCenter/AppCenter/Internals/MSAppCenterPrivate.h
+++ b/AppCenter/AppCenter/Internals/MSAppCenterPrivate.h
@@ -19,7 +19,6 @@
  * @discussion This may be called only once per application process lifetime.
  * @param appSecret A unique and secret key used to identify the application.
  */
-// FIXME: Rename to configureWithAppSecret
-- (BOOL)configure:(NSString *)appSecret;
+- (BOOL)configureWithAppSecret:(NSString *)appSecret;
 
 @end

--- a/AppCenter/AppCenter/MSAppCenter.m
+++ b/AppCenter/AppCenter/MSAppCenter.m
@@ -59,7 +59,7 @@ static NSString *const kMSGroupId = @"AppCenter";
 #pragma mark - public
 
 + (void)configureWithAppSecret:(NSString *)appSecret {
-  [[self sharedInstance] configure:appSecret];
+  [[self sharedInstance] configureWithAppSecret:appSecret];
 }
 
 + (void)start:(NSString *)appSecret withServices:(NSArray<Class> *)services {
@@ -192,7 +192,7 @@ static NSString *const kMSGroupId = @"AppCenter";
  * Configuring without an app secret is valid. If that is the case, the app secret will
  * not be set.
  */
-- (BOOL)configure:(NSString *)appSecret {
+- (BOOL)configureWithAppSecret:(NSString *)appSecret {
   @synchronized(self) {
     BOOL success = false;
     if (self.sdkConfigured) {
@@ -235,7 +235,7 @@ static NSString *const kMSGroupId = @"AppCenter";
 
 - (void)start:(NSString *)appSecret withServices:(NSArray<Class> *)services {
   @synchronized(self) {
-    BOOL configured = [self configure:appSecret];
+    BOOL configured = [self configureWithAppSecret:appSecret];
     if (configured && services) {
       MSLogVerbose([MSAppCenter logTag], @"Prepare to start services: %@", [services componentsJoinedByString:@", "]);
       NSArray *sortedServices = [self sortServices:services];

--- a/AppCenter/AppCenterTests/MSAppCenterTests.m
+++ b/AppCenter/AppCenterTests/MSAppCenterTests.m
@@ -499,7 +499,7 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 
   // If
   id<MSChannelGroupProtocol> channelGroup = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
-  [self.sut configure:@"AnAppSecret"];
+  [self.sut configureWithAppSecret:@"AnAppSecret"];
   self.sut.channelGroup = channelGroup;
 
   // When
@@ -513,7 +513,7 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 
   // If
   id<MSChannelGroupProtocol> channelGroup = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
-  [self.sut configure:@"AnAppSecret"];
+  [self.sut configureWithAppSecret:@"AnAppSecret"];
   self.sut.channelGroup = channelGroup;
 
   // When


### PR DESCRIPTION
Fix Sasquatch Swift target token