### PR TITLE
Adds nested transmissionTargets feature

### DIFF
--- a/AppCenterAnalytics/AppCenterAnalytics.xcodeproj/project.pbxproj
+++ b/AppCenterAnalytics/AppCenterAnalytics.xcodeproj/project.pbxproj
@@ -171,6 +171,9 @@
 		38337D6F20C0AB0D00CEDA17 /* MSEventLogPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 38337D6E20C0AB0D00CEDA17 /* MSEventLogPrivate.h */; };
 		38337D7020C0AB0D00CEDA17 /* MSEventLogPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 38337D6E20C0AB0D00CEDA17 /* MSEventLogPrivate.h */; };
 		38337D7120C0AB0D00CEDA17 /* MSEventLogPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 38337D6E20C0AB0D00CEDA17 /* MSEventLogPrivate.h */; };
+		3855D51420E2F03000CBC499 /* MSAnalyticsTransmissionTargetPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 3855D51320E2F03000CBC499 /* MSAnalyticsTransmissionTargetPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3855D51520E2F03000CBC499 /* MSAnalyticsTransmissionTargetPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 3855D51320E2F03000CBC499 /* MSAnalyticsTransmissionTargetPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3855D51620E2F03000CBC499 /* MSAnalyticsTransmissionTargetPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 3855D51320E2F03000CBC499 /* MSAnalyticsTransmissionTargetPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		387C77051D6CC39400D68CC1 /* MSServiceAbstract.h in Headers */ = {isa = PBXBuildFile; fileRef = 387C77041D6CC39400D68CC1 /* MSServiceAbstract.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6E0684381D35A3B900A8CC6C /* OCHamcrestIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E0684371D35A3B900A8CC6C /* OCHamcrestIOS.framework */; };
 		6E3E2CCB1D359D5E00B1EE50 /* MSEventLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E3E2CC51D359D5E00B1EE50 /* MSEventLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -322,6 +325,7 @@
 		35BF19E41DF9D59E00193027 /* MSMockAnalyticsDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSMockAnalyticsDelegate.m; sourceTree = "<group>"; };
 		3813B9641DBFE68200831214 /* MSAnalyticsInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSAnalyticsInternal.h; sourceTree = "<group>"; };
 		38337D6E20C0AB0D00CEDA17 /* MSEventLogPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSEventLogPrivate.h; sourceTree = "<group>"; };
+		3855D51320E2F03000CBC499 /* MSAnalyticsTransmissionTargetPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSAnalyticsTransmissionTargetPrivate.h; sourceTree = "<group>"; };
 		387C77041D6CC39400D68CC1 /* MSServiceAbstract.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSServiceAbstract.h; path = ../AppCenter/AppCenter/MSServiceAbstract.h; sourceTree = "<group>"; };
 		6E0684371D35A3B900A8CC6C /* OCHamcrestIOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCHamcrestIOS.framework; path = ../../Vendor/iOS/OCHamcrest/OCHamcrestIOS.framework; sourceTree = "<group>"; };
 		6E3E2CC51D359D5E00B1EE50 /* MSEventLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSEventLog.h; sourceTree = "<group>"; };
@@ -602,6 +606,7 @@
 				E85547CE1D2D64F0002DF6E2 /* MSAnalyticsPrivate.h */,
 				3813B9641DBFE68200831214 /* MSAnalyticsInternal.h */,
 				35BF19E21DF9C43F00193027 /* MSAnalyticsDelegate.h */,
+				3855D51320E2F03000CBC499 /* MSAnalyticsTransmissionTargetPrivate.h */,
 				351343352057093600E6DC7D /* MSAnalyticsTransmissionTargetInternal.h */,
 				C27452D520AE0EF100B64B68 /* MSAnalytics+Validation.h */,
 				C27452D120AE0DAC00B64B68 /* MSAnalytics+Validation.m */,
@@ -679,6 +684,7 @@
 				043121601EE0C20A007054C5 /* MSServiceAbstract.h in Headers */,
 				043121621EE0C20A007054C5 /* MSAnalyticsInternal.h in Headers */,
 				043121631EE0C20A007054C5 /* MSAnalyticsPrivate.h in Headers */,
+				3855D51620E2F03000CBC499 /* MSAnalyticsTransmissionTargetPrivate.h in Headers */,
 				C27452D820AE0EF100B64B68 /* MSAnalytics+Validation.h in Headers */,
 				043121651EE0C20A007054C5 /* MSAnalytics.h in Headers */,
 				04A082071F74BB8C00DC776D /* MSService.h in Headers */,
@@ -707,6 +713,7 @@
 				351343452059DC0A00E6DC7D /* MSAnalyticsTransmissionTargetInternal.h in Headers */,
 				0485AF781EAA79E300C10CAF /* AppCenterAnalytics.h in Headers */,
 				0485AF7B1EAA79E300C10CAF /* MSAnalyticsInternal.h in Headers */,
+				3855D51520E2F03000CBC499 /* MSAnalyticsTransmissionTargetPrivate.h in Headers */,
 				C27452D720AE0EF100B64B68 /* MSAnalytics+Validation.h in Headers */,
 				0485AF7C1EAA79E300C10CAF /* MSAnalyticsPrivate.h in Headers */,
 				0485AF7E1EAA79E300C10CAF /* MSAnalytics.h in Headers */,
@@ -735,6 +742,7 @@
 				0485AF8F1EAA852A00C10CAF /* MSAnalyticsCategory.h in Headers */,
 				E85547F71D2D6A7D002DF6E2 /* AppCenterAnalytics.h in Headers */,
 				3813B9651DBFE68200831214 /* MSAnalyticsInternal.h in Headers */,
+				3855D51420E2F03000CBC499 /* MSAnalyticsTransmissionTargetPrivate.h in Headers */,
 				C27452D620AE0EF100B64B68 /* MSAnalytics+Validation.h in Headers */,
 				E85547FA1D2D6A9E002DF6E2 /* MSAnalyticsPrivate.h in Headers */,
 				E85547F81D2D6A7D002DF6E2 /* MSAnalytics.h in Headers */,

--- a/AppCenterAnalytics/AppCenterAnalytics/Internals/MSAnalyticsTransmissionTargetPrivate.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/Internals/MSAnalyticsTransmissionTargetPrivate.h
@@ -1,0 +1,16 @@
+#import <Foundation/Foundation.h>
+
+#import "MSAnalyticsTransmissionTarget.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSAnalyticsTransmissionTarget ()
+
+/**
+ * Child transmission targets nested to this transmission target.
+ */
+@property(nonatomic) NSMutableDictionary<NSString *, MSAnalyticsTransmissionTarget *> *childTransmissionTargets;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
@@ -1,6 +1,3 @@
-
-
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
@@ -1,3 +1,6 @@
+
+
+
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -18,6 +21,15 @@ NS_ASSUME_NONNULL_BEGIN
  * @param properties dictionary of properties.
  */
 - (void)trackEvent:(NSString *)eventName withProperties:(nullable NSDictionary<NSString *, NSString *> *)properties;
+
+/**
+ * Get a nested transmission target.
+ *
+ * @param token The token of the transmission target to retrieve.
+ *
+ * @returns A transmission target object nested to this parent transmission target.
+ */
+- (MSAnalyticsTransmissionTarget *)transmissionTargetForToken:(NSString *)token;
 
 @end
 

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
@@ -1,5 +1,5 @@
-#import "MSAnalyticsTransmissionTargetInternal.h"
 #import "MSAnalyticsInternal.h"
+#import "MSAnalyticsTransmissionTargetInternal.h"
 #import "MSAnalyticsTransmissionTargetPrivate.h"
 
 @implementation MSAnalyticsTransmissionTarget

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
@@ -34,12 +34,7 @@
 
 - (MSAnalyticsTransmissionTarget *)transmissionTargetForToken:(NSString *)token {
 
-  // Return this target when token is the same.
-  if ([token isEqualToString:self.transmissionTargetToken]) {
-    return self;
-  }
-
-  // Look up for the token in the dictionary, create one if doesn't exist.
+  // Look up for the token in the dictionary, create a new transmission target if doesn't exist.
   MSAnalyticsTransmissionTarget *target = self.childTransmissionTargets[token];
   if (!target) {
     target = [[MSAnalyticsTransmissionTarget alloc] initWithTransmissionTargetToken:token];

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
@@ -1,12 +1,14 @@
 #import "MSAnalyticsTransmissionTargetInternal.h"
 #import "MSAnalyticsInternal.h"
+#import "MSAnalyticsTransmissionTargetPrivate.h"
 
 @implementation MSAnalyticsTransmissionTarget
 
 - (instancetype)initWithTransmissionTargetToken:(NSString *)transmissionTargetToken {
   self = [super init];
   if (self) {
-    self.transmissionTargetToken = transmissionTargetToken;
+    _transmissionTargetToken = transmissionTargetToken;
+    _childTransmissionTargets = [NSMutableDictionary<NSString *, MSAnalyticsTransmissionTarget *> new];
   }
   return self;
 }
@@ -28,6 +30,22 @@
  */
 - (void)trackEvent:(NSString *)eventName withProperties:(nullable NSDictionary<NSString *, NSString *> *)properties {
   [MSAnalytics trackEvent:eventName withProperties:properties forTransmissionTarget:self];
+}
+
+- (MSAnalyticsTransmissionTarget *)transmissionTargetForToken:(NSString *)token {
+
+  // Return this target when token is the same.
+  if ([token isEqualToString:self.transmissionTargetToken]) {
+    return self;
+  }
+
+  // Look up for the token in the dictionary, create one if doesn't exist.
+  MSAnalyticsTransmissionTarget *target = self.childTransmissionTargets[token];
+  if (!target) {
+    target = [[MSAnalyticsTransmissionTarget alloc] initWithTransmissionTargetToken:token];
+    self.childTransmissionTargets[token] = target;
+  }
+  return target;
 }
 
 @end

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
@@ -59,12 +59,19 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
 - (void)testTransmissionTargetForToken {
 
   // If
+  OCMClassMock([MSAnalytics class]);
+  NSDictionary *properties = [NSDictionary new];
+  NSString *event1 = @"event1";
+  NSString *event2 = @"event2";
+  NSString *event3 = @"event3";
+
   MSAnalyticsTransmissionTarget *parentTransmissionTarget =
       [[MSAnalyticsTransmissionTarget alloc] initWithTransmissionTargetToken:kMSTestTransmissionToken];
   MSAnalyticsTransmissionTarget *childTransmissionTarget;
 
   // When
   childTransmissionTarget = [parentTransmissionTarget transmissionTargetForToken:kMSTestTransmissionToken2];
+  [childTransmissionTarget trackEvent:event1 withProperties:properties];
 
   // Then
   XCTAssertEqualObjects(kMSTestTransmissionToken2, childTransmissionTarget.transmissionTargetToken);
@@ -74,6 +81,7 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
   // When
   MSAnalyticsTransmissionTarget *childTransmissionTarget2 =
       [parentTransmissionTarget transmissionTargetForToken:kMSTestTransmissionToken2];
+  [childTransmissionTarget2 trackEvent:event2 withProperties:properties];
 
   // Then
   XCTAssertEqualObjects(childTransmissionTarget, childTransmissionTarget2);
@@ -81,12 +89,20 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
                         parentTransmissionTarget.childTransmissionTargets[kMSTestTransmissionToken2]);
 
   // When
-  childTransmissionTarget2 = [parentTransmissionTarget transmissionTargetForToken:kMSTestTransmissionToken];
+  MSAnalyticsTransmissionTarget *childTransmissionTarget3 =
+      [parentTransmissionTarget transmissionTargetForToken:kMSTestTransmissionToken];
+  [childTransmissionTarget3 trackEvent:event3 withProperties:properties];
 
   // Then
-  XCTAssertEqualObjects(parentTransmissionTarget, childTransmissionTarget2);
-  XCTAssertNil(parentTransmissionTarget.childTransmissionTargets[kMSTestTransmissionToken]);
+  XCTAssertNotEqualObjects(parentTransmissionTarget, childTransmissionTarget3);
+  XCTAssertEqualObjects(childTransmissionTarget3,
+                        parentTransmissionTarget.childTransmissionTargets[kMSTestTransmissionToken]);
+  OCMVerify(ClassMethod(
+      [MSAnalytics trackEvent:event1 withProperties:properties forTransmissionTarget:childTransmissionTarget]));
+  OCMVerify(ClassMethod(
+      [MSAnalytics trackEvent:event2 withProperties:properties forTransmissionTarget:childTransmissionTarget2]));
+  OCMVerify(ClassMethod(
+      [MSAnalytics trackEvent:event3 withProperties:properties forTransmissionTarget:childTransmissionTarget3]));
 }
 
 @end
-

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
@@ -1,5 +1,3 @@
-@import XCTest;
-
 #import "MSAnalyticsInternal.h"
 #import "MSAnalyticsTransmissionTargetInternal.h"
 #import "MSAnalyticsTransmissionTargetPrivate.h"

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
@@ -2,9 +2,11 @@
 
 #import "MSAnalyticsInternal.h"
 #import "MSAnalyticsTransmissionTargetInternal.h"
+#import "MSAnalyticsTransmissionTargetPrivate.h"
 #import "MSTestFrameworks.h"
 
 static NSString *const kMSTestTransmissionToken = @"TestTransmissionToken";
+static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
 
 @interface MSAnalyticsTransmissionTargetTests : XCTestCase
 @end
@@ -16,18 +18,20 @@ static NSString *const kMSTestTransmissionToken = @"TestTransmissionToken";
 - (void)testInitialization {
 
   // When
-  MSAnalyticsTransmissionTarget *transmissionTarget = [[MSAnalyticsTransmissionTarget alloc] initWithTransmissionTargetToken:kMSTestTransmissionToken];
+  MSAnalyticsTransmissionTarget *transmissionTarget =
+      [[MSAnalyticsTransmissionTarget alloc] initWithTransmissionTargetToken:kMSTestTransmissionToken];
 
   // Then
   XCTAssertNotNil(transmissionTarget);
-  XCTAssertEqual(kMSTestTransmissionToken, [transmissionTarget transmissionTargetToken]);
+  XCTAssertEqual(kMSTestTransmissionToken, transmissionTarget.transmissionTargetToken);
 }
 
 - (void)testTrackEvent {
 
   // If
   OCMClassMock([MSAnalytics class]);
-  MSAnalyticsTransmissionTarget *transmissionTarget = [[MSAnalyticsTransmissionTarget alloc] initWithTransmissionTargetToken:kMSTestTransmissionToken];
+  MSAnalyticsTransmissionTarget *transmissionTarget =
+      [[MSAnalyticsTransmissionTarget alloc] initWithTransmissionTargetToken:kMSTestTransmissionToken];
   NSString *eventName = @"event";
 
   // When
@@ -41,7 +45,8 @@ static NSString *const kMSTestTransmissionToken = @"TestTransmissionToken";
 
   // If
   OCMClassMock([MSAnalytics class]);
-  MSAnalyticsTransmissionTarget *transmissionTarget = [[MSAnalyticsTransmissionTarget alloc] initWithTransmissionTargetToken:kMSTestTransmissionToken];
+  MSAnalyticsTransmissionTarget *transmissionTarget =
+      [[MSAnalyticsTransmissionTarget alloc] initWithTransmissionTargetToken:kMSTestTransmissionToken];
   NSString *eventName = @"event";
   NSDictionary *properties = [NSDictionary new];
 
@@ -49,7 +54,40 @@ static NSString *const kMSTestTransmissionToken = @"TestTransmissionToken";
   [transmissionTarget trackEvent:eventName withProperties:properties];
 
   // Then
-  OCMVerify(ClassMethod([MSAnalytics trackEvent:eventName withProperties:properties forTransmissionTarget:transmissionTarget]));
+  OCMVerify(ClassMethod(
+      [MSAnalytics trackEvent:eventName withProperties:properties forTransmissionTarget:transmissionTarget]));
+}
+
+- (void)testTransmissionTargetForToken {
+
+  // If
+  MSAnalyticsTransmissionTarget *parentTransmissionTarget =
+      [[MSAnalyticsTransmissionTarget alloc] initWithTransmissionTargetToken:kMSTestTransmissionToken];
+  MSAnalyticsTransmissionTarget *childTransmissionTarget;
+
+  // When
+  childTransmissionTarget = [parentTransmissionTarget transmissionTargetForToken:kMSTestTransmissionToken2];
+
+  // Then
+  XCTAssertEqualObjects(kMSTestTransmissionToken2, childTransmissionTarget.transmissionTargetToken);
+  XCTAssertEqualObjects(childTransmissionTarget,
+                        parentTransmissionTarget.childTransmissionTargets[kMSTestTransmissionToken2]);
+
+  // When
+  MSAnalyticsTransmissionTarget *childTransmissionTarget2 =
+      [parentTransmissionTarget transmissionTargetForToken:kMSTestTransmissionToken2];
+
+  // Then
+  XCTAssertEqualObjects(childTransmissionTarget, childTransmissionTarget2);
+  XCTAssertEqualObjects(childTransmissionTarget2,
+                        parentTransmissionTarget.childTransmissionTargets[kMSTestTransmissionToken2]);
+
+  // When
+  childTransmissionTarget2 = [parentTransmissionTarget transmissionTargetForToken:kMSTestTransmissionToken];
+
+  // Then
+  XCTAssertEqualObjects(parentTransmissionTarget, childTransmissionTarget2);
+  XCTAssertNil(parentTransmissionTarget.childTransmissionTargets[kMSTestTransmissionToken]);
 }
 
 @end


### PR DESCRIPTION
Adds nested transmissionTargets feature. One can call the `transmissionTargetForToken:` method on a  transmission target to create a nested transmission target.