### PR TITLE
Feature/dont require appsecret in sender

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.h
@@ -44,6 +44,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy) NSMutableArray *channels;
 
+/**
+ * The app secret.
+ */
+@property(nonatomic, copy) NSString *appSecret;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -43,10 +43,9 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
   return self;
 }
 
-- (void)attachSenderWithAppSecret:(NSString *)appSecret installId:(NSUUID *)installId logUrl:(NSString *)logUrl {
+- (void)attachSenderWithInstallId:(NSUUID *)installId logUrl:(NSString *)logUrl {
   if (!self.sender) {
-    self.sender =
-        [[MSAppCenterIngestion alloc] initWithBaseUrl:logUrl appSecret:appSecret installId:[installId UUIDString]];
+    self.sender = [[MSAppCenterIngestion alloc] initWithBaseUrl:logUrl installId:[installId UUIDString]];
   }
 }
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -15,8 +15,6 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 
 @interface MSChannelGroupDefault () <MSChannelDelegate>
 
-@property(nonatomic, copy) NSString *appSecret;
-
 @end
 
 @implementation MSChannelGroupDefault

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -15,9 +15,13 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 
 @interface MSChannelGroupDefault () <MSChannelDelegate>
 
+@property(nonatomic, copy) NSString *appSecret;
+
 @end
 
 @implementation MSChannelGroupDefault
+
+@synthesize appSecret = _appSecret;
 
 #pragma mark - Initialization
 
@@ -58,6 +62,7 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
                                                    storage:self.storage
                                              configuration:configuration
                                          logsDispatchQueue:self.logsDispatchQueue];
+    [channel setAppSecret:self.appSecret];
     [channel addDelegate:self];
     dispatch_async(self.logsDispatchQueue, ^{
       [channel flushQueue];
@@ -69,6 +74,13 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
                               }];
   }
   return channel;
+}
+
+- (void)setAppSecret:(NSString *)appSecret {
+  _appSecret = appSecret;
+  for (id<MSChannelUnitProtocol> unit in self.channels) {
+    [unit setAppSecret:appSecret];
+  }
 }
 
 #pragma mark - Delegate

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupProtocol.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupProtocol.h
@@ -39,11 +39,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Attach an App Center sender to a channel group if a channel group started without an app secret.
  *
- * @param appSecret A unique and secret key used to identify the application.
  * @param installId A unique installation identifier.
  * @param logUrl A base URL to use for backend communication.
  */
-- (void)attachSenderWithAppSecret:(NSString *)appSecret installId:(NSUUID *)installId logUrl:(NSString *)logUrl;
+- (void)attachSenderWithInstallId:(NSUUID *)installId logUrl:(NSString *)logUrl;
 
 /**
  * Change the base URL (schema + authority + port only) used to communicate with the backend.

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelProtocol.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelProtocol.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)resume;
 
+- (void)setAppSecret:(NSString *)appSecret;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelProtocol.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelProtocol.h
@@ -37,6 +37,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)resume;
 
+/**
+ * Set the app secret.
+ *
+ * @param appSecret The app secret.
+ *
+ * @discussion The app secret should be a property on MSChannelProtocol with synthesize statements in
+ * MSDefaultChannelGroup and MSDefaultChannelUnit with MSDefaultChannelGroup having the custom setter (setAppSecret:).
+ * The problem is that the compiler somehow doesn't "understand" that setAppSecret: is a setter, and it throws a warning
+ * because we're accessing the ivar directly. This doesn't make any sense but we spent about 2hrs yesterday trying
+ * different solutions and this PR is what we came up with.
+ */
 - (void)setAppSecret:(NSString *)appSecret;
 
 @end

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelProtocol.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelProtocol.h
@@ -45,8 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion The app secret should be a property on MSChannelProtocol with synthesize statements in
  * MSDefaultChannelGroup and MSDefaultChannelUnit with MSDefaultChannelGroup having the custom setter (setAppSecret:).
  * The problem is that the compiler somehow doesn't "understand" that setAppSecret: is a setter, and it throws a warning
- * because we're accessing the ivar directly. This doesn't make any sense but we spent about 2hrs yesterday trying
- * different solutions and this PR is what we came up with.
+ * because we're accessing the ivar directly. 
  */
 - (void)setAppSecret:(NSString *)appSecret;
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.h
@@ -93,6 +93,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic) BOOL discardLogs;
 
+/**
+ * The app secret.
+ */
+@property(nonatomic, copy) NSString *appSecret;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -8,7 +8,7 @@
 #import "MSSender.h"
 #import "MSStorage.h"
 
-@interface MSChannelUnitDefault()
+@interface MSChannelUnitDefault ()
 
 @property(nonatomic, copy) NSString *appSecret;
 
@@ -259,6 +259,7 @@
 
                // Forward logs to the sender.
                [self.sender sendAsync:container
+                            appSecret:self.appSecret
                     completionHandler:^(NSString *senderBatchId, NSUInteger statusCode,
                                         __attribute__((unused)) NSData *data, NSError *error) {
                       dispatch_async(self.logsDispatchQueue, ^{

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -8,12 +8,6 @@
 #import "MSSender.h"
 #import "MSStorage.h"
 
-@interface MSChannelUnitDefault ()
-
-@property(nonatomic, copy) NSString *appSecret;
-
-@end
-
 @implementation MSChannelUnitDefault
 
 @synthesize configuration = _configuration;

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -8,6 +8,12 @@
 #import "MSSender.h"
 #import "MSStorage.h"
 
+@interface MSChannelUnitDefault()
+
+@property(nonatomic, copy) NSString *appSecret;
+
+@end
+
 @implementation MSChannelUnitDefault
 
 @synthesize configuration = _configuration;
@@ -48,6 +54,10 @@
     }
   }
   return self;
+}
+
+- (void)setAppSecret:(NSString *)appSecret {
+  _appSecret = appSecret;
 }
 
 #pragma mark - MSChannelDelegate

--- a/AppCenter/AppCenter/Internals/Sender/MSAppCenterIngestion.h
+++ b/AppCenter/AppCenter/Internals/Sender/MSAppCenterIngestion.h
@@ -10,12 +10,11 @@ NS_ASSUME_NONNULL_BEGIN
  * Initialize the Sender.
  *
  * @param baseUrl Base url.
- * @param appSecret A unique and secret key used to identify the application.
  * @param installId A unique installation identifier.
  *
  * @return A sender instance.
  */
-- (id)initWithBaseUrl:(NSString *)baseUrl appSecret:(NSString *)appSecret installId:(NSString *)installId;
+- (id)initWithBaseUrl:(NSString *)baseUrl installId:(NSString *)installId;
 
 @end
 

--- a/AppCenter/AppCenter/Internals/Sender/MSAppCenterIngestion.m
+++ b/AppCenter/AppCenter/Internals/Sender/MSAppCenterIngestion.m
@@ -13,12 +13,11 @@ static NSString *const kMSAPIVersion = @"1.0.0";
 static NSString *const kMSAPIVersionKey = @"api-version";
 static NSString *const kMSApiPath = @"/logs";
 
-- (id)initWithBaseUrl:(NSString *)baseUrl appSecret:(NSString *)appSecret installId:(NSString *)installId {
+- (id)initWithBaseUrl:(NSString *)baseUrl installId:(NSString *)installId {
   self = [super initWithBaseUrl:baseUrl
       apiPath:kMSApiPath
       headers:@{
         kMSHeaderContentTypeKey : kMSAppCenterContentType,
-        kMSHeaderAppSecretKey : appSecret,
         kMSHeaderInstallIDKey : installId
       }
       queryStrings:@{
@@ -29,7 +28,9 @@ static NSString *const kMSApiPath = @"/logs";
   return self;
 }
 
-- (void)sendAsync:(NSObject *)data completionHandler:(MSSendAsyncCompletionHandler)handler {
+- (void)sendAsync:(NSObject *)data
+            appSecret:(NSString *)appSecret
+    completionHandler:(MSSendAsyncCompletionHandler)handler {
   MSLogContainer *container = (MSLogContainer *)data;
   NSString *batchId = container.batchId;
 
@@ -48,10 +49,10 @@ static NSString *const kMSApiPath = @"/logs";
     return;
   }
 
-  [super sendAsync:container callId:container.batchId completionHandler:handler];
+  [super sendAsync:container appSecret:appSecret callId:container.batchId completionHandler:handler];
 }
 
-- (NSURLRequest *)createRequest:(NSObject *)data {
+- (NSURLRequest *)createRequest:(NSObject *)data appSecret:(NSString *)appSecret {
   MSLogContainer *container = (MSLogContainer *)data;
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.sendURL];
 
@@ -60,6 +61,7 @@ static NSString *const kMSApiPath = @"/logs";
 
   // Set Header params.
   request.allHTTPHeaderFields = self.httpHeaders;
+  [request setValue:appSecret forHTTPHeaderField:kMSHeaderAppSecretKey];
 
   // Set body.
   NSString *jsonString = [container serializeLog];

--- a/AppCenter/AppCenter/Internals/Sender/MSHttpSender.h
+++ b/AppCenter/AppCenter/Internals/Sender/MSHttpSender.h
@@ -17,12 +17,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy) NSString *apiPath;
 
 /**
- *	Send Url.
+ *  Send Url.
  */
 @property(nonatomic) NSURL *sendURL;
 
 /**
- *	Request header parameters.
+ *  Request header parameters.
  */
 @property(nonatomic) NSDictionary *httpHeaders;
 
@@ -34,10 +34,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Send data to backend
  * @param data A data instance that will be transformed request body.
+ * @param appSecret The appSecret.
  * @param callId A unique ID that identify a request.
  * @param handler Completion handler
  */
-- (void)sendAsync:(NSObject *)data callId:(NSString *)callId completionHandler:(MSSendAsyncCompletionHandler)handler;
+- (void)sendAsync:(NSObject *)data
+            appSecret:(NSString *)appSecret
+               callId:(NSString *)callId
+    completionHandler:(MSSendAsyncCompletionHandler)handler;
 
 @end
 

--- a/AppCenter/AppCenter/Internals/Sender/MSHttpSender.h
+++ b/AppCenter/AppCenter/Internals/Sender/MSHttpSender.h
@@ -17,17 +17,17 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy) NSString *apiPath;
 
 /**
- *  Send Url.
+ * Send Url.
  */
 @property(nonatomic) NSURL *sendURL;
 
 /**
- *  Request header parameters.
+ * Request header parameters.
  */
 @property(nonatomic) NSDictionary *httpHeaders;
 
 /**
- *  Pending http calls.
+ * Pending http calls.
  */
 @property NSMutableDictionary<NSString *, MSSenderCall *> *pendingCalls;
 

--- a/AppCenter/AppCenter/Internals/Sender/MSHttpSender.m
+++ b/AppCenter/AppCenter/Internals/Sender/MSHttpSender.m
@@ -369,9 +369,7 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
 /**
  * This is an empty method and expect to be overridden in sub classes.
  */
-- (NSURLRequest *)createRequest:(NSObject *)data appSecret:(NSString *)appSecret {
-  (void)data;
-  (void)appSecret;
+- (NSURLRequest *)createRequest:(NSObject *)__unused data appSecret:(NSString *)__unused appSecret {
   return nil;
 }
 

--- a/AppCenter/AppCenter/Internals/Sender/MSHttpSender.m
+++ b/AppCenter/AppCenter/Internals/Sender/MSHttpSender.m
@@ -24,16 +24,22 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
          queryStrings:(NSDictionary *)queryStrings
          reachability:(MS_Reachability *)reachability
        retryIntervals:(NSArray *)retryIntervals {
-  return [self initWithBaseUrl:baseUrl apiPath:apiPath headers:headers queryStrings:queryStrings reachability:reachability retryIntervals:retryIntervals maxNumberOfConnections:4];
+  return [self initWithBaseUrl:baseUrl
+                       apiPath:apiPath
+                       headers:headers
+                  queryStrings:queryStrings
+                  reachability:reachability
+                retryIntervals:retryIntervals
+        maxNumberOfConnections:4];
 }
 
 - (id)initWithBaseUrl:(NSString *)baseUrl
-              apiPath:(NSString *)apiPath
-              headers:(NSDictionary *)headers
-         queryStrings:(NSDictionary *)queryStrings
-         reachability:(MS_Reachability *)reachability
-       retryIntervals:(NSArray *)retryIntervals
-maxNumberOfConnections:(NSInteger)maxNumberOfConnections {
+                   apiPath:(NSString *)apiPath
+                   headers:(NSDictionary *)headers
+              queryStrings:(NSDictionary *)queryStrings
+              reachability:(MS_Reachability *)reachability
+            retryIntervals:(NSArray *)retryIntervals
+    maxNumberOfConnections:(NSInteger)maxNumberOfConnections {
   if ((self = [super init])) {
     _httpHeaders = headers;
     _pendingCalls = [NSMutableDictionary new];
@@ -81,8 +87,10 @@ maxNumberOfConnections:(NSInteger)maxNumberOfConnections {
 
 #pragma mark - MSSender
 
-- (void)sendAsync:(NSObject *)data completionHandler:(MSSendAsyncCompletionHandler)handler {
-  [self sendAsync:data callId:MS_UUID_STRING completionHandler:handler];
+- (void)sendAsync:(NSObject *)data
+            appSecret:(NSString *)appSecret
+    completionHandler:(MSSendAsyncCompletionHandler)handler {
+  [self sendAsync:data appSecret:(NSString *)appSecret callId:MS_UUID_STRING completionHandler:handler];
 }
 
 - (void)addDelegate:(id<MSSenderDelegate>)delegate {
@@ -208,13 +216,12 @@ maxNumberOfConnections:(NSInteger)maxNumberOfConnections {
     if (self.suspended || !self.enabled) {
       return;
     }
-
     if (!call) {
       return;
     }
 
     // Create the request.
-    NSURLRequest *request = [self createRequest:call.data];
+    NSURLRequest *request = [self createRequest:call.data appSecret:call.appSecret];
     if (!request) {
       return;
     }
@@ -362,8 +369,9 @@ maxNumberOfConnections:(NSInteger)maxNumberOfConnections {
 /**
  * This is an empty method and expect to be overridden in sub classes.
  */
-- (NSURLRequest *)createRequest:(NSObject *)data {
+- (NSURLRequest *)createRequest:(NSObject *)data appSecret:(NSString *)appSecret {
   (void)data;
+  (void)appSecret;
   return nil;
 }
 
@@ -407,7 +415,10 @@ maxNumberOfConnections:(NSInteger)maxNumberOfConnections {
   return [flattenedHeaders componentsJoinedByString:@", "];
 }
 
-- (void)sendAsync:(NSObject *)data callId:(NSString *)callId completionHandler:(MSSendAsyncCompletionHandler)handler {
+- (void)sendAsync:(NSObject *)data
+            appSecret:(NSString *)appSecret
+               callId:(NSString *)callId
+    completionHandler:(MSSendAsyncCompletionHandler)handler {
   @synchronized(self) {
 
     // Check if call has already been created(retry scenario).
@@ -416,6 +427,7 @@ maxNumberOfConnections:(NSInteger)maxNumberOfConnections {
       call = [[MSSenderCall alloc] initWithRetryIntervals:self.callsRetryIntervals];
       call.delegate = self;
       call.data = data;
+      call.appSecret = appSecret;
       call.callId = callId;
       call.completionHandler = handler;
 

--- a/AppCenter/AppCenter/Internals/Sender/MSHttpSenderPrivate.h
+++ b/AppCenter/AppCenter/Internals/Sender/MSHttpSenderPrivate.h
@@ -69,8 +69,10 @@
 
 /**
  * Create a request based on data. Must override this method in sub classes.
+ *
  * @param data A data instance that will be transformed to request body.
  * @param appSecret The app secret.
+ *
  * @return A URL request.
  */
 - (NSURLRequest *)createRequest:(NSObject *)data appSecret:(NSString *)appSecret;

--- a/AppCenter/AppCenter/Internals/Sender/MSHttpSenderPrivate.h
+++ b/AppCenter/AppCenter/Internals/Sender/MSHttpSenderPrivate.h
@@ -70,9 +70,10 @@
 /**
  * Create a request based on data. Must override this method in sub classes.
  * @param data A data instance that will be transformed to request body.
+ * @param appSecret The app secret.
  * @return A URL request.
  */
-- (NSURLRequest *)createRequest:(NSObject *)data;
+- (NSURLRequest *)createRequest:(NSObject *)data appSecret:(NSString *)appSecret;
 
 /**
  * Convert key/value pairs for headers to a string.

--- a/AppCenter/AppCenter/Internals/Sender/MSOneCollectorIngestion.m
+++ b/AppCenter/AppCenter/Internals/Sender/MSOneCollectorIngestion.m
@@ -35,7 +35,9 @@ NSString *const kMSOneCollectorUploadTimeKey = @"Upload-Time";
   return self;
 }
 
-- (void)sendAsync:(NSObject *)data completionHandler:(MSSendAsyncCompletionHandler)handler {
+- (void)sendAsync:(NSObject *)data
+            appSecret:(NSString *)appSecret
+    completionHandler:(MSSendAsyncCompletionHandler)handler {
   MSLogContainer *container = (MSLogContainer *)data;
   NSString *batchId = container.batchId;
 
@@ -53,10 +55,11 @@ NSString *const kMSOneCollectorUploadTimeKey = @"Upload-Time";
     handler(batchId, 0, nil, error);
     return;
   }
-  [super sendAsync:container callId:container.batchId completionHandler:handler];
+  [super sendAsync:container appSecret:appSecret callId:container.batchId completionHandler:handler];
 }
 
-- (NSURLRequest *)createRequest:(NSObject *)data {
+- (NSURLRequest *)createRequest:(NSObject *)data appSecret:(NSString *)appSecret {
+  (void)appSecret;
   MSLogContainer *container = (MSLogContainer *)data;
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.sendURL];
 

--- a/AppCenter/AppCenter/Internals/Sender/MSOneCollectorIngestion.m
+++ b/AppCenter/AppCenter/Internals/Sender/MSOneCollectorIngestion.m
@@ -58,8 +58,7 @@ NSString *const kMSOneCollectorUploadTimeKey = @"Upload-Time";
   [super sendAsync:container appSecret:appSecret callId:container.batchId completionHandler:handler];
 }
 
-- (NSURLRequest *)createRequest:(NSObject *)data appSecret:(NSString *)appSecret {
-  (void)appSecret;
+- (NSURLRequest *)createRequest:(NSObject *)data appSecret:(NSString *)__unused appSecret {
   MSLogContainer *container = (MSLogContainer *)data;
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.sendURL];
 

--- a/AppCenter/AppCenter/Internals/Sender/MSSender.h
+++ b/AppCenter/AppCenter/Internals/Sender/MSSender.h
@@ -25,9 +25,10 @@ NS_ASSUME_NONNULL_BEGIN
  * Send data.
  *
  * @param data Instance that will be transformed to request body.
+ * @param appSecret The app secret.
  * @param handler Completion handler.
  */
-- (void)sendAsync:(nullable NSObject *)data completionHandler:(MSSendAsyncCompletionHandler)handler;
+- (void)sendAsync:(nullable NSObject *)data appSecret:(NSString *)appSecret completionHandler:(MSSendAsyncCompletionHandler)handler;
 
 /**
  *  Add the given delegate to the sender.

--- a/AppCenter/AppCenter/Internals/Sender/MSSender.h
+++ b/AppCenter/AppCenter/Internals/Sender/MSSender.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param appSecret The app secret.
  * @param handler Completion handler.
  */
-- (void)sendAsync:(nullable NSObject *)data appSecret:(NSString *)appSecret completionHandler:(MSSendAsyncCompletionHandler)handler;
+- (void)sendAsync:(nullable NSObject *)data appSecret:(nullable NSString *)appSecret completionHandler:(MSSendAsyncCompletionHandler)handler;
 
 /**
  *  Add the given delegate to the sender.

--- a/AppCenter/AppCenter/Internals/Sender/MSSenderCall.h
+++ b/AppCenter/AppCenter/Internals/Sender/MSSenderCall.h
@@ -22,9 +22,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) NSObject *data;
 
 /**
+ * The app secret.
+ */
+@property(nonatomic, copy) NSString *appSecret;
+
+/**
  * Unique call ID.
  */
-@property(nonatomic) NSString *callId;
+@property(nonatomic, copy) NSString *callId;
 
 /**
  *  Call completion handler used for communicating with calling component.

--- a/AppCenter/AppCenter/MSAppCenter.m
+++ b/AppCenter/AppCenter/MSAppCenter.m
@@ -419,7 +419,7 @@ static NSString *const kMSGroupId = @"AppCenter";
   self.channelGroup = [MSChannelGroupDefault new];
   if (self.appSecret) {
     [self.channelGroup setAppSecret:self.appSecret];
-    [self.channelGroup attachSenderWithAppSecret:self.appSecret installId:self.installId logUrl:self.logUrl];
+    [self.channelGroup attachSenderWithInstallId:self.installId logUrl:self.logUrl];
   }
   self.oneCollectorChannelDelegate = [[MSOneCollectorChannelDelegate alloc] initWithInstallId:self.installId];
   [self.channelGroup addDelegate:self.oneCollectorChannelDelegate];

--- a/AppCenter/AppCenter/MSAppCenter.m
+++ b/AppCenter/AppCenter/MSAppCenter.m
@@ -418,6 +418,7 @@ static NSString *const kMSGroupId = @"AppCenter";
   // Construct channel group.
   self.channelGroup = [MSChannelGroupDefault new];
   if (self.appSecret) {
+    [self.channelGroup setAppSecret:self.appSecret];
     [self.channelGroup attachSenderWithAppSecret:self.appSecret installId:self.installId logUrl:self.logUrl];
   }
   self.oneCollectorChannelDelegate = [[MSOneCollectorChannelDelegate alloc] initWithInstallId:self.installId];

--- a/AppCenter/AppCenterTests/MSAbstractLogTests.m
+++ b/AppCenter/AppCenterTests/MSAbstractLogTests.m
@@ -211,7 +211,7 @@
   
   // IF
   NSArray *expectedIKeys = @[@"o:iKey1", @"o:iKey2"];
-  self.sut.transmissionTargetTokens = @[@"iKey1-dummytoken", @"iKey2-dummytoken"];
+  self.sut.transmissionTargetTokens = [NSSet setWithArray:@[@"iKey1-dummytoken", @"iKey2-dummytoken"]];
   // When
   csLogs = [self.sut toCommonSchemaLogs];
   

--- a/AppCenter/AppCenterTests/MSAppCenterIngestionTests.m
+++ b/AppCenter/AppCenterTests/MSAppCenterIngestionTests.m
@@ -12,6 +12,7 @@
 
 static NSTimeInterval const kMSTestTimeout = 5.0;
 static NSString *const kMSBaseUrl = @"https://test.com";
+static NSString *const kMSTestAppSecret = @"TestAppSecret";
 
 @interface MSAppCenterIngestionTests : XCTestCase
 
@@ -30,11 +31,10 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 - (void)setUp {
   [super setUp];
 
-  NSDictionary *headers = @{
-    @"Content-Type" : @"application/json",
-    @"App-Secret" : @"myUnitTestAppSecret",
-    @"Install-ID" : MS_UUID_STRING
-  };
+  NSDictionary *headers =
+      @{ @"Content-Type" : @"application/json",
+         @"App-Secret" : kMSTestAppSecret,
+         @"Install-ID" : MS_UUID_STRING };
 
   NSDictionary *queryStrings = @{ @"api-version" : @"1.0.0" };
 
@@ -73,9 +73,9 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   [MSHttpTestUtil stubHttp200Response];
   NSString *containerId = @"1";
   MSLogContainer *container = [self createLogContainerWithId:containerId];
-
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"HTTP Response 200"];
   [self.sut sendAsync:container
+              appSecret:kMSTestAppSecret
       completionHandler:^(NSString *batchId, NSUInteger statusCode, __attribute__((unused)) NSData *data,
                           NSError *error) {
 
@@ -107,6 +107,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
   // When
   [self.sut sendAsync:container
+              appSecret:kMSTestAppSecret
       completionHandler:^(NSString *batchId, NSUInteger statusCode, __attribute__((unused)) NSData *data,
                           NSError *error) {
 
@@ -155,7 +156,8 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
   // When
   [self.sut sendAsync:container
-      completionHandler:^(__attribute__((unused)) NSString *batchId, __attribute__((unused)) NSUInteger statusCode,
+            appSecret:kMSTestAppSecret
+    completionHandler:^(__attribute__((unused)) NSString *batchId, __attribute__((unused)) NSUInteger statusCode,
                           __attribute__((unused)) NSData *data, __attribute__((unused)) NSError *error) {
 
         // This should not be happening.
@@ -194,6 +196,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
     // Send one batch now that the sender is suspended.
     [self.sut sendAsync:container
+              appSecret:kMSTestAppSecret
         completionHandler:^(__attribute__((unused)) NSString *batchId, NSUInteger statusCode,
                             __attribute__((unused)) NSData *data, NSError *error) {
           forwardedStatus = statusCode;
@@ -243,6 +246,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   // Send logs
   for (NSUInteger i = 0; i < [containers count]; i++) {
     [self.sut sendAsync:containers[i]
+              appSecret:kMSTestAppSecret
         completionHandler:^(__attribute__((unused)) NSString *batchId, __attribute__((unused)) NSUInteger statusCode,
                             __attribute__((unused)) NSData *data, __attribute__((unused)) NSError *error) {
           @synchronized(tasks) {
@@ -306,6 +310,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   // Send logs
   for (NSUInteger i = 0; i < [containers count]; i++) {
     [self.sut sendAsync:containers[i]
+              appSecret:kMSTestAppSecret
         completionHandler:^(__attribute__((unused)) NSString *batchId, __attribute__((unused)) NSUInteger statusCode,
                             __attribute__((unused)) NSData *data, __attribute__((unused)) NSError *error) {
           @synchronized(tasks) {
@@ -488,6 +493,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   MSLogContainer *container = [[MSLogContainer alloc] initWithBatchId:@"1" andLogs:(NSArray<id<MSLog>> *)@[ log ]];
 
   [self.sut sendAsync:container
+            appSecret:kMSTestAppSecret
       completionHandler:^(__attribute__((unused)) NSString *batchId, __attribute__((unused)) NSUInteger statusCode,
                           __attribute__((unused)) NSData *data, NSError *error) {
 
@@ -504,6 +510,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"HTTP Network Down"];
   [self.sut sendAsync:container
+            appSecret:kMSTestAppSecret
       completionHandler:^(__attribute__((unused)) NSString *batchId, __attribute__((unused)) NSUInteger statusCode,
                           __attribute__((unused)) NSData *data, NSError *error) {
 
@@ -699,7 +706,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   NSData *httpBody = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
 
   // When
-  NSURLRequest *request = [self.sut createRequest:logContainer];
+  NSURLRequest *request = [self.sut createRequest:logContainer appSecret:kMSTestAppSecret];
 
   // Then
   XCTAssertEqualObjects(request.HTTPBody, httpBody);
@@ -713,7 +720,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   httpBody = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
 
   // When
-  request = [self.sut createRequest:logContainer];
+  request = [self.sut createRequest:logContainer appSecret:kMSTestAppSecret];
 
   // Then
   XCTAssertTrue(request.HTTPBody.length < httpBody.length);

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -31,6 +31,25 @@
   assertThat(sut.channels, isEmpty());
   assertThat(sut.sender, equalTo(senderMock));
   assertThat(sut.storage, notNilValue());
+  assertThat(sut.appSecret, nilValue());
+}
+
+- (void)testSetAppSecret {
+  
+  // If
+  id senderMock = OCMProtocolMock(@protocol(MSSender));
+  
+  // When
+  MSChannelGroupDefault *sut = [[MSChannelGroupDefault alloc] initWithSender:senderMock];
+  
+  // Then
+  assertThat(sut.appSecret, nilValue());
+  
+  // When
+  sut.appSecret = @"TestAppSecret";
+  
+  // Then
+  XCTAssertEqual(sut.appSecret, @"TestAppSecret");
 }
 
 - (void)testAddNewChannel {

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -90,7 +90,7 @@
   MSChannelGroupDefault *sut = [[MSChannelGroupDefault alloc] initWithSender:senderMock];
 
   // When
-  MSChannelUnitDefault *channelUnit = [sut addChannelUnitWithConfiguration:[MSChannelUnitConfiguration new]];
+  MSChannelUnitDefault *channelUnit = (MSChannelUnitDefault *)[sut addChannelUnitWithConfiguration:[MSChannelUnitConfiguration new]];
 
   // Then
   XCTAssertEqual(senderMock, channelUnit.sender);
@@ -105,7 +105,7 @@
 
   // When
   MSChannelUnitDefault *channelUnit =
-      [sut addChannelUnitWithConfiguration:[MSChannelUnitConfiguration new] withSender:senderMockCustom];
+      (MSChannelUnitDefault *)[sut addChannelUnitWithConfiguration:[MSChannelUnitConfiguration new] withSender:senderMockCustom];
 
   // Then
   XCTAssertNotEqual(senderMockDefault, channelUnit.sender);
@@ -226,7 +226,7 @@
                 });
 
   // Then
-  OCMVerify([channelUnitMock addDelegate:sut]);
+  OCMVerify([channelUnitMock addDelegate:(id<MSChannelDelegate>)sut]);
   OCMVerify([channelUnitMock flushQueue]);
 
   // Clear

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -69,8 +69,23 @@ static NSString *const kMSTestGroupId = @"GroupId";
   assertThat(self.sut.configuration, equalTo(self.configMock));
   assertThat(self.sut.sender, equalTo(self.senderMock));
   assertThat(self.sut.storage, equalTo(self.storageMock));
+  assertThat(self.sut.appSecret, nilValue());
   assertThatUnsignedLong(self.sut.itemsCount, equalToInt(0));
   OCMVerify([self.senderMock addDelegate:self.sut]);
+}
+
+- (void)testSetAppSecret {
+
+  // When new MSChannelUnitDefault
+  
+  // Then
+  assertThat(self.sut.appSecret, nilValue());
+  
+  // When
+  self.sut.appSecret = @"TestAppSecret";
+  
+  // Then
+  XCTAssertEqual(self.sut.appSecret, @"TestAppSecret");
 }
 
 - (void)testLogsSentWithSuccess {

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -88,11 +88,11 @@ static NSString *const kMSTestGroupId = @"GroupId";
   // Init mocks.
   id<MSLog> enqueuedLog = [self getValidMockLog];
   id senderMock = OCMProtocolMock(@protocol(MSSender));
-  OCMStub([senderMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+  OCMStub([senderMock sendAsync:OCMOCK_ANY appSecret:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
 
     // Get sender bloc for later call.
     [invocation retainArguments];
-    [invocation getArgument:&senderBlock atIndex:3];
+    [invocation getArgument:&senderBlock atIndex:4];
     [invocation getArgument:&logContainer atIndex:2];
   });
 
@@ -121,6 +121,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                                                    storage:storageMock
                                                              configuration:config
                                                          logsDispatchQueue:dispatch_get_main_queue()];
+  [sut setAppSecret:@"TestAppSecret"];
   [sut addDelegate:delegateMock];
   OCMReject([delegateMock channel:sut didFailSendingLog:OCMOCK_ANY withError:OCMOCK_ANY]);
   OCMExpect([delegateMock channel:sut didSucceedSendingLog:expectedLog]);
@@ -181,11 +182,11 @@ static NSString *const kMSTestGroupId = @"GroupId";
   // Init mocks.
   id<MSLog> enqueuedLog = [self getValidMockLog];
   id senderMock = OCMProtocolMock(@protocol(MSSender));
-  OCMStub([senderMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+  OCMStub([senderMock sendAsync:OCMOCK_ANY appSecret:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
 
     // Get sender bloc for later call.
     [invocation retainArguments];
-    [invocation getArgument:&senderBlock atIndex:3];
+    [invocation getArgument:&senderBlock atIndex:4];
     [invocation getArgument:&logContainer atIndex:2];
   });
 
@@ -213,6 +214,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                                                    storage:storageMock
                                                              configuration:config
                                                          logsDispatchQueue:dispatch_get_main_queue()];
+  [sut setAppSecret:@"TestAppSecret"];
   [sut addDelegate:delegateMock];
   OCMExpect([delegateMock channel:sut didFailSendingLog:expectedLog withError:OCMOCK_ANY]);
   OCMReject([delegateMock channel:sut didSucceedSendingLog:OCMOCK_ANY]);
@@ -338,7 +340,8 @@ static NSString *const kMSTestGroupId = @"GroupId";
 
   // Set up mock and stubs.
   id senderMock = OCMProtocolMock(@protocol(MSSender));
-  OCMStub([senderMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+  OCMStub([senderMock sendAsync:OCMOCK_ANY appSecret:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+    
     MSLogContainer *container;
     [invocation getArgument:&container atIndex:2];
     if (container) {
@@ -364,6 +367,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                                                    storage:storageMock
                                                              configuration:config
                                                          logsDispatchQueue:self.logsDispatchQueue];
+  [self.sut setAppSecret:@"TestAppSecret"];
 
   // When
   for (NSUInteger i = 1; i <= expectedMaxPendingBatched + 1; i++) {
@@ -399,11 +403,11 @@ static NSString *const kMSTestGroupId = @"GroupId";
 
   // Init mocks.
   id senderMock = OCMProtocolMock(@protocol(MSSender));
-  OCMStub([senderMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+  OCMStub([senderMock sendAsync:OCMOCK_ANY appSecret:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
 
     // Get sender block for later call.
     [invocation retainArguments];
-    [invocation getArgument:&senderBlock atIndex:3];
+    [invocation getArgument:&senderBlock atIndex:4];
     [invocation getArgument:&lastBatchLogContainer atIndex:2];
   });
 
@@ -431,6 +435,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                                                    storage:storageMock
                                                              configuration:config
                                                          logsDispatchQueue:dispatch_get_main_queue()];
+  [sut setAppSecret:@"TestAppSecret"];
 
   // When
   [sut enqueueItem:[self getValidMockLog]];
@@ -473,8 +478,8 @@ static NSString *const kMSTestGroupId = @"GroupId";
   int batchSizeLimit = 1;
   id mockLog = [self getValidMockLog];
   id senderMock = OCMProtocolMock(@protocol(MSSender));
-  OCMReject([senderMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]);
-  OCMStub([senderMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]);
+  OCMReject([senderMock sendAsync:OCMOCK_ANY appSecret:OCMOCK_ANY completionHandler:OCMOCK_ANY]);
+  OCMStub([senderMock sendAsync:OCMOCK_ANY appSecret:OCMOCK_ANY completionHandler:OCMOCK_ANY]);
   id storageMock = OCMProtocolMock(@protocol(MSStorage));
   OCMStub([storageMock
       loadLogsWithGroupId:kMSTestGroupId

--- a/AppCenter/AppCenterTests/MSOneCollectorIngestionTests.m
+++ b/AppCenter/AppCenterTests/MSOneCollectorIngestionTests.m
@@ -54,7 +54,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   // When
   NSString *containerId = @"1";
   MSLogContainer *container = [self createLogContainerWithId:containerId];
-  NSURLRequest *request = [self.sut createRequest:container];
+  NSURLRequest *request = [self.sut createRequest:container appSecret:@"TestAppSecret"];
   NSArray *keys = [request.allHTTPHeaderFields allKeys];
 
   // Then
@@ -66,6 +66,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
       [NSString stringWithFormat:kMSOneCollectorClientVersionFormat, [MSUtility sdkVersion]];
   XCTAssertTrue([[request.allHTTPHeaderFields objectForKey:kMSOneCollectorClientVersionKey]
       isEqualToString:expectedClientVersion]);
+  XCTAssertNil([request.allHTTPHeaderFields objectForKey:kMSHeaderAppSecretKey]);
   XCTAssertTrue([keys containsObject:kMSOneCollectorApiKey]);
   NSArray *tokens = [[request.allHTTPHeaderFields objectForKey:kMSOneCollectorApiKey] componentsSeparatedByString:@","];
   XCTAssertTrue([tokens count] == 3);
@@ -91,7 +92,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
       [[MSLogContainer alloc] initWithBatchId:containerId andLogs:(NSArray<id<MSLog>> *)@[ log1, log2 ]];
 
   // When
-  NSURLRequest *request = [self.sut createRequest:logContainer];
+  NSURLRequest *request = [self.sut createRequest:logContainer appSecret:nil];
 
   // Then
   XCTAssertNotNil(request);
@@ -112,6 +113,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   MSLogContainer *container = [self createLogContainerWithId:containerId];
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"HTTP Response 200"];
   [self.sut sendAsync:container
+            appSecret:nil
       completionHandler:^(NSString *batchId, NSUInteger statusCode, __attribute__((unused)) NSData *data,
                           NSError *error) {
         XCTAssertNil(error);
@@ -141,6 +143,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
   // When
   [self.sut sendAsync:container
+            appSecret:nil
       completionHandler:^(__attribute__((unused)) NSString *batchId, __attribute__((unused)) NSUInteger statusCode,
                           __attribute__((unused)) NSData *data, NSError *error) {
 
@@ -161,6 +164,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   // When
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"HTTP Network Down"];
   [self.sut sendAsync:container
+            appSecret:nil
       completionHandler:^(__attribute__((unused)) NSString *batchId, __attribute__((unused)) NSUInteger statusCode,
                           __attribute__((unused)) NSData *data, NSError *error) {
 
@@ -230,7 +234,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   NSData *httpBody = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
 
   // When
-  NSURLRequest *request = [self.sut createRequest:logContainer];
+  NSURLRequest *request = [self.sut createRequest:logContainer appSecret:nil];
 
   // Then
   XCTAssertNil(request.allHTTPHeaderFields[kMSHeaderContentEncodingKey]);
@@ -258,7 +262,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   NSData *httpBody = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
 
   // When
-  NSURLRequest *request = [self.sut createRequest:logContainer];
+  NSURLRequest *request = [self.sut createRequest:logContainer appSecret:nil];
 
   // Then
   XCTAssertEqual(request.allHTTPHeaderFields[kMSHeaderContentEncodingKey], kMSHeaderContentEncoding);

--- a/AppCenterDistribute/AppCenterDistribute/Internals/Sender/MSDistributeSender.m
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/Sender/MSDistributeSender.m
@@ -39,8 +39,9 @@ static NSString *const kMSLatestPublicReleaseApiPathFormat =
   return self;
 }
 
-- (NSURLRequest *)createRequest:(NSObject *)data {
+- (NSURLRequest *)createRequest:(NSObject *)data appSecret:(NSString *)appSecret {
   (void)data;
+  (void)appSecret;
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.sendURL];
 
   // Set method.

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -189,7 +189,9 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
   self.releaseDetails = nil;
 }
 
-- (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup appSecret:(nullable NSString *)appSecret transmissionTargetToken:(nullable NSString *)token {
+- (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup
+                    appSecret:(nullable NSString *)appSecret
+      transmissionTargetToken:(nullable NSString *)token {
   [super startWithChannelGroup:channelGroup appSecret:appSecret transmissionTargetToken:token];
   MSLogVerbose([MSDistribute logTag], @"Started Distribute service.");
 }
@@ -356,6 +358,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
       __weak typeof(self) weakSelf = self;
       [self.sender
                   sendAsync:nil
+                  appSecret:self.appSecret
           completionHandler:^(__unused NSString *callId, NSUInteger statusCode, NSData *data, __unused NSError *error) {
             typeof(self) strongSelf = weakSelf;
             if (!strongSelf) {
@@ -745,8 +748,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
 
 - (void)storeDownloadedReleaseDetails:(nullable MSReleaseDetails *)details {
   if (details == nil) {
-    MSLogDebug([MSDistribute logTag],
-               @"Downloaded release details are missing or broken, won't store.");
+    MSLogDebug([MSDistribute logTag], @"Downloaded release details are missing or broken, won't store.");
     return;
   }
   NSString *groupId = details.distributionGroupId;
@@ -756,8 +758,8 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
    * IPA can contain several hashes, each for different architecture and we can't predict which will be installed,
    * so save all hashes as comma separated string.
    */
-  NSString *releaseHashes = [details.packageHashes count] > 0 ? [details.packageHashes componentsJoinedByString:@","]
-                                                              : nil;
+  NSString *releaseHashes =
+      [details.packageHashes count] > 0 ? [details.packageHashes componentsJoinedByString:@","] : nil;
   [MS_USER_DEFAULTS setObject:groupId forKey:kMSDownloadedDistributionGroupIdKey];
   [MS_USER_DEFAULTS setObject:releaseId forKey:kMSDownloadedReleaseIdKey];
   [MS_USER_DEFAULTS setObject:releaseHashes forKey:kMSDownloadedReleaseHashKey];
@@ -823,16 +825,21 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
 
   // Skip if the current release was not updated.
   NSString *updatedReleaseHashes = [MS_USER_DEFAULTS objectForKey:kMSDownloadedReleaseHashKey];
-  if ((updatedReleaseHashes == nil) || ([updatedReleaseHashes rangeOfString:currentInstalledReleaseHash].location == NSNotFound)) {
+  if ((updatedReleaseHashes == nil) ||
+      ([updatedReleaseHashes rangeOfString:currentInstalledReleaseHash].location == NSNotFound)) {
     return;
   }
 
   // Skip if the group ID of an updated release is the same as the stored one.
   NSString *storedDistributionGroupId = [MS_USER_DEFAULTS objectForKey:kMSDistributionGroupIdKey];
-  if ((storedDistributionGroupId == nil) || ([updatedReleaseDistributionGroupId isEqualToString:storedDistributionGroupId] == NO)) {
+  if ((storedDistributionGroupId == nil) ||
+      ([updatedReleaseDistributionGroupId isEqualToString:storedDistributionGroupId] == NO)) {
 
-    // Set group ID from downloaded release details if an updated release was downloaded from another distribution group.
-    MSLogDebug([MSDistribute logTag], @"Stored group ID doesn't match the group ID of the updated release, updating group id: %@", updatedReleaseDistributionGroupId);
+    // Set group ID from downloaded release details if an updated release was downloaded from another distribution
+    // group.
+    MSLogDebug([MSDistribute logTag],
+               @"Stored group ID doesn't match the group ID of the updated release, updating group id: %@",
+               updatedReleaseDistributionGroupId);
     [MS_USER_DEFAULTS setObject:updatedReleaseDistributionGroupId forKey:kMSDistributionGroupIdKey];
   }
 

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeSenderTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeSenderTests.m
@@ -26,7 +26,7 @@
                                                             retryIntervals:@[]];
 
   // When
-  NSURLRequest *request = [sender createRequest:[NSData new]];
+  NSURLRequest *request = [sender createRequest:[NSData new] appSecret:nil];
 
   // Then
   assertThat(request.HTTPMethod, equalTo(@"GET"));
@@ -51,7 +51,7 @@
                                                                queryStrings:@{}];
 
   // When
-  NSURLRequest *request1 = [sender1 createRequest:[NSData new]];
+  NSURLRequest *request1 = [sender1 createRequest:[NSData new] appSecret:nil];
 
   // Then
   assertThat(request1.HTTPMethod, equalTo(@"GET"));


### PR DESCRIPTION
Some context on this:
- the way `setAppSecret:` is implemented is a little unituitive. It should be a property on `MSChannelProtocol` with `@synthesize` statements in `MSDefaultChannelGroup` and `MSDefaultChannelUnit` with `MSDefaultChannelGroup` having the custom setter (`setAppSecret:`). The problem is that the compiler somehow doesn't "understand" that `setAppSecret:` is a setter, and it throws a warning because we're accessing the `ivar` directly. This doesn't make any sense but we spent about 2hrs yesterday trying different solutions and this PR is what we came up with.
- we experimented with passing around the created `NSURLRequest`. Unfortunately, this will make tracking `batchId` really hard as a `NSURLRequest` contains the `MSLogContainer` as it's body but serialized to an `NSString`, which is then converted and compressed to NSData. So accessing the actual content of an the request object becomes very expensive, so we decided to not pass around `NSURLRequest` objects.
- we also looked at removing the `appSecret` property from the `ChannelUnitDefault` and only have it in `ChannelGroupDefault` - this would be more similar to Android. The problem is that Android has most of the batching, etc. logic in `ChannelGroup`/`Channel`, while iOS/Apple has lots of it one level down in `ChannnelUnitDefault`. We think that it's best to keep the `appSecret` in both `...Group` and `...Unit` for now. 