### PR TITLE
Make 0 a recoverable code

### DIFF
--- a/AppCenter/AppCenter/Internals/Sender/Util/MSSenderUtil.m
+++ b/AppCenter/AppCenter/Internals/Sender/Util/MSSenderUtil.m
@@ -3,7 +3,9 @@
 @implementation MSSenderUtil
 
 + (BOOL)isRecoverableError:(NSInteger)statusCode {
-  return statusCode >= 500 || statusCode == 408 || statusCode == 429;
+
+  // There are some cases when statusCode is 0, e.g., when server is unreachable.
+  return statusCode >= 500 || statusCode == 408 || statusCode == 429 || statusCode == 0;
 }
 
 + (NSInteger)getStatusCode:(NSURLResponse *)response {

--- a/AppCenter/AppCenterTests/MSSenderUtilTests.m
+++ b/AppCenter/AppCenterTests/MSSenderUtilTests.m
@@ -123,7 +123,7 @@
 }
 
 - (void)testIsRecoverableError {
-  for (int i = 100; i < 530; i++) {
+  for (int i = 0; i < 530; i++) {
 
     // When
     BOOL result = [MSSenderUtil isRecoverableError:i];
@@ -134,6 +134,8 @@
     } else if (i == 408) {
       XCTAssertTrue(result);
     } else if (i == 429) {
+      XCTAssertTrue(result);
+    } else if (i == 0) {
       XCTAssertTrue(result);
     } else {
       XCTAssertFalse(result);


### PR DESCRIPTION
This should fix the issue reported in the .NET repo - https://github.com/Microsoft/AppCenter-SDK-DotNet/issues/597

Turns out there was a status code '0' being returned sometimes, and when this is the case it is treated as fatal, and that removes the update token/group id, which tricks the SDK into thinking the app is side loaded even if it wasn't