### PR TITLE
Use __unused instead of (void)ingestion for MSIngestionDelegate callbacks

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -74,18 +74,15 @@
 
 #pragma mark - MSIngestionDelegate
 
-- (void)ingestionDidSuspend:(id<MSIngestionProtocol>)ingestion {
-  (void)ingestion;
+- (void)ingestionDidSuspend:(__unused id<MSIngestionProtocol>)ingestion {
   [self suspend];
 }
 
-- (void)ingestionDidResume:(id<MSIngestionProtocol>)ingestion {
-  (void)ingestion;
+- (void)ingestionDidResume:(__unused id<MSIngestionProtocol>)ingestion {
   [self resume];
 }
 
-- (void)ingestionDidReceiveFatalError:(id<MSIngestionProtocol>)ingestion {
-  (void)ingestion;
+- (void)ingestionDidReceiveFatalError:(__unused id<MSIngestionProtocol>)ingestion {
 
   // Disable and delete data on fatal errors.
   [self setEnabled:NO andDeleteDataOnDisabled:YES];

--- a/AppCenter/AppCenter/Internals/Ingestion/MSIngestionDelegate.h
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSIngestionDelegate.h
@@ -9,20 +9,20 @@
  *
  * @param ingestion Ingestion.
  */
-- (void)ingestionDidSuspend:(id<MSIngestionProtocol>)ingestion;
+- (void)ingestionDidSuspend:(__unused id<MSIngestionProtocol>)ingestion;
 
 /**
  * Triggered after the ingestion has resumed its state.
  *
  * @param ingestion Ingestion.
  */
-- (void)ingestionDidResume:(id<MSIngestionProtocol>)ingestion;
+- (void)ingestionDidResume:(__unused id<MSIngestionProtocol>)ingestion;
 
 /**
  * Triggered when ingestion receives a fatal error.
  *
  * @param ingestion Ingestion.
  */
-- (void)ingestionDidReceiveFatalError:(id<MSIngestionProtocol>)ingestion;
+- (void)ingestionDidReceiveFatalError:(__unused id<MSIngestionProtocol>)ingestion;
 
 @end


### PR DESCRIPTION
@jaelim-ms requested this in #1041 - It's probably okay but I don't like that we do this. Marking the param as `__unused` means that classes that implement the callback cannot use the `ingestion` param at all.
Imho the protocol should leave it to the implementation to determine if the param is used or not.