### PR TITLE
Fix 1ds logs enqueue from log buffer

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
@@ -83,7 +83,10 @@ NSString *const kMSLogNameRegex = @"^[a-zA-Z0-9]((\\.(?!(\\.|$)))|[_a-zA-Z0-9]){
   id<MSChannelUnitProtocol> oneCollectorChannelUnit = nil;
   NSString *groupId = channelUnit.configuration.groupId;
   
-  // Re-enqueue the 1ds logs if the channel is not 1ds.
+  /*
+   * Reroute Custom Schema logs to their One Collector channel if they were enqueued to a non One Collector channel.
+   * Happens to logs from the log buffer after a crash.
+   */
   if ([(NSObject *)log isKindOfClass:[MSCommonSchemaLog class]] && ![self isOneCollectorGroup:groupId]) {
     oneCollectorChannelUnit = [self.oneCollectorChannels objectForKey:groupId];
     if (oneCollectorChannelUnit) {

--- a/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
@@ -79,12 +79,22 @@ NSString *const kMSLogNameRegex = @"^[a-zA-Z0-9]((\\.(?!(\\.|$)))|[_a-zA-Z0-9]){
 - (void)channel:(id<MSChannelProtocol>)channel
      didPrepareLog:(id<MSLog>)log
     withInternalId:(NSString *)__unused internalId {
+  id<MSChannelUnitProtocol> channelUnit = (id<MSChannelUnitProtocol>)channel;
+  id<MSChannelUnitProtocol> oneCollectorChannelUnit = nil;
+  NSString *groupId = channelUnit.configuration.groupId;
+  if ([(NSObject *)log isKindOfClass:[MSCommonSchemaLog class]] && ![self isOneCollectorGroup:groupId]) {
+    oneCollectorChannelUnit = [self.oneCollectorChannels objectForKey:groupId];
+    if (oneCollectorChannelUnit) {
+      dispatch_async(oneCollectorChannelUnit.logsDispatchQueue, ^{
+        [oneCollectorChannelUnit enqueueItem:log];
+      });
+    }
+    return;
+  }
   if (![self shouldSendLogToOneCollector:log] || ![channel conformsToProtocol:@protocol(MSChannelUnitProtocol)]) {
     return;
   }
-  id<MSChannelUnitProtocol> channelUnit = (id<MSChannelUnitProtocol>)channel;
-  NSString *groupId = channelUnit.configuration.groupId;
-  id<MSChannelUnitProtocol> oneCollectorChannelUnit = [self.oneCollectorChannels objectForKey:groupId];
+  oneCollectorChannelUnit = [self.oneCollectorChannels objectForKey:groupId];
   if (!oneCollectorChannelUnit) {
     return;
   }
@@ -97,10 +107,13 @@ NSString *const kMSLogNameRegex = @"^[a-zA-Z0-9]((\\.(?!(\\.|$)))|[_a-zA-Z0-9]){
   }
 }
 
-- (BOOL)channelUnit:(id<MSChannelUnitProtocol>)__unused channelUnit shouldFilterLog:(id<MSLog>)log {
+- (BOOL)channelUnit:(id<MSChannelUnitProtocol>) channelUnit shouldFilterLog:(id<MSLog>)log {
 
   // Validate Custom Schema logs, filter out invalid logs.
   if ([log isKindOfClass:[MSCommonSchemaLog class]]) {
+    if (![self isOneCollectorGroup:channelUnit.configuration.groupId]) {
+      return true;
+    }
     return ![self validateLog:(MSCommonSchemaLog *)log];
   }
 

--- a/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
@@ -82,6 +82,8 @@ NSString *const kMSLogNameRegex = @"^[a-zA-Z0-9]((\\.(?!(\\.|$)))|[_a-zA-Z0-9]){
   id<MSChannelUnitProtocol> channelUnit = (id<MSChannelUnitProtocol>)channel;
   id<MSChannelUnitProtocol> oneCollectorChannelUnit = nil;
   NSString *groupId = channelUnit.configuration.groupId;
+  
+  // Re-enqueue the 1ds logs if the channel is not 1ds.
   if ([(NSObject *)log isKindOfClass:[MSCommonSchemaLog class]] && ![self isOneCollectorGroup:groupId]) {
     oneCollectorChannelUnit = [self.oneCollectorChannels objectForKey:groupId];
     if (oneCollectorChannelUnit) {

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -423,7 +423,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
   _enableMachExceptionHandler = enableMachExceptionHandler;
 }
 
-#pragma mark - Channel Persist Delegate
+#pragma mark - Channel Delegate
 
 /**
  * Why are we doing the event-buffering inside crashes?
@@ -438,15 +438,6 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 - (void)channel:(id<MSChannelProtocol>)__unused channel
      didPrepareLog:(id<MSLog>)log
     withInternalId:(NSString *)internalId {
-
-  /*
-   * FIXME: Don't buffer OC logs yet. OC logs from the buffer are currently queued to an AC channel which is wrong. It
-   * should either be enqueued to an OC channel or it should be cached by the log buffer just before the conversion to
-   * an OC log so that we'll never have to persist an OC log and we'll only have to deal with the AC channel.
-   */
-  if (log.transmissionTargetTokens) {
-    return;
-  }
 
   // Don't buffer event if log is empty, crashes module is disabled or the log is related to crash.
   NSObject *logObject = static_cast<NSObject *>(log);

--- a/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
@@ -541,13 +541,13 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   [self.sut channel:nil didPrepareLog:[MSAppleErrorLog new] withInternalId:uuid3];
 
   // Then
-  assertThatLong([self crashesLogBufferCount], equalToLong(1));
-
+  assertThatLong([self crashesLogBufferCount], equalToLong(2));
+  
   // When
   [self.sut channel:nil didCompleteEnqueueingLog:nil withInternalId:uuid3];
   
   // Then
-  assertThatLong([self crashesLogBufferCount], equalToLong(1));
+  assertThatLong([self crashesLogBufferCount], equalToLong(2));
 
   // When
   [self.sut channel:nil didCompleteEnqueueingLog:nil withInternalId:uuid2];
@@ -590,7 +590,7 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   [self.sut channel:nil didPrepareLog:[MSAppleErrorLog new] withInternalId:uuid3];
   
   // Then
-  assertThatLong([self crashesLogBufferCount], equalToLong(1));
+  assertThatLong([self crashesLogBufferCount], equalToLong(2));
   
   // When
   // Save on crash.
@@ -603,7 +603,7 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
                   fromApplication:YES];
 
   // Then
-  XCTAssertEqual(1U, numInvocations);
+  XCTAssertEqual(2U, numInvocations);
 }
 
 - (void)testInitializationPriorityCorrect {


### PR DESCRIPTION
OC logs from the buffer are currently queued to an AC channel which is wrong.

The main idea of the PR: in the 1ds delegate re-enqueue 1ds logs if they aren't in 1ds channel