### PR TITLE
Add and clean up references in TestApps project

### DIFF
--- a/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
+++ b/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@
 				354273DD20126A3E00BE766F /* EventFilter */,
 				84226D3A1E8937FF00798417 /* AppCenterDelegate.swift */,
 				849A3E711E8A9922008711CB /* AppCenterProtocol.swift */,
+				35FBE78020FD095200F7B05C /* MSTransmissionTargets.swift */,
 				041E2BEE1FB6465000793316 /* Constants.h */,
 				84226CB11E8909F700798417 /* Storyboards */,
 				84226CB01E8909EA00798417 /* ViewControllers */,
@@ -511,7 +512,6 @@
 				045A947D1F97C840002B7CB1 /* App.xcconfig */,
 				84226C1C1E88FEFC00798417 /* Assets.xcassets */,
 				041A4BAF1F8C28A3009E1B6C /* Sasquatch.strings */,
-				35FBE78020FD095200F7B05C /* MSTransmissionTargets.swift */,
 				84226D091E891FB900798417 /* Sasquatch-Bridging-Header.h */,
 			);
 			name = "Supporting Files";

--- a/TestApps/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
+++ b/TestApps/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		84A0FF6C1E8A87E1000E7A28 /* MSDistributeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A0FF6B1E8A87E1000E7A28 /* MSDistributeViewController.swift */; };
 		84A0FF6D1E8A87E1000E7A28 /* MSDistributeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A0FF6B1E8A87E1000E7A28 /* MSDistributeViewController.swift */; };
 		84D63FF91E8BAA90004C9F86 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 845964A91E8A7E6600BABA51 /* Main.storyboard */; };
+		B2299FA621065E35002F7055 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84226C1C1E88FEFC00798417 /* Assets.xcassets */; };
+		B2299FA721065E37002F7055 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84226C1C1E88FEFC00798417 /* Assets.xcassets */; };
 		B241DE31201E793D009F135D /* MSEventFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B241DE30201E793D009F135D /* MSEventFilter.m */; };
 		B241DE32201E7945009F135D /* MSEventFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B241DE30201E793D009F135D /* MSEventFilter.m */; };
 		B25762BA210659A4008326CA /* MSTransmissionTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25762B9210659A4008326CA /* MSTransmissionTargets.swift */; };
@@ -833,6 +835,7 @@
 				047D13721EAFBDBE00D699BA /* AppCenterDistributeResources.bundle in Resources */,
 				F89F0DE81FD018FF005F24C8 /* LaunchScreen.storyboard in Resources */,
 				845964AB1E8A7E6600BABA51 /* Main.storyboard in Resources */,
+				B2299FA621065E35002F7055 /* Assets.xcassets in Resources */,
 				F87E96201FDEFFD400AF2717 /* MSAnalyticsPropertyTableViewCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -847,6 +850,7 @@
 				F89F0DE91FD01910005F24C8 /* LaunchScreen.storyboard in Resources */,
 				3847DD1620FEDF58003152CE /* MSAnalyticsTranmissionTargetSelectorViewCell.xib in Resources */,
 				84D63FF91E8BAA90004C9F86 /* Main.storyboard in Resources */,
+				B2299FA721065E37002F7055 /* Assets.xcassets in Resources */,
 				F87E96221FDEFFD800AF2717 /* MSAnalyticsPropertyTableViewCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TestApps/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
+++ b/TestApps/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
@@ -31,8 +31,6 @@
 		5CE258921EA5F62E00DA8FB9 /* AnalyticsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE258791EA5F5DF00DA8FB9 /* AnalyticsUITests.swift */; };
 		5CE258931EA5F62E00DA8FB9 /* CrashesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE2587B1EA5F5EB00DA8FB9 /* CrashesUITests.swift */; };
 		5CE258941EA5F62E00DA8FB9 /* DistributeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE2587D1EA5F5FC00DA8FB9 /* DistributeUITests.swift */; };
-		803CFF271F6A7E1D0072B9BA /* MSPushViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803CFF261F6A7E1D0072B9BA /* MSPushViewController.swift */; };
-		803CFF281F6A7E1D0072B9BA /* MSPushViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803CFF261F6A7E1D0072B9BA /* MSPushViewController.swift */; };
 		84226C4B1E88FF4A00798417 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 84226C4A1E88FF4A00798417 /* main.m */; };
 		84226C4E1E88FF4A00798417 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 84226C4D1E88FF4A00798417 /* AppDelegate.m */; };
 		84226C561E88FF4A00798417 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84226C551E88FF4A00798417 /* Assets.xcassets */; };
@@ -64,8 +62,8 @@
 		84D63FF91E8BAA90004C9F86 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 845964A91E8A7E6600BABA51 /* Main.storyboard */; };
 		B241DE31201E793D009F135D /* MSEventFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B241DE30201E793D009F135D /* MSEventFilter.m */; };
 		B241DE32201E7945009F135D /* MSEventFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = B241DE30201E793D009F135D /* MSEventFilter.m */; };
-		B241DE34201E797E009F135D /* MSEventFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B241DE33201E797E009F135D /* MSEventFilterViewController.swift */; };
-		B241DE35201E79A6009F135D /* MSEventFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B241DE33201E797E009F135D /* MSEventFilterViewController.swift */; };
+		B25762BA210659A4008326CA /* MSTransmissionTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25762B9210659A4008326CA /* MSTransmissionTargets.swift */; };
+		B25762BB210659A4008326CA /* MSTransmissionTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25762B9210659A4008326CA /* MSTransmissionTargets.swift */; };
 		B27424851EF2193E00F591E5 /* AppCenterDistributeResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 047D13711EAFBDBE00D699BA /* AppCenterDistributeResources.bundle */; };
 		B2B36CE21EEF49B700230341 /* MSCustomPropertiesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B36CE11EEF49B700230341 /* MSCustomPropertiesViewController.swift */; };
 		B2B36CE31EEF49C400230341 /* MSCustomPropertiesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B36CE11EEF49B700230341 /* MSCustomPropertiesViewController.swift */; };
@@ -208,7 +206,6 @@
 		5CE2587D1EA5F5FC00DA8FB9 /* DistributeUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DistributeUITests.swift; path = SasquatchUITests/DistributeUITests.swift; sourceTree = SOURCE_ROOT; };
 		5CE258871EA5F62400DA8FB9 /* SasquatchObjCUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SasquatchObjCUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CE258961EA5FAE100DA8FB9 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		803CFF261F6A7E1D0072B9BA /* MSPushViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSPushViewController.swift; sourceTree = "<group>"; };
 		84226C1C1E88FEFC00798417 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		84226C471E88FF4A00798417 /* SasquatchObjC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SasquatchObjC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		84226C4A1E88FF4A00798417 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -237,7 +234,7 @@
 		84A0FF6B1E8A87E1000E7A28 /* MSDistributeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSDistributeViewController.swift; sourceTree = "<group>"; };
 		B241DE2F201E793D009F135D /* MSEventFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSEventFilter.h; path = EventFilter/MSEventFilter.h; sourceTree = "<group>"; };
 		B241DE30201E793D009F135D /* MSEventFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MSEventFilter.m; path = EventFilter/MSEventFilter.m; sourceTree = "<group>"; };
-		B241DE33201E797E009F135D /* MSEventFilterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSEventFilterViewController.swift; sourceTree = "<group>"; };
+		B25762B9210659A4008326CA /* MSTransmissionTargets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSTransmissionTargets.swift; sourceTree = "<group>"; };
 		B2B36CE11EEF49B700230341 /* MSCustomPropertiesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSCustomPropertiesViewController.swift; sourceTree = "<group>"; };
 		D31EF9291E9517B500450162 /* SasquatchWatchObjC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SasquatchWatchObjC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D31EF92C1E9517B600450162 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
@@ -382,6 +379,7 @@
 				84226D3A1E8937FF00798417 /* AppCenterDelegate.swift */,
 				849A3E711E8A9922008711CB /* AppCenterProtocol.swift */,
 				04AB77691FB627CD00EC6074 /* Constants.h */,
+				B25762B9210659A4008326CA /* MSTransmissionTargets.swift */,
 				84226CB11E8909F700798417 /* Storyboards */,
 				84226CB21E8909FF00798417 /* Supporting Files */,
 				84226CB01E8909EA00798417 /* ViewControllers */,
@@ -439,8 +437,6 @@
 				B2B36CE11EEF49B700230341 /* MSCustomPropertiesViewController.swift */,
 				F87E961B1FDEFFD400AF2717 /* MSCustomPropertyTableViewCell.swift */,
 				84A0FF6B1E8A87E1000E7A28 /* MSDistributeViewController.swift */,
-				B241DE33201E797E009F135D /* MSEventFilterViewController.swift */,
-				803CFF261F6A7E1D0072B9BA /* MSPushViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -917,9 +913,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3847DD0C20FEDF4A003152CE /* TargetPropertiesTableSection.swift in Sources */,
-				B241DE34201E797E009F135D /* MSEventFilterViewController.swift in Sources */,
 				3847DD0820FEDF4A003152CE /* PropertiesTableSection.swift in Sources */,
-				803CFF271F6A7E1D0072B9BA /* MSPushViewController.swift in Sources */,
 				849A3E721E8A9922008711CB /* AppCenterProtocol.swift in Sources */,
 				845964AD1E8A7E9700BABA51 /* MSMainViewController.swift in Sources */,
 				84A0FF691E8A87C9000E7A28 /* MSAnalyticsViewController.swift in Sources */,
@@ -936,6 +930,7 @@
 				84226D3C1E8938D100798417 /* AppCenterDelegate.swift in Sources */,
 				B241DE31201E793D009F135D /* MSEventFilter.m in Sources */,
 				F87E961F1FDEFFD400AF2717 /* MSAnalyticsPropertyTableViewCell.swift in Sources */,
+				B25762BA210659A4008326CA /* MSTransmissionTargets.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -943,16 +938,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				803CFF281F6A7E1D0072B9BA /* MSPushViewController.swift in Sources */,
 				F87E96211FDEFFD800AF2717 /* MSAnalyticsPropertyTableViewCell.swift in Sources */,
 				849A3E731E8A9922008711CB /* AppCenterProtocol.swift in Sources */,
 				3847DD1420FEDF58003152CE /* MSAnalyticsTranmissionTargetSelectorViewCell.swift in Sources */,
 				84A0FF671E8A87B4000E7A28 /* MSCrashesViewController.swift in Sources */,
 				3847DD1220FEDF58003152CE /* MSAnalyticsChildTransmissionTargetTableViewController.swift in Sources */,
 				84A0FF6A1E8A87C9000E7A28 /* MSAnalyticsViewController.swift in Sources */,
+				B25762BB210659A4008326CA /* MSTransmissionTargets.swift in Sources */,
 				84226D3D1E8938D200798417 /* AppCenterDelegate.swift in Sources */,
 				B2B36CE31EEF49C400230341 /* MSCustomPropertiesViewController.swift in Sources */,
-				B241DE35201E79A6009F135D /* MSEventFilterViewController.swift in Sources */,
 				3847DD0D20FEDF4A003152CE /* TargetPropertiesTableSection.swift in Sources */,
 				3847DD0B20FEDF4A003152CE /* EventPropertiesTableSection.swift in Sources */,
 				845178ED1E8A8B0D004A0A6F /* MSMainViewController.swift in Sources */,


### PR DESCRIPTION
Most likely results from a merge gone wrong which resulted in the iOS apps not compiling:
* adds reference to `MSTransmissionTargets.swift`
* removes old references to `MSEventFilterViewController.swift` and `MSPushViewController.swift`