### PR TITLE
Update the description for one of our crash test cases

### DIFF
--- a/CrashLib/CrashLib/MSCrashSmashStackTop.m
+++ b/CrashLib/CrashLib/MSCrashSmashStackTop.m
@@ -17,7 +17,8 @@
 - (NSString *)desc {
   return @""
           "Overwrite data above the current stack pointer. This will destroy the current stack trace. "
-          "Reporting of this crash is expected to fail. Succeeding is basically luck.";
+          "Reporting of this crash is expected to fail. Succeeding is basically luck. "
+          "Apple added additional check that prevent this crash from happening in iOS 12 and up.";
 }
 
 - (void)crash {

--- a/CrashLib/CrashLib/MSCrashSmashStackTop.m
+++ b/CrashLib/CrashLib/MSCrashSmashStackTop.m
@@ -18,7 +18,7 @@
   return @""
           "Overwrite data above the current stack pointer. This will destroy the current stack trace. "
           "Reporting of this crash is expected to fail. Succeeding is basically luck. "
-          "Apple added additional check that prevent this crash from happening in iOS 12 and up.";
+          "Apple added additional checks that prevent this crash from happening in iOS 12 and up.";
 }
 
 - (void)crash {


### PR DESCRIPTION
As of iOS 12, smashing the top of the stack does no longer cause a crash. This PR updates the description of that crash test case.