### PR TITLE
Use Puppet’s app secret for SasquatchPuppet

### DIFF
--- a/TestApps/Sasquatch/Sasquatch/Constants.h
+++ b/TestApps/Sasquatch/Sasquatch/Constants.h
@@ -6,5 +6,6 @@ static NSString *const kMSTargetToken1 = @"602c2d529a824339bef93a7b9a035e6a-a018
 static NSString *const kMSTargetToken2 = @"902923ebd7a34552bd7a0c33207611ab-a48969f4-4823-428f-a88c-eff15e474137-7039";
 static NSString *const kMSSwiftRuntimeTargetToken = @"238db5abfbaa4c299b78dd539f78b829-cd10afb7-0ec2-496f-ac8a-c21974fbb82c-7564";
 static NSString *const kMSObjCRuntimeTargetToken = @"1aa046cfdc8f49bdbd64190290caf7dd-ba041023-af4d-4432-a87e-eb2431150797-7361";
+static NSString *const kMSPuppetRuntimeTargetToken = @"b9bb5bcb40f24830aa12f681e6462292-10b4c5da-67be-49ce-936b-8b2b80a83a80-7868";
 static NSString *const kMSOneCollectorEnabledKey = @"isOneCollectorEnabled";
 static NSString *const kMSStartTargetKey = @"startTarget";

--- a/TestApps/Sasquatch/Sasquatch/MSTransmissionTargets.swift
+++ b/TestApps/Sasquatch/Sasquatch/MSTransmissionTargets.swift
@@ -18,7 +18,12 @@ class MSTransmissionTargets {
 
     // Parent target.
     let appName = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
-    let parentTargetToken = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
+    #if ACTIVE_COMPILATION_CONDITION_PUPPET
+    let objCRuntimeToken = kMSPuppetRuntimeTargetToken
+    #else
+    let objCRuntimeToken = kMSObjCRuntimeTargetToken
+    #endif
+    let parentTargetToken = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : objCRuntimeToken
     let parentTarget = MSAnalytics.transmissionTarget(forToken: parentTargetToken)
     transmissionTargets[parentTargetToken] = parentTarget
     sendsAnalyticsEvents[parentTargetToken] = true

--- a/TestApps/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsTranmissionTargetSelectorViewCell.swift
+++ b/TestApps/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsTranmissionTargetSelectorViewCell.swift
@@ -1,25 +1,30 @@
 import UIKit
 
 @objc(MSAnalyticsTranmissionTargetSelectorViewCell) class MSAnalyticsTranmissionTargetSelectorViewCell: UITableViewCell {
-
-@IBOutlet weak var transmissionTargetSelector: UISegmentedControl!
-
+  
+  @IBOutlet weak var transmissionTargetSelector: UISegmentedControl!
+  
   public var didSelectTransmissionTarget: (() -> Void)?
   public var transmissionTargetMapping: [String]?
-
+  
   override func awakeFromNib() {
     super.awakeFromNib()
     let appName = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
-    let runtimeToken: String = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
+    #if ACTIVE_COMPILATION_CONDITION_PUPPET
+    let objCRuntimeToken = kMSPuppetRuntimeTargetToken
+    #else
+    let objcRuntimeToken = kMSObjCRuntimeTargetToken
+    #endif
+    let runtimeToken: String = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : objCRuntimeToken
     transmissionTargetMapping = [kMSTargetToken1, kMSTargetToken2, runtimeToken]
     didSelectTransmissionTarget = {_ in}
     transmissionTargetSelector.addTarget(self, action: #selector(onSegmentSelected), for: .valueChanged)
   }
-
+  
   public func selectedTransmissionTarget() -> String! {
     return transmissionTargetMapping![transmissionTargetSelector.selectedSegmentIndex]
   }
-
+  
   func onSegmentSelected() {
     didSelectTransmissionTarget?()
   }

--- a/TestApps/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsTranmissionTargetSelectorViewCell.swift
+++ b/TestApps/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsTranmissionTargetSelectorViewCell.swift
@@ -6,7 +6,7 @@ import UIKit
   
   public var didSelectTransmissionTarget: (() -> Void)?
   public var transmissionTargetMapping: [String]?
-  
+
   override func awakeFromNib() {
     super.awakeFromNib()
     let appName = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
@@ -20,11 +20,11 @@ import UIKit
     didSelectTransmissionTarget = {_ in}
     transmissionTargetSelector.addTarget(self, action: #selector(onSegmentSelected), for: .valueChanged)
   }
-  
+
   public func selectedTransmissionTarget() -> String! {
     return transmissionTargetMapping![transmissionTargetSelector.selectedSegmentIndex]
   }
-  
+
   func onSegmentSelected() {
     didSelectTransmissionTarget?()
   }

--- a/TestApps/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsTranmissionTargetSelectorViewCell.swift
+++ b/TestApps/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsTranmissionTargetSelectorViewCell.swift
@@ -13,7 +13,7 @@ import UIKit
     #if ACTIVE_COMPILATION_CONDITION_PUPPET
     let objCRuntimeToken = kMSPuppetRuntimeTargetToken
     #else
-    let objcRuntimeToken = kMSObjCRuntimeTargetToken
+    let objCRuntimeToken = kMSObjCRuntimeTargetToken
     #endif
     let runtimeToken: String = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : objCRuntimeToken
     transmissionTargetMapping = [kMSTargetToken1, kMSTargetToken2, runtimeToken]

--- a/TestApps/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
+++ b/TestApps/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
@@ -81,7 +81,12 @@ class MSTransmissionTargetsViewController: UITableViewController {
     runtimeTargetSection.headerText = "Runtime Transmission Target"
     runtimeTargetSection.footerText = "This transmission target is the parent of the two transmission targets below."
     let appName = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
-    runtimeTargetSection.token = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
+    #if ACTIVE_COMPILATION_CONDITION_PUPPET
+    let objCRuntimeToken = kMSPuppetRuntimeTargetToken
+    #else
+    let objcRuntimeToken = kMSObjCRuntimeTargetToken
+    #endif
+    runtimeTargetSection.token = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : objCRuntimeToken
 
     // Child 1.
     let child1TargetSection = MSTransmissionTargetSection()

--- a/TestApps/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
+++ b/TestApps/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
@@ -84,7 +84,7 @@ class MSTransmissionTargetsViewController: UITableViewController {
     #if ACTIVE_COMPILATION_CONDITION_PUPPET
     let objCRuntimeToken = kMSPuppetRuntimeTargetToken
     #else
-    let objcRuntimeToken = kMSObjCRuntimeTargetToken
+    let objCRuntimeToken = kMSObjCRuntimeTargetToken
     #endif
     runtimeTargetSection.token = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : objCRuntimeToken
 

--- a/TestApps/Sasquatch/Sasquatch/ViewControllers/PropertiesTableSection/TargetPropertiesTableSection.swift
+++ b/TestApps/Sasquatch/Sasquatch/ViewControllers/PropertiesTableSection/TargetPropertiesTableSection.swift
@@ -1,10 +1,9 @@
 import UIKit
 
 class TargetPropertiesTableSection : PropertiesTableSection {
-  
   var targetProperties: [String: [(String, String)]]!
   var transmissionTargetSelectorCell: MSAnalyticsTranmissionTargetSelectorViewCell?
-  
+
   override init(tableSection: Int, tableView: UITableView) {
     super.init(tableSection: tableSection, tableView: tableView)
     targetProperties = [String: [(String, String)]]()
@@ -21,7 +20,7 @@ class TargetPropertiesTableSection : PropertiesTableSection {
     transmissionTargetSelectorCell = loadCellFromNib()
     transmissionTargetSelectorCell?.didSelectTransmissionTarget = reloadSection
   }
-  
+
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     if isHeaderCell(indexPath) {
       return transmissionTargetSelectorCell!
@@ -29,11 +28,11 @@ class TargetPropertiesTableSection : PropertiesTableSection {
       return super.tableView(tableView, cellForRowAt: indexPath)
     }
   }
-  
+
   override func numberOfCustomHeaderCells() -> Int {
     return 1
   }
-  
+
   override func propertyKeyChanged(sender: UITextField!) {
     let selectedTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
     let arrayIndex = getCellRow(forTextField: sender) - propertyCellOffset()
@@ -44,7 +43,7 @@ class TargetPropertiesTableSection : PropertiesTableSection {
     target.propertyConfigurator.setEventPropertyString(currentPropertyValue, forKey: sender.text!)
     targetProperties[selectedTarget!]![arrayIndex].0 = sender.text!
   }
-  
+
   override func propertyValueChanged(sender: UITextField!) {
     let selectedTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
     let arrayIndex = getCellRow(forTextField: sender) - propertyCellOffset()
@@ -53,17 +52,17 @@ class TargetPropertiesTableSection : PropertiesTableSection {
     target.propertyConfigurator.setEventPropertyString(sender.text!, forKey: currentPropertyKey)
     targetProperties[selectedTarget!]![arrayIndex].1 = sender.text!
   }
-  
+
   override func propertyAtRow(row: Int) -> (String, String) {
     let selectedTarget = transmissionTargetSelectorCell!.selectedTransmissionTarget()
     return targetProperties[selectedTarget!]![row - propertyCellOffset()]
   }
-  
+
   override func getPropertyCount() -> Int {
     let selectedTarget = transmissionTargetSelectorCell!.selectedTransmissionTarget()
     return (targetProperties[selectedTarget!]!.count)
   }
-  
+
   override func removeProperty(atRow row: Int) {
     let selectedTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
     let arrayIndex = row - propertyCellOffset()
@@ -72,20 +71,19 @@ class TargetPropertiesTableSection : PropertiesTableSection {
     target.propertyConfigurator.removeEventPropertyforKey(key)
     targetProperties[selectedTarget!]!.remove(at: arrayIndex)
   }
-  
+
   override func addProperty(property: (String, String)) {
     let selectedTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
     targetProperties[selectedTarget!]!.insert(property, at: 0)
     let target = MSTransmissionTargets.shared.transmissionTargets[selectedTarget!]!
     target.propertyConfigurator.setEventPropertyString(property.1, forKey: property.0)
   }
-  
+
   func isHeaderCell(_ indexPath: IndexPath) -> Bool {
     return !(isPropertyRow(indexPath) || isInsertRow(indexPath))
   }
-  
+
   func reloadSection() {
     tableView.reloadSections([tableSection], with: .none)
   }
 }
-

--- a/TestApps/Sasquatch/Sasquatch/ViewControllers/PropertiesTableSection/TargetPropertiesTableSection.swift
+++ b/TestApps/Sasquatch/Sasquatch/ViewControllers/PropertiesTableSection/TargetPropertiesTableSection.swift
@@ -1,22 +1,27 @@
 import UIKit
 
 class TargetPropertiesTableSection : PropertiesTableSection {
-
+  
   var targetProperties: [String: [(String, String)]]!
   var transmissionTargetSelectorCell: MSAnalyticsTranmissionTargetSelectorViewCell?
-
+  
   override init(tableSection: Int, tableView: UITableView) {
     super.init(tableSection: tableSection, tableView: tableView)
     targetProperties = [String: [(String, String)]]()
     let appName = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
-    let parentTargetToken = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
+    #if ACTIVE_COMPILATION_CONDITION_PUPPET
+    let objCRuntimeToken = kMSPuppetRuntimeTargetToken
+    #else
+    let objCRuntimeToken = kMSObjCRuntimeTargetToken
+    #endif
+    let parentTargetToken = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : objCRuntimeToken
     targetProperties[parentTargetToken] = [(String, String)]()
     targetProperties[kMSTargetToken1] = [(String, String)]()
     targetProperties[kMSTargetToken2] = [(String, String)]()
     transmissionTargetSelectorCell = loadCellFromNib()
     transmissionTargetSelectorCell?.didSelectTransmissionTarget = reloadSection
   }
-
+  
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
     if isHeaderCell(indexPath) {
       return transmissionTargetSelectorCell!
@@ -24,11 +29,11 @@ class TargetPropertiesTableSection : PropertiesTableSection {
       return super.tableView(tableView, cellForRowAt: indexPath)
     }
   }
-
+  
   override func numberOfCustomHeaderCells() -> Int {
     return 1
   }
-
+  
   override func propertyKeyChanged(sender: UITextField!) {
     let selectedTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
     let arrayIndex = getCellRow(forTextField: sender) - propertyCellOffset()
@@ -39,7 +44,7 @@ class TargetPropertiesTableSection : PropertiesTableSection {
     target.propertyConfigurator.setEventPropertyString(currentPropertyValue, forKey: sender.text!)
     targetProperties[selectedTarget!]![arrayIndex].0 = sender.text!
   }
-
+  
   override func propertyValueChanged(sender: UITextField!) {
     let selectedTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
     let arrayIndex = getCellRow(forTextField: sender) - propertyCellOffset()
@@ -48,17 +53,17 @@ class TargetPropertiesTableSection : PropertiesTableSection {
     target.propertyConfigurator.setEventPropertyString(sender.text!, forKey: currentPropertyKey)
     targetProperties[selectedTarget!]![arrayIndex].1 = sender.text!
   }
-
+  
   override func propertyAtRow(row: Int) -> (String, String) {
     let selectedTarget = transmissionTargetSelectorCell!.selectedTransmissionTarget()
     return targetProperties[selectedTarget!]![row - propertyCellOffset()]
   }
-
+  
   override func getPropertyCount() -> Int {
     let selectedTarget = transmissionTargetSelectorCell!.selectedTransmissionTarget()
     return (targetProperties[selectedTarget!]!.count)
   }
-
+  
   override func removeProperty(atRow row: Int) {
     let selectedTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
     let arrayIndex = row - propertyCellOffset()
@@ -67,18 +72,18 @@ class TargetPropertiesTableSection : PropertiesTableSection {
     target.propertyConfigurator.removeEventPropertyforKey(key)
     targetProperties[selectedTarget!]!.remove(at: arrayIndex)
   }
-
+  
   override func addProperty(property: (String, String)) {
     let selectedTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
     targetProperties[selectedTarget!]!.insert(property, at: 0)
     let target = MSTransmissionTargets.shared.transmissionTargets[selectedTarget!]!
     target.propertyConfigurator.setEventPropertyString(property.1, forKey: property.0)
   }
-
+  
   func isHeaderCell(_ indexPath: IndexPath) -> Bool {
     return !(isPropertyRow(indexPath) || isInsertRow(indexPath))
   }
-
+  
   func reloadSection() {
     tableView.reloadSections([tableSection], with: .none)
   }

--- a/TestApps/Sasquatch/SasquatchObjC/AppDelegate.h
+++ b/TestApps/Sasquatch/SasquatchObjC/AppDelegate.h
@@ -2,6 +2,6 @@
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (strong, nonatomic) UIWindow *window;
+@property(strong, nonatomic) UIWindow *window;
 
 @end

--- a/TestApps/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/TestApps/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -38,9 +38,15 @@ enum { START_FROM_APP = 0, START_FROM_LIBRARY, START_FROM_BOTH };
   BOOL useOneCollector = [[NSUserDefaults standardUserDefaults] boolForKey:kMSOneCollectorEnabledKey];
   long startTarget = [[NSUserDefaults standardUserDefaults] integerForKey:kMSStartTargetKey];
 
+#if GCC_PREPROCESSOR_MACRO_PUPPET
+  NSString *secretString = useOneCollector ? @"target=09855e8251634d618c1d8ef3325e3530-8c17b252-f3c1-41e1-af64-"
+                                             @"78a72d13ac22-6684;appsecret=7dfb022a-17b5-4d4a-9c75-12bc3ef5e6b7"
+                                           : @"7dfb022a-17b5-4d4a-9c75-12bc3ef5e6b7";
+#else
   NSString *secretString = useOneCollector ? @"target=5a06bf4972a44a059d59c757e6d0b595-cb71af5d-2d79-4fb4-b969-"
                                              @"01840f1543e9-6845;appsecret=3ccfe7f5-ec01-4de5-883c-f563bbbe147a"
                                            : @"3ccfe7f5-ec01-4de5-883c-f563bbbe147a";
+#endif
 
   switch (startTarget) {
   case START_FROM_LIBRARY:
@@ -146,8 +152,8 @@ enum { START_FROM_APP = 0, START_FROM_LIBRARY, START_FROM_BOTH };
 }
 
 - (void)setAppCenterDelegate {
-   AppCenterDelegateObjC *appCenterDel = [[AppCenterDelegateObjC alloc] init];
-  for (UIViewController *controller in [(UITabBarController*)([[self window] rootViewController]) viewControllers]) {
+  AppCenterDelegateObjC *appCenterDel = [[AppCenterDelegateObjC alloc] init];
+  for (UIViewController *controller in [(UITabBarController *)([[self window] rootViewController])viewControllers]) {
     id<AppCenterProtocol> sasquatchController = (id<AppCenterProtocol>)controller;
     sasquatchController.appCenter = appCenterDel;
   }


### PR DESCRIPTION
We want to have SasquatchPuppet's events etc go to it's own app in AppCenter. Previously, it'd use SasquatchObjC's secret/token, making testing a little harder.