### PR TITLE
Fix/fix tests ios 9

### DIFF
--- a/AppCenter/AppCenter.xcodeproj/project.pbxproj
+++ b/AppCenter/AppCenter.xcodeproj/project.pbxproj
@@ -389,6 +389,9 @@
 		38E1B67A1DDE3FDF000EFED1 /* MSAppCenterPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 38E1B6791DDE3FDF000EFED1 /* MSAppCenterPrivate.h */; };
 		38F1944E1DADB93100D3E0FE /* MSHttpIngestionPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 38F1944D1DADB93100D3E0FE /* MSHttpIngestionPrivate.h */; };
 		38FD798F1EB7B0B800DE2FB3 /* MSAppCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E0401551D1C9AAA0051BCFA /* MSAppCenter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		38FDFF6A2109409900E17269 /* MSMockKeychainUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 38FDFF692109409900E17269 /* MSMockKeychainUtil.m */; };
+		38FDFF6B2109409900E17269 /* MSMockKeychainUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 38FDFF692109409900E17269 /* MSMockKeychainUtil.m */; };
+		38FDFF6C2109409900E17269 /* MSMockKeychainUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 38FDFF692109409900E17269 /* MSMockKeychainUtil.m */; };
 		58603633B718B7A2702C23CB /* MSAbstractLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 58603EA088552D6FBB8EBE6C /* MSAbstractLogTests.m */; };
 		58603867BA3B4B1CB87D0E5D /* MSAbstractLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 58603EA088552D6FBB8EBE6C /* MSAbstractLogTests.m */; };
 		5C7877921EA0CFF3002263CC /* MSLogDBStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C7877911EA0CFF3002263CC /* MSLogDBStorageTests.m */; };
@@ -811,6 +814,8 @@
 		38C633C81FDF163D005F40C9 /* MSAppDelegateUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSAppDelegateUtil.h; sourceTree = "<group>"; };
 		38E1B6791DDE3FDF000EFED1 /* MSAppCenterPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSAppCenterPrivate.h; sourceTree = "<group>"; };
 		38F1944D1DADB93100D3E0FE /* MSHttpIngestionPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSHttpIngestionPrivate.h; sourceTree = "<group>"; };
+		38FDFF682109409900E17269 /* MSMockKeychainUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSMockKeychainUtil.h; sourceTree = "<group>"; };
+		38FDFF692109409900E17269 /* MSMockKeychainUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSMockKeychainUtil.m; sourceTree = "<group>"; };
 		58603EA088552D6FBB8EBE6C /* MSAbstractLogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSAbstractLogTests.m; sourceTree = "<group>"; };
 		5C7877911EA0CFF3002263CC /* MSLogDBStorageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSLogDBStorageTests.m; sourceTree = "<group>"; };
 		6E0401031D1C98220051BCFA /* libAppCenter.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAppCenter.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1359,6 +1364,8 @@
 				386E8D911E25932100EECF0F /* MSHttpTestUtil.m */,
 				E88D17041D35B6B500A5EA57 /* MSMockLog.h */,
 				E88D17051D35B6B500A5EA57 /* MSMockLog.m */,
+				38FDFF682109409900E17269 /* MSMockKeychainUtil.h */,
+				38FDFF692109409900E17269 /* MSMockKeychainUtil.m */,
 				D377A30B1E83A04600B2C97A /* MSMockUserDefaults.h */,
 				D377A30C1E83A05900B2C97A /* MSMockUserDefaults.m */,
 				805F3F691F209C8A00B489E4 /* MSMockService.h */,
@@ -2138,6 +2145,7 @@
 				049378431FE4914E000ADBAF /* MSSessionContextTests.m in Sources */,
 				38AE131320C1B54000FAB2AD /* MSModelTestsUtililty.m in Sources */,
 				0446DF041F3B864600C8E338 /* MSMockUserDefaults.m in Sources */,
+				38FDFF6C2109409900E17269 /* MSMockKeychainUtil.m in Sources */,
 				0446DF051F3B864600C8E338 /* MSLogWithPropertiesTests.m in Sources */,
 				0446DF061F3B864600C8E338 /* MSDeviceLogTests.m in Sources */,
 				E7D23C7120B6412300A47D62 /* MSCSExtensionsTests.m in Sources */,
@@ -2178,6 +2186,7 @@
 				E7D23C7020B6412300A47D62 /* MSCSExtensionsTests.m in Sources */,
 				04A140871ECE63BB001CEE94 /* MSServiceAbstractTests.m in Sources */,
 				0446DF311F3B86FE00C8E338 /* MSStoragePerfomanceTests.m in Sources */,
+				38FDFF6B2109409900E17269 /* MSMockKeychainUtil.m in Sources */,
 				04A79A4A20C6F63E006D0072 /* MSOneCollectorIngestionTests.m in Sources */,
 				046AEAD41ECA562A00CBE511 /* MSMockUserDefaults.m in Sources */,
 				046AEAD71ECA562A00CBE511 /* MSLogWithPropertiesTests.m in Sources */,
@@ -2355,6 +2364,7 @@
 				380A4DCB1DD6908A00E99219 /* MSUtilityTests.m in Sources */,
 				04A79A4920C6F63C006D0072 /* MSOneCollectorIngestionTests.m in Sources */,
 				3849BA7E1EF3489D0072E3E0 /* MSDBStorageTests.m in Sources */,
+				38FDFF6A2109409900E17269 /* MSMockKeychainUtil.m in Sources */,
 				35C0E3CD1FD6146A004E841E /* MSMockSecondService.m in Sources */,
 				E829E4231D25C8BA00F19DA1 /* MSAppCenterIngestionTests.m in Sources */,
 				805F3F6B1F209C9D00B489E4 /* MSMockService.m in Sources */,

--- a/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
+++ b/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
@@ -15,9 +15,9 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
 }
 
 + (BOOL)storeString:(NSString *)string forKey:(NSString *)key withServiceName:(NSString *)serviceName {
-  NSMutableDictionary *item = [MSKeychainUtil generateItem:key withServiceName:serviceName];
-  item[(__bridge id)kSecValueData] = [string dataUsingEncoding:NSUTF8StringEncoding];
-  OSStatus status = SecItemAdd((__bridge CFDictionaryRef)item, nil);
+  NSMutableDictionary *attributes = [MSKeychainUtil generateItem:key withServiceName:serviceName];
+  attributes[(__bridge id)kSecValueData] = [string dataUsingEncoding:NSUTF8StringEncoding];
+  OSStatus status = [self addSecItem:attributes];
   return status == noErr;
 }
 
@@ -28,8 +28,8 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
 + (NSString *)deleteStringForKey:(NSString *)key withServiceName:(NSString *)serviceName {
   NSString *string = [MSKeychainUtil stringForKey:key];
   if (string) {
-    NSMutableDictionary *item = [MSKeychainUtil generateItem:key withServiceName:serviceName];
-    OSStatus status = SecItemDelete((__bridge CFDictionaryRef)item);
+    NSMutableDictionary *query = [MSKeychainUtil generateItem:key withServiceName:serviceName];
+    OSStatus status = [self deleteSecItem:query];
     if (status == noErr) {
       return string;
     }
@@ -42,13 +42,13 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
 }
 
 + (NSString *)stringForKey:(NSString *)key withServiceName:(NSString *)serviceName {
-  NSMutableDictionary *item = [MSKeychainUtil generateItem:key withServiceName:serviceName];
-  item[(__bridge id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
-  item[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
-  CFTypeRef data = nil;
-  OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)item, &data);
+  NSMutableDictionary *query = [MSKeychainUtil generateItem:key withServiceName:serviceName];
+  query[(__bridge id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
+  query[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
+  CFTypeRef result = nil;
+  OSStatus status = [self secItemCopyMatchingQuery:query result:&result];
   if (status == noErr) {
-    return [[NSString alloc] initWithData:(__bridge_transfer NSData *)data encoding:NSUTF8StringEncoding];
+    return [[NSString alloc] initWithData:(__bridge_transfer NSData *)result encoding:NSUTF8StringEncoding];
   }
   return nil;
 }
@@ -58,10 +58,10 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
 }
 
 + (BOOL)clear {
-  NSMutableDictionary *item = [NSMutableDictionary new];
-  item[(__bridge id)kSecClass] = (__bridge id)kSecClassGenericPassword;
-  item[(__bridge id)kSecAttrService] = AppCenterKeychainServiceName(kMSServiceSuffix);
-  OSStatus status = SecItemDelete((__bridge CFDictionaryRef)item);
+  NSMutableDictionary *query = [NSMutableDictionary new];
+  query[(__bridge id)kSecClass] = (__bridge id)kSecClassGenericPassword;
+  query[(__bridge id)kSecAttrService] = AppCenterKeychainServiceName(kMSServiceSuffix);
+  OSStatus status = [self deleteSecItem:query];
   return status == noErr;
 }
 
@@ -71,6 +71,21 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
   item[(__bridge id)kSecAttrService] = serviceName;
   item[(__bridge id)kSecAttrAccount] = key;
   return item;
+}
+
+#pragma mark - Keychain wrapper
+
++ (OSStatus)deleteSecItem:(NSMutableDictionary *)query {
+  return SecItemDelete((__bridge CFDictionaryRef)query);
+}
+
++ (OSStatus)addSecItem:(NSMutableDictionary *)attributes {
+  return SecItemAdd((__bridge CFDictionaryRef)attributes, nil);
+}
+
++ (OSStatus)secItemCopyMatchingQuery:(NSMutableDictionary *)query
+                              result:(CFTypeRef *__nullable CF_RETURNS_RETAINED)result {
+  return SecItemCopyMatching((__bridge CFDictionaryRef)query, result);
 }
 
 @end

--- a/AppCenter/AppCenter/Internals/Util/MSKeychainUtilPrivate.h
+++ b/AppCenter/AppCenter/Internals/Util/MSKeychainUtilPrivate.h
@@ -45,6 +45,34 @@ static NSString *const kMSServiceSuffix = @"AppCenter";
  */
 + (NSString *_Nullable)stringForKey:(NSString *)key withServiceName:(NSString *)serviceName;
 
+/**
+ * Deletes items that match a search query.
+ *
+ * @param query A dictionary that describes the search for the keychain items you want to delete.
+ *
+ * @return A result code for the deletion.
+ */
++ (OSStatus)deleteSecItem:(NSMutableDictionary *)query;
+
+/**
+ * Adds one or more items to a keychain.
+ *
+ * @param attributes A dictionary that describes the item to add.
+ *
+ * @return A result code for the addition.
+ */
++ (OSStatus)addSecItem:(NSMutableDictionary *)attributes;
+
+/**
+ * Returns one or more keychain items that match a search query, or copies attributes of specific keychain items.
+ *
+ * @param query A dictionary that describes the search.
+ * @param result A reference to the found items.
+ *
+ * @return A result code for the addition.
+ */
++ (OSStatus)secItemCopyMatchingQuery:(NSMutableDictionary *)query
+                              result:(CFTypeRef *__nullable CF_RETURNS_RETAINED)result;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenter/AppCenterTests/MSEncrypterTests.m
+++ b/AppCenter/AppCenterTests/MSEncrypterTests.m
@@ -1,9 +1,11 @@
 #import "MSEncrypterPrivate.h"
+#import "MSMockKeychainUtil.h"
 #import "MSTestFrameworks.h"
 
 @interface MSEncrypterTests : XCTestCase
 
 @property(nonatomic) NSString *keyTag;
+@property(nonatomic) id keychainUtilMock;
 
 @end
 
@@ -11,10 +13,12 @@
 
 - (void)setUp {
   [super setUp];
+  self.keychainUtilMock = [MSMockKeychainUtil new];
   self.keyTag = @"kMSTestEncryptionKeyTag";
 }
 
 - (void)tearDown {
+  [self.keychainUtilMock stopMocking];
   [MSEncrypter deleteKeyWithTag:self.keyTag];
 }
 

--- a/AppCenter/AppCenterTests/MSLogDBStorageTests.m
+++ b/AppCenter/AppCenterTests/MSLogDBStorageTests.m
@@ -1,7 +1,6 @@
 #import "MSAbstractLogInternal.h"
 #import "MSCommonSchemaLog.h"
 #import "MSDBStoragePrivate.h"
-#import "MSKeychainUtil.h"
 #import "MSLogDBStoragePrivate.h"
 #import "MSTestFrameworks.h"
 #import "MSUtility.h"
@@ -502,29 +501,30 @@ static NSString *const kMSAnotherTestGroupId = @"AnotherGroupId";
 }
 
 - (void)testMigration {
-  
+
   // If
   [self.sut deleteDatabase];
-  
+
   // Create old version db.
   // DO NOT CHANGE. THIS IS ALREADY PUBLISHED SCHEMA.
   MSDBSchema *schema0 = @{
-   kMSLogTableName : @[
-     @{kMSIdColumnName : @[ kMSSQLiteTypeInteger, kMSSQLiteConstraintPrimaryKey, kMSSQLiteConstraintAutoincrement ]},
-     @{kMSGroupIdColumnName : @[ kMSSQLiteTypeText, kMSSQLiteConstraintNotNull ]},
-     @{kMSLogColumnName : @[ kMSSQLiteTypeText, kMSSQLiteConstraintNotNull ]}
-   ]
+    kMSLogTableName : @[
+      @{kMSIdColumnName : @[ kMSSQLiteTypeInteger, kMSSQLiteConstraintPrimaryKey, kMSSQLiteConstraintAutoincrement ]},
+      @{kMSGroupIdColumnName : @[ kMSSQLiteTypeText, kMSSQLiteConstraintNotNull ]},
+      @{kMSLogColumnName : @[ kMSSQLiteTypeText, kMSSQLiteConstraintNotNull ]}
+    ]
   };
-  MSDBStorage * storage0 = [[MSDBStorage alloc] initWithSchema:schema0 version:0 filename:kMSDBFileName];
+  MSDBStorage *storage0 = [[MSDBStorage alloc] initWithSchema:schema0 version:0 filename:kMSDBFileName];
   [self generateAndSaveLogsWithCount:10 groupId:kMSTestGroupId storage:storage0];
-  
+
   // When
   self.sut = [[MSLogDBStorage alloc] initWithCapacity:kMSTestMaxCapacity];
-  
+
   // Then
   assertThatInt([self loadLogsWhere:nil].count, equalToUnsignedInt(10));
-  NSString *currentTable = [self.sut executeSelectionQuery:
-      [NSString stringWithFormat:@"SELECT sql FROM sqlite_master WHERE name='%@'", kMSLogTableName]][0][0];
+  NSString *currentTable =
+      [self.sut executeSelectionQuery:[NSString stringWithFormat:@"SELECT sql FROM sqlite_master WHERE name='%@'",
+                                                                 kMSLogTableName]][0][0];
   assertThat(currentTable, is(@"CREATE TABLE \"logs\" ("
                               @"\"id\" INTEGER PRIMARY KEY AUTOINCREMENT, "
                               @"\"groupId\" TEXT NOT NULL, "
@@ -536,7 +536,9 @@ static NSString *const kMSAnotherTestGroupId = @"AnotherGroupId";
   return [self generateAndSaveLogsWithCount:count groupId:groupId storage:self.sut];
 }
 
-- (NSArray<id<MSLog>> *)generateAndSaveLogsWithCount:(NSUInteger)count groupId:(NSString *)groupId storage:(MSDBStorage *)storage {
+- (NSArray<id<MSLog>> *)generateAndSaveLogsWithCount:(NSUInteger)count
+                                             groupId:(NSString *)groupId
+                                             storage:(MSDBStorage *)storage {
   NSMutableArray<id<MSLog>> *logs = [NSMutableArray arrayWithCapacity:count];
   NSUInteger truelogCount;
   for (NSUInteger i = 0; i < count; ++i) {
@@ -554,7 +556,7 @@ static NSString *const kMSAnotherTestGroupId = @"AnotherGroupId";
   // Check the insertion worked.
   truelogCount =
       [storage countEntriesForTable:kMSLogTableName
-                           condition:[NSString stringWithFormat:@"\"%@\" = '%@'", kMSGroupIdColumnName, groupId]];
+                          condition:[NSString stringWithFormat:@"\"%@\" = '%@'", kMSGroupIdColumnName, groupId]];
   assertThatUnsignedInteger(truelogCount, equalToUnsignedInteger(count));
   return logs;
 }

--- a/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.h
+++ b/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.h
@@ -1,0 +1,6 @@
+#import <UIKit/UIKit.h>
+#import "MSKeychainUtil.h"
+
+@interface MSMockKeychainUtil : MSKeychainUtil
+
+@end

--- a/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.h
+++ b/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.h
@@ -1,4 +1,3 @@
-#import <UIKit/UIKit.h>
 #import "MSKeychainUtil.h"
 
 @interface MSMockKeychainUtil : MSKeychainUtil

--- a/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.m
+++ b/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.m
@@ -1,0 +1,82 @@
+#import "MSMockKeychainUtil.h"
+#import "MSTestFrameworks.h"
+
+static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, NSString *> *> *dictionary;
+static NSString *kMSDefaultServiceName = @"DefaultServiceName";
+
+@interface MSMockKeychainUtil ()
+@property(nonatomic) id mockKeychainUtil;
+@end
+
+@implementation MSMockKeychainUtil
+
++ (void)load {
+  dictionary = [NSMutableDictionary new];
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+
+    // Mock MSUserDefaults shared method to return this instance.
+    _mockKeychainUtil = OCMClassMock([MSKeychainUtil class]);
+    OCMStub([_mockKeychainUtil storeString:[OCMArg any] forKey:[OCMArg any]])
+        .andCall([self class], @selector(storeString:forKey:));
+    OCMStub([_mockKeychainUtil storeString:[OCMArg any] forKey:[OCMArg any] withServiceName:[OCMArg any]])
+        .andCall([self class], @selector(storeString:forKey:withServiceName:));
+    OCMStub([_mockKeychainUtil deleteStringForKey:[OCMArg any]]).andCall([self class], @selector(deleteStringForKey:));
+    OCMStub([_mockKeychainUtil deleteStringForKey:[OCMArg any] withServiceName:[OCMArg any]])
+        .andCall([self class], @selector(deleteStringForKey:withServiceName:));
+    OCMStub([_mockKeychainUtil stringForKey:[OCMArg any]]).andCall([self class], @selector(stringForKey:));
+    OCMStub([_mockKeychainUtil stringForKey:[OCMArg any] withServiceName:[OCMArg any]])
+        .andCall([self class], @selector(stringForKey:withServiceName:));
+    OCMStub([_mockKeychainUtil clear]).andCall([self class], @selector(clear));
+  }
+  return self;
+}
+
++ (BOOL)storeString:(NSString *)string forKey:(NSString *)key {
+  return [self storeString:string forKey:key withServiceName:kMSDefaultServiceName];
+}
+
++ (BOOL)storeString:(NSString *)string forKey:(NSString *)key withServiceName:(NSString *)serviceName {
+
+  // Don't store nil objects.
+  if (!string) {
+    return NO;
+  }
+  if (!dictionary[serviceName]) {
+    dictionary[serviceName] = [NSMutableDictionary new];
+  }
+  dictionary[serviceName][key] = string;
+  return YES;
+}
+
++ (NSString *_Nullable)deleteStringForKey:(NSString *)key {
+  return [self deleteStringForKey:key withServiceName:kMSDefaultServiceName];
+}
+
++ (NSString *_Nullable)deleteStringForKey:(NSString *)key withServiceName:(NSString *)serviceName {
+  [dictionary[serviceName] removeObjectForKey:key];
+  return key;
+}
+
++ (NSString *_Nullable)stringForKey:(NSString *)key {
+  return [self stringForKey:key withServiceName:kMSDefaultServiceName];
+}
+
++ (NSString *_Nullable)stringForKey:(NSString *)key withServiceName:(NSString *)serviceName {
+  return dictionary[serviceName][key];
+}
+
++ (BOOL)clear {
+  [dictionary[kMSDefaultServiceName] removeAllObjects];
+  return YES;
+}
+
+- (void)stopMocking {
+  [dictionary removeAllObjects];
+  [self.mockKeychainUtil stopMocking];
+}
+
+@end

--- a/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
+++ b/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		383A2FE61EBA30B300817742 /* MSDistributeAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 383A2FE51EBA30B300817742 /* MSDistributeAppDelegate.m */; };
 		384135BE1FD99B5400FC7836 /* MSDistributeDataMigration.h in Headers */ = {isa = PBXBuildFile; fileRef = 384135BD1FD99B5400FC7836 /* MSDistributeDataMigration.h */; };
 		384135C01FD99EB400FC7836 /* MSDistributeDataMigration.m in Sources */ = {isa = PBXBuildFile; fileRef = 384135BF1FD99EB400FC7836 /* MSDistributeDataMigration.m */; };
+		387CC631210A9D9C002BA068 /* MSMockKeychainUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 387CC630210A9D9C002BA068 /* MSMockKeychainUtil.m */; };
 		388B559B1E64B3FD00E4F1D7 /* MSBasicMachOParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 388B55991E64B3FD00E4F1D7 /* MSBasicMachOParser.m */; };
 		388B559C1E64B3FD00E4F1D7 /* MSBasicMachOParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 388B559A1E64B3FD00E4F1D7 /* MSBasicMachOParser.h */; };
 		389638A41E79F59D007C3809 /* MSDistributeTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 389638A31E79F59D007C3809 /* MSDistributeTestUtil.m */; };
@@ -195,6 +196,8 @@
 		384135BD1FD99B5400FC7836 /* MSDistributeDataMigration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSDistributeDataMigration.h; sourceTree = "<group>"; };
 		384135BF1FD99EB400FC7836 /* MSDistributeDataMigration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDistributeDataMigration.m; sourceTree = "<group>"; };
 		386A69EF1FD88A9B0057B316 /* MSDistributeDataMigrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSDistributeDataMigrationTests.m; sourceTree = "<group>"; };
+		387CC62F210A9D9C002BA068 /* MSMockKeychainUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSMockKeychainUtil.h; path = ../../../AppCenter/AppCenterTests/Util/MSMockKeychainUtil.h; sourceTree = "<group>"; };
+		387CC630210A9D9C002BA068 /* MSMockKeychainUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MSMockKeychainUtil.m; path = ../../../AppCenter/AppCenterTests/Util/MSMockKeychainUtil.m; sourceTree = "<group>"; };
 		388B55991E64B3FD00E4F1D7 /* MSBasicMachOParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MSBasicMachOParser.m; path = ../MSBasicMachOParser.m; sourceTree = "<group>"; };
 		388B559A1E64B3FD00E4F1D7 /* MSBasicMachOParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSBasicMachOParser.h; path = ../MSBasicMachOParser.h; sourceTree = "<group>"; };
 		389638A31E79F59D007C3809 /* MSDistributeTestUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDistributeTestUtil.m; sourceTree = "<group>"; };
@@ -462,6 +465,8 @@
 		389638A21E79F557007C3809 /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				387CC62F210A9D9C002BA068 /* MSMockKeychainUtil.h */,
+				387CC630210A9D9C002BA068 /* MSMockKeychainUtil.m */,
 				F8BEA3CC1FBB0BDE00D4DE37 /* MSHttpTestUtil.h */,
 				F8BEA3CB1FBB0BDE00D4DE37 /* MSHttpTestUtil.m */,
 				389638A51E79F60F007C3809 /* MSDistributeTestUtil.h */,
@@ -762,6 +767,7 @@
 				040AF0251E523B80005C1174 /* MSReleaseDetailsTests.m in Sources */,
 				B20DE7B71E5F97330023075C /* MSDistributeUtilTests.m in Sources */,
 				9E8E3A39203E68B4001A23FD /* MSDistributionStartSessionLogTest.m in Sources */,
+				387CC631210A9D9C002BA068 /* MSMockKeychainUtil.m in Sources */,
 				040AF02A1E52748D005C1174 /* MSDistributeIngestionTests.m in Sources */,
 				F8BEA3CF1FBB0BE400D4DE37 /* MSHttpTestUtil.m in Sources */,
 				04DC2ECB1E78A3E3003F23B5 /* MSErrorDetailsTests.m in Sources */,

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeDataMigrationTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeDataMigrationTests.m
@@ -1,11 +1,12 @@
 #import "MSDistributeInternal.h"
 #import "MSDistributeDataMigration.h"
 #import "MSKeychainUtilPrivate.h"
+#import "MSMockKeychainUtil.h"
 #import "MSTestFrameworks.h"
 #import "MSUtility.h"
 
 @interface MSKeychainUtilDistributeMigrationTests : XCTestCase
-
+@property(nonatomic) id keychainUtilMock;
 @end
 
 @implementation MSKeychainUtilDistributeMigrationTests
@@ -14,12 +15,12 @@
 
 - (void)setUp {
   [super setUp];
-  [MSKeychainUtil clear];
+  self.keychainUtilMock = [MSMockKeychainUtil new];
 }
 
 - (void)tearDown {
   [super tearDown];
-  [MSKeychainUtil clear];
+  [self.keychainUtilMock stopMocking];
 }
 
 #if !TARGET_OS_TV

--- a/AppCenterPush/AppCenterPushTests/MSAppDelegateForwarderTests.m
+++ b/AppCenterPush/AppCenterPushTests/MSAppDelegateForwarderTests.m
@@ -884,9 +884,12 @@
   [self waitForExpectations:@[ customCalledExpectation1, customCalledExpectation2, originalCalledExpectation ]
                     timeout:1000];
   
-  // In the end the completion handler must be called with the forwarded value.
-  assertThatBool(isExpectedHandlerCalled, isTrue());
-  assertThatInteger(forwardedFetchResult, equalToInteger(expectedFetchResult));
+  [self waitForExpectationsWithTimeout:1000 handler:^(__unused NSError *error) {
+    
+    // In the end the completion handler must be called with the forwarded value.
+    assertThatBool(isExpectedHandlerCalled, isTrue());
+    assertThatInteger(forwardedFetchResult, equalToInteger(expectedFetchResult));
+  }];
 }
 
 #endif


### PR DESCRIPTION
Fix tests failing because Apple keychain wouldn't work for unit tests in iOS 10+.

KeychainUtil is now mocked for unit tests.