### PR TITLE
Hide backing property for addAuthenticationProvider-API

### DIFF
--- a/AppCenterAnalytics/AppCenterAnalytics/Internals/MSAnalyticsTransmissionTargetPrivate.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/Internals/MSAnalyticsTransmissionTargetPrivate.h
@@ -31,6 +31,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, readonly) id<MSChannelGroupProtocol> channelGroup;
 
+/**
+ * Authentication provider.
+ */
+@property(class, nonatomic) MSAnalyticsAuthenticationProvider* authenticationProvider;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
@@ -12,11 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, readonly) MSPropertyConfigurator *propertyConfigurator;
 
-/**
- * Authentication provider.
- */
-@property(class, nonatomic, setter=addAuthenticationProvider:) MSAnalyticsAuthenticationProvider* authenticationProvider;
-
 + (void)addAuthenticationProvider:(MSAnalyticsAuthenticationProvider *)authenticatioProvider;
 
 /**

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, readonly) MSPropertyConfigurator *propertyConfigurator;
 
-+ (void)addAuthenticationProvider:(MSAnalyticsAuthenticationProvider *)authenticatioProvider;
++ (void)addAuthenticationProvider:(MSAnalyticsAuthenticationProvider *)authenticatioProvider NS_SWIFT_NAME(addAuthenticationProvider(authenticationProvider:));
 
 /**
  * Track an event.

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
@@ -15,7 +15,7 @@ static id _authenticationProvider;
 - (instancetype)
 initWithTransmissionTargetToken:(NSString *)token
                    parentTarget:(MSAnalyticsTransmissionTarget *)parentTarget
-                   channelGroup:(id <MSChannelGroupProtocol>)channelGroup {
+                   channelGroup:(id<MSChannelGroupProtocol>)channelGroup {
   if ((self = [super init])) {
     _propertyConfigurator =
         [[MSPropertyConfigurator alloc] initWithTransmissionTarget:self];
@@ -41,21 +41,15 @@ initWithTransmissionTargetToken:(NSString *)token
   return self;
 }
 
-+ (MSAnalyticsAuthenticationProvider *)authenticationProvider {
-  @synchronized (self) {
-    return _authenticationProvider;
-  }
-}
-
 + (void)addAuthenticationProvider:
     (MSAnalyticsAuthenticationProvider *)authenticationProvider {
-  @synchronized (self) {
+  @synchronized(self) {
 
     /*
      * No need to validate the authentication provider's properties as they are
      * required for initialization and can't be null.
      */
-    _authenticationProvider = authenticationProvider;
+    self.authenticationProvider = authenticationProvider;
 
     /* Request token now. */
     [authenticationProvider acquireTokenAsync];
@@ -91,15 +85,15 @@ initWithTransmissionTargetToken:(NSString *)token
   // Override properties.
   if (properties) {
     [mergedProperties
-        addEntriesFromDictionary:(NSDictionary *_Nonnull) properties];
+        addEntriesFromDictionary:(NSDictionary * _Nonnull)properties];
   } else if ([mergedProperties count] == 0) {
 
     // Set nil for the properties to pass nil to trackEvent.
     mergedProperties = nil;
   }
   [MSAnalytics trackEvent:eventName
-           withProperties:mergedProperties
-    forTransmissionTarget:self];
+             withProperties:mergedProperties
+      forTransmissionTarget:self];
 }
 
 - (MSAnalyticsTransmissionTarget *)transmissionTargetForToken:
@@ -119,7 +113,7 @@ initWithTransmissionTargetToken:(NSString *)token
 }
 
 - (BOOL)isEnabled {
-  @synchronized ([MSAnalytics sharedInstance]) {
+  @synchronized([MSAnalytics sharedInstance]) {
 
     // Get isEnabled value from persistence.
     // No need to cache the value in a property, user settings already have
@@ -133,7 +127,7 @@ initWithTransmissionTargetToken:(NSString *)token
 }
 
 - (void)setEnabled:(BOOL)isEnabled {
-  @synchronized ([MSAnalytics sharedInstance]) {
+  @synchronized([MSAnalytics sharedInstance]) {
     if (self.isEnabled != isEnabled) {
 
       // Don't enable if the immediate parent is disabled.
@@ -157,23 +151,23 @@ initWithTransmissionTargetToken:(NSString *)token
 
 #pragma mark - ChannelDelegate callbacks
 
-- (void)channel:(id <MSChannelProtocol>)__unused channel
-     prepareLog:(id <MSLog>)log {
+- (void)channel:(id<MSChannelProtocol>)__unused channel
+     prepareLog:(id<MSLog>)log {
 
   /*
    * Only set ticketKey for owned target. Not strictly necessary but this avoids
    * setting the ticketKeyHash multiple times for a log.
    */
   if (![log.transmissionTargetTokens
-      containsObject:self.transmissionTargetToken]) {
+          containsObject:self.transmissionTargetToken]) {
     return;
   }
   if ([log isKindOfClass:[MSCommonSchemaLog class]] && [self isEnabled]) {
     if (MSAnalyticsTransmissionTarget.authenticationProvider) {
       NSString *ticketKeyHash =
           MSAnalyticsTransmissionTarget.authenticationProvider.ticketKeyHash;
-      ((MSCommonSchemaLog *) log).ext.protocolExt.ticketKeys =
-          @[ticketKeyHash];
+      ((MSCommonSchemaLog *)log).ext.protocolExt.ticketKeys =
+          @[ ticketKeyHash ];
       [MSAnalyticsTransmissionTarget.authenticationProvider checkTokenExpiry];
     }
   }
@@ -181,9 +175,22 @@ initWithTransmissionTargetToken:(NSString *)token
 
 #pragma mark - Private methods
 
++ (MSAnalyticsAuthenticationProvider *)authenticationProvider {
+  @synchronized(self) {
+    return _authenticationProvider;
+  }
+}
+
++ (void)setAuthenticationProvider:
+    (MSAnalyticsAuthenticationProvider *)authenticationProvider {
+  @synchronized(self) {
+    _authenticationProvider = authenticationProvider;
+  }
+}
+
 - (void)mergeEventPropertiesWith:
     (NSMutableDictionary<NSString *, NSString *> *)mergedProperties {
-  @synchronized ([MSAnalytics sharedInstance]) {
+  @synchronized([MSAnalytics sharedInstance]) {
     for (NSString *key in self.propertyConfigurator.eventProperties) {
       if ([mergedProperties objectForKey:key] == nil) {
         NSString *value =
@@ -202,7 +209,7 @@ initWithTransmissionTargetToken:(NSString *)token
  */
 - (BOOL)isImmediateParent {
   return self.parentTarget ? self.parentTarget.isEnabled
-      : [MSAnalytics isEnabled];
+                           : [MSAnalytics isEnabled];
 }
 
 @end

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
@@ -44,6 +44,11 @@ initWithTransmissionTargetToken:(NSString *)token
 + (void)addAuthenticationProvider:
     (MSAnalyticsAuthenticationProvider *)authenticationProvider {
   @synchronized(self) {
+    if (!authenticationProvider) {
+      MSLogError([MSAnalytics logTag],
+                 @"Authentication provider may not be null.");
+      return;
+    }
 
     /*
      * No need to validate the authentication provider's properties as they are
@@ -51,8 +56,8 @@ initWithTransmissionTargetToken:(NSString *)token
      */
     self.authenticationProvider = authenticationProvider;
 
-    /* Request token now. */
-    [authenticationProvider acquireTokenAsync];
+    // Request token now.
+    [self.authenticationProvider acquireTokenAsync];
   }
 }
 

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
@@ -39,6 +39,7 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
 - (void)tearDown {
   [self.settingsMock stopMocking];
   [self.analyticsClassMock stopMocking];
+  MSAnalyticsTransmissionTarget.authenticationProvider = nil;
   [super tearDown];
 }
 
@@ -882,12 +883,6 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
   
   // Then
   XCTAssertEqual(provider, MSAnalyticsTransmissionTarget.authenticationProvider);
-  
-  // When
-  [MSAnalyticsTransmissionTarget addAuthenticationProvider:nil];
-  
-  // Then
-  XCTAssertNil(MSAnalyticsTransmissionTarget.authenticationProvider);
 }
 
 @end

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
@@ -1,3 +1,4 @@
+#import "MSAnalyticsAuthenticationProviderInternal.h"
 #import "MSAnalyticsInternal.h"
 #import "MSAnalyticsPrivate.h"
 #import "MSAnalyticsTransmissionTargetInternal.h"
@@ -46,43 +47,44 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
 - (void)testInitialization {
 
   // When
-  MSAnalyticsTransmissionTarget *transmissionTarget =
+  MSAnalyticsTransmissionTarget *sut =
       [[MSAnalyticsTransmissionTarget alloc]
           initWithTransmissionTargetToken:kMSTestTransmissionToken
                              parentTarget:nil
                              channelGroup:self.channelGroupMock];
 
   // Then
-  XCTAssertNotNil(transmissionTarget);
+  XCTAssertNotNil(sut);
   XCTAssertEqual(kMSTestTransmissionToken,
-                 transmissionTarget.transmissionTargetToken);
-  XCTAssertEqualObjects(transmissionTarget.propertyConfigurator.eventProperties,
+                 sut.transmissionTargetToken);
+  XCTAssertEqualObjects(sut.propertyConfigurator.eventProperties,
                         @{});
+  XCTAssertNil(MSAnalyticsTransmissionTarget.authenticationProvider);
 }
 
 - (void)testTrackEvent {
 
   // If
-  MSAnalyticsTransmissionTarget *target = [[MSAnalyticsTransmissionTarget alloc]
+  MSAnalyticsTransmissionTarget *sut = [[MSAnalyticsTransmissionTarget alloc]
       initWithTransmissionTargetToken:kMSTestTransmissionToken
                          parentTarget:nil
                          channelGroup:self.channelGroupMock];
   NSString *eventName = @"event";
 
   // When
-  [target trackEvent:eventName];
+  [sut trackEvent:eventName];
 
   // Then
-  XCTAssertTrue(target.propertyConfigurator.eventProperties.count == 0);
+  XCTAssertTrue(sut.propertyConfigurator.eventProperties.count == 0);
   OCMVerify(ClassMethod([self.analyticsClassMock trackEvent:eventName
                                              withProperties:nil
-                                      forTransmissionTarget:target]));
+                                      forTransmissionTarget:sut]));
 }
 
 - (void)testTrackEventWithProperties {
 
   // If
-  MSAnalyticsTransmissionTarget *target = [[MSAnalyticsTransmissionTarget alloc]
+  MSAnalyticsTransmissionTarget *sut = [[MSAnalyticsTransmissionTarget alloc]
       initWithTransmissionTargetToken:kMSTestTransmissionToken
                          parentTarget:nil
                          channelGroup:self.channelGroupMock];
@@ -90,13 +92,13 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
   NSDictionary *properties = @{ @"prop1" : @"val1", @"prop2" : @"val2" };
 
   // When
-  [target trackEvent:eventName withProperties:properties];
+  [sut trackEvent:eventName withProperties:properties];
 
   // Then
-  XCTAssertTrue(target.propertyConfigurator.eventProperties.count == 0);
+  XCTAssertTrue(sut.propertyConfigurator.eventProperties.count == 0);
   OCMVerify(ClassMethod([self.analyticsClassMock trackEvent:eventName
                                              withProperties:properties
-                                      forTransmissionTarget:target]));
+                                      forTransmissionTarget:sut]));
 }
 
 - (void)testTransmissionTargetForToken {
@@ -852,6 +854,40 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
   XCTAssertNotEqual(log2.ext.appExt.name, child1.propertyConfigurator.appName);
   XCTAssertNotEqual(log2.ext.appExt.locale,
                     child1.propertyConfigurator.appLocale);
+}
+
+- (void)testAddAuthenticationProvider {
+  
+  // If
+  MSAnalyticsAuthenticationProvider *provider = [[MSAnalyticsAuthenticationProvider alloc] initWithAuthenticationType:MSAnalyticsAuthenticationTypeMsaCompact ticketKey:@"ticketKey" delegate:OCMOCK_ANY];
+
+  // When
+  [MSAnalyticsTransmissionTarget addAuthenticationProvider:provider];
+  
+  // Then
+  XCTAssertNotNil(MSAnalyticsTransmissionTarget.authenticationProvider);
+  XCTAssertEqual(provider, MSAnalyticsTransmissionTarget.authenticationProvider);
+  
+  // If
+  MSAnalyticsAuthenticationProvider *provider2 = [[MSAnalyticsAuthenticationProvider alloc] initWithAuthenticationType:MSAnalyticsAuthenticationTypeMsaDelegate ticketKey:@"ticketKey2" delegate:OCMOCK_ANY];
+
+  // When
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [MSAnalyticsTransmissionTarget addAuthenticationProvider:provider2];
+  });
+  [MSAnalyticsTransmissionTarget addAuthenticationProvider:provider];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [MSAnalyticsTransmissionTarget addAuthenticationProvider:provider2];
+  });
+  
+  // Then
+  XCTAssertEqual(provider, MSAnalyticsTransmissionTarget.authenticationProvider);
+  
+  // When
+  [MSAnalyticsTransmissionTarget addAuthenticationProvider:nil];
+  
+  // Then
+  XCTAssertNil(MSAnalyticsTransmissionTarget.authenticationProvider);
 }
 
 @end

--- a/Sasquatch/Sasquatch/ViewControllers/MSSignInViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSSignInViewController.swift
@@ -122,7 +122,7 @@ class MSSignInViewController: UIViewController, WKNavigationDelegate, MSAnalytic
             self.refreshToken = refreshToken
             NSLog("Successfully signed in with user_id: %@", newUrl.valueOf("user_id")!)
             let provider = MSAnalyticsAuthenticationProvider(authenticationType: .msaCompact, ticketKey: newUrl.valueOf("user_id")!, delegate: self)
-            MSAnalyticsTransmissionTarget.authenticationProvider = provider
+            MSAnalyticsTransmissionTarget.addAuthenticationProvider(authenticationProvider:provider)
           }
         }
       }


### PR DESCRIPTION
Aligns the API with the Android SDK by hiding the backing property and don't allow adding an authentication provider that is `nil`.
