### PR TITLE
Fix issues in the sasquatch apps

### DIFF
--- a/Sasquatch/Sasquatch/MSTransmissionTargets.swift
+++ b/Sasquatch/Sasquatch/MSTransmissionTargets.swift
@@ -18,7 +18,7 @@ class MSTransmissionTargets {
 
     // Parent target.
     let appName = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
-    let parentTargetToken = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
+    let parentTargetToken = appName.contains("SasquatchSwift") ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
     let parentTarget = MSAnalytics.transmissionTarget(forToken: parentTargetToken)
     transmissionTargets[parentTargetToken] = parentTarget
     sendsAnalyticsEvents[parentTargetToken] = true

--- a/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsTransmissionTargetSelectorViewCell.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsTransmissionTargetSelectorViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
   override func awakeFromNib() {
     super.awakeFromNib()
     let appName = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
-    let runtimeToken: String = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
+    let runtimeToken: String = appName.contains("SasquatchSwift") ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
     transmissionTargetMapping = [kMSTargetToken1, kMSTargetToken2, runtimeToken]
     didSelectTransmissionTarget = {_ in}
     transmissionTargetSelector.addTarget(self, action: #selector(onSegmentSelected), for: .valueChanged)

--- a/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
@@ -177,7 +177,10 @@ class MSTransmissionTargetsViewController: UITableViewController {
   func targetEnabledSwitchValueChanged(sender: UISwitch!) {
     let sectionIndex = getCellSection(forView: sender)
     let section = transmissionTargetSections![sectionIndex]
-    if (sectionIndex == Section.Runtime.rawValue) {
+    if (sectionIndex == Section.Default.rawValue) {
+      section.setTransmissionTargetEnabled(sender!.isOn)
+    }
+    else if (sectionIndex == Section.Runtime.rawValue) {
       section.setTransmissionTargetEnabled(sender!.isOn)
       for childSectionIndex in 2...3 {
         guard let childCell = tableView.cellForRow(at: IndexPath(row: kEnabledCellRowIndex, section: childSectionIndex)) else {

--- a/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
@@ -189,7 +189,7 @@ class MSTransmissionTargetsViewController: UITableViewController {
         let childSwitch: UISwitch? = childCell.getSubview()
         let childTarget = transmissionTargetSections![childSectionIndex].getTransmissionTarget()
         childSwitch!.setOn(childTarget!.isEnabled(), animated: true)
-        childSwitch?.isEnabled = sender!.isOn
+        childSwitch!.isEnabled = sender!.isOn
       }
     }
     else if (sectionIndex == Section.Child1.rawValue || sectionIndex == Section.Child2.rawValue) {
@@ -200,7 +200,7 @@ class MSTransmissionTargetsViewController: UITableViewController {
         // Switch tried to enable the transmission target but it didn't work.
         sender!.setOn(false, animated: true)
         section.setTransmissionTargetEnabled(false)
-        sender?.isEnabled = false
+        sender!.isEnabled = false
       }
     }
   }

--- a/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
@@ -140,7 +140,7 @@ class MSTransmissionTargetsViewController: UITableViewController {
       let switcher: UISwitch? = cell.getSubview()
       switcher?.isOn = section.isTransmissionTargetEnabled()
       switcher?.addTarget(self, action: #selector(targetEnabledSwitchValueChanged), for: .valueChanged)
-      
+
       // Special label text for default target section.
       if indexPath.section == Section.Default.rawValue {
         let label: UILabel? = cell.getSubview()

--- a/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
@@ -60,18 +60,24 @@ class MSTransmissionTargetsViewController: UITableViewController {
   private let kAnalyticsCellRowIndex = 1
   private let kTokenCellRowIndex = 2
   private let kEnabledStateIndicatorRowIndex = 2
-  private let kDefaultTargetSectionIndex = 0
-  private let kTargetPropertiesSectionIndex = 4
-  private let kCSPropertiesSectionIndex = 5
   private var targetPropertiesSection: TargetPropertiesTableSection?
   private var csPropertiesSection: CommonSchemaPropertiesTableSection?
   private static let defaultTransmissionTargetIsEnabled = UserDefaults.standard.bool(forKey: kMSOneCollectorEnabledKey)
+  
+  enum Section : Int {
+    case Default = 0
+    case Runtime
+    case Child1
+    case Child2
+    case TargetProperties
+    case CommonSchemaProperties
+  }
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    targetPropertiesSection = TargetPropertiesTableSection(tableSection: kTargetPropertiesSectionIndex, tableView: tableView)
-    csPropertiesSection = CommonSchemaPropertiesTableSection(tableSection: kCSPropertiesSectionIndex, tableView: tableView)
+    targetPropertiesSection = TargetPropertiesTableSection(tableSection: Section.TargetProperties.rawValue, tableView: tableView)
+    csPropertiesSection = CommonSchemaPropertiesTableSection(tableSection: Section.CommonSchemaProperties.rawValue, tableView: tableView)
     
     // Default target section.
     let defaultTargetSection = MSTransmissionTargetSection()
@@ -109,10 +115,10 @@ class MSTransmissionTargetsViewController: UITableViewController {
   }
 
   override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    if section == kTargetPropertiesSectionIndex {
+    if section == Section.TargetProperties.rawValue {
       return targetPropertiesSection!.tableView(tableView, numberOfRowsInSection:section)
     }
-    else if section == kCSPropertiesSectionIndex {
+    else if section == Section.CommonSchemaProperties.rawValue {
       return csPropertiesSection!.tableView(tableView, numberOfRowsInSection:section)
     }
     else {
@@ -121,10 +127,10 @@ class MSTransmissionTargetsViewController: UITableViewController {
   }
 
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    if indexPath.section == kTargetPropertiesSectionIndex {
+    if indexPath.section == Section.TargetProperties.rawValue {
       return targetPropertiesSection!.tableView(tableView, cellForRowAt:indexPath)
     }
-    else if indexPath.section == kCSPropertiesSectionIndex {
+    else if indexPath.section == Section.CommonSchemaProperties.rawValue {
       return csPropertiesSection!.tableView(tableView, cellForRowAt: indexPath)
     }
     let section = transmissionTargetSections![indexPath.section]
@@ -134,9 +140,9 @@ class MSTransmissionTargetsViewController: UITableViewController {
       let switcher: UISwitch? = cell.getSubview()
       switcher?.isOn = section.isTransmissionTargetEnabled()
       switcher?.addTarget(self, action: #selector(targetEnabledSwitchValueChanged), for: .valueChanged)
-
+      
       // Special label text for default target section.
-      if indexPath.section == kDefaultTargetSectionIndex {
+      if indexPath.section == Section.Default.rawValue {
         let label: UILabel? = cell.getSubview()
         label!.text = "Enable On Next Launch"
       }
@@ -152,7 +158,7 @@ class MSTransmissionTargetsViewController: UITableViewController {
       switcher?.addTarget(self, action: #selector(targetShouldSendAnalyticsSwitchValueChanged), for: .valueChanged)
       return cell
     case kTokenCellRowIndex:
-      if indexPath.section == kDefaultTargetSectionIndex {
+      if indexPath.section == Section.Default.rawValue {
         fallthrough
       }
       let cell = tableView.dequeueReusableCell(withIdentifier: kTokenCellId)!
@@ -171,8 +177,8 @@ class MSTransmissionTargetsViewController: UITableViewController {
   func targetEnabledSwitchValueChanged(sender: UISwitch!) {
     let sectionIndex = getCellSection(forView: sender)
     let section = transmissionTargetSections![sectionIndex]
-    section.setTransmissionTargetEnabled(sender!.isOn)
-    if (sectionIndex == 1) {
+    if (sectionIndex == Section.Runtime.rawValue) {
+      section.setTransmissionTargetEnabled(sender!.isOn)
       for childSectionIndex in 2...3 {
         guard let childCell = tableView.cellForRow(at: IndexPath(row: kEnabledCellRowIndex, section: childSectionIndex)) else {
           continue
@@ -181,6 +187,17 @@ class MSTransmissionTargetsViewController: UITableViewController {
         let childTarget = transmissionTargetSections![childSectionIndex].getTransmissionTarget()
         childSwitch!.setOn(childTarget!.isEnabled(), animated: true)
         childSwitch?.isEnabled = sender!.isOn
+      }
+    }
+    else if (sectionIndex == Section.Child1.rawValue || sectionIndex == Section.Child2.rawValue) {
+      let switchEnabled = sender!.isOn
+      section.setTransmissionTargetEnabled(switchEnabled)
+      if(switchEnabled && (section.isTransmissionTargetEnabled() == false)) {
+        
+        // Switch tried to enable the transmission target but it didn't work.
+        sender!.setOn(false, animated: true)
+        section.setTransmissionTargetEnabled(false)
+        sender?.isEnabled = false
       }
     }
   }
@@ -195,7 +212,7 @@ class MSTransmissionTargetsViewController: UITableViewController {
     if section < transmissionTargetSections!.count {
       return transmissionTargetSections![section].headerText
     }
-    else if section == kCSPropertiesSectionIndex {
+    else if section == Section.CommonSchemaProperties.rawValue {
       return "Override Common Schema Properties"
     }
     return "Transmission Target Properties"
@@ -209,13 +226,13 @@ class MSTransmissionTargetsViewController: UITableViewController {
   }
 
   override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
-    if indexPath.section == kTargetPropertiesSectionIndex {
+    if indexPath.section == Section.TargetProperties.rawValue {
       targetPropertiesSection?.tableView(tableView, commit: editingStyle, forRowAt: indexPath)
     }
   }
 
   override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCellEditingStyle {
-    if indexPath.section == kTargetPropertiesSectionIndex {
+    if indexPath.section == Section.TargetProperties.rawValue {
       return targetPropertiesSection!.tableView(tableView, editingStyleForRowAt: indexPath)
     }
     return .none
@@ -223,13 +240,13 @@ class MSTransmissionTargetsViewController: UITableViewController {
 
   override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     tableView.deselectRow(at: indexPath, animated: true)
-    if indexPath.section == kTargetPropertiesSectionIndex && targetPropertiesSection!.isInsertRow(indexPath) {
+    if indexPath.section == Section.TargetProperties.rawValue && targetPropertiesSection!.isInsertRow(indexPath) {
       self.tableView(tableView, commit: .insert, forRowAt: indexPath)
     }
   }
 
   override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-    if indexPath.section == kTargetPropertiesSectionIndex || indexPath.section == kCSPropertiesSectionIndex {
+    if indexPath.section == Section.TargetProperties.rawValue || indexPath.section == Section.CommonSchemaProperties.rawValue {
       return super.tableView(tableView, heightForRowAt: IndexPath(row: 0, section: indexPath.section))
     }
     return super.tableView(tableView, heightForRowAt: indexPath)
@@ -244,7 +261,7 @@ class MSTransmissionTargetsViewController: UITableViewController {
   }
 
   override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-    if indexPath.section == kTargetPropertiesSectionIndex {
+    if indexPath.section == Section.TargetProperties.rawValue {
       return targetPropertiesSection!.tableView(tableView, canEditRowAt:indexPath)
     }
     return false

--- a/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSTransmissionTargetsViewController.swift
@@ -84,7 +84,7 @@ class MSTransmissionTargetsViewController: UITableViewController {
     runtimeTargetSection.headerText = "Runtime Transmission Target"
     runtimeTargetSection.footerText = "This transmission target is the parent of the two transmission targets below."
     let appName = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
-    runtimeTargetSection.token = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
+    runtimeTargetSection.token = appName.contains("SasquatchSwift") ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
 
     // Child 1.
     let child1TargetSection = MSTransmissionTargetSection()

--- a/Sasquatch/Sasquatch/ViewControllers/Sections/CommonSchemaPropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/CommonSchemaPropertiesTableSection.swift
@@ -22,7 +22,7 @@ class CommonSchemaPropertiesTableSection : PropertiesTableSection {
     propertyValues = [String: [String]]()
     collectDeviceIdStates = [String: Bool]()
     let appName = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
-    let parentTargetToken = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
+    let parentTargetToken = appName.contains("SasquatchSwift") ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
     for token in [parentTargetToken, kMSTargetToken1, kMSTargetToken2] {
       propertyValues[token] = Array(repeating: "", count: propertyKeys.count + 1)
       collectDeviceIdStates[token] = false

--- a/Sasquatch/Sasquatch/ViewControllers/Sections/TargetPropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/TargetPropertiesTableSection.swift
@@ -8,7 +8,7 @@ class TargetPropertiesTableSection : PropertiesTableSection {
     super.init(tableSection: tableSection, tableView: tableView)
     targetProperties = [String: [(String, String)]]()
     let appName = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
-    let parentTargetToken = appName == "SasquatchSwift" ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
+    let parentTargetToken = appName.contains("SasquatchSwift") ? kMSSwiftRuntimeTargetToken : kMSObjCRuntimeTargetToken
     targetProperties[parentTargetToken] = [(String, String)]()
     targetProperties[kMSTargetToken1] = [(String, String)]()
     targetProperties[kMSTargetToken2] = [(String, String)]()


### PR DESCRIPTION
* Makes sure SasquatchSwift-Preview uses the SasquatchSwift runtime token
*  Make sure the UI doesn't look like it's possible to enable a child target with the runtime target (parent) disabled