### PR TITLE
Sasquatch UI test is failed

### DIFF
--- a/Sasquatch/SasquatchUITests/AppCenterUITests.swift
+++ b/Sasquatch/SasquatchUITests/AppCenterUITests.swift
@@ -193,10 +193,12 @@ class AppCenterUITests: XCTestCase {
     let installId : String = installIdCell.staticTexts.element(boundBy: 1).label
     XCTAssertNotNil(UUID(uuidString: installId))
 
+    #if ACTIVE_COMPILATION_CONDITION_PUPPET
     // Check app secret.
     let appSecretCell : XCUIElement = app.tables["App Center"].cell(containing: "App Secret")
     let appSecret : String = appSecretCell.staticTexts.element(boundBy: 1).label
     XCTAssertNotNil(UUID(uuidString: appSecret))
+    #endif
 
     // Check log url.
     let logUrlCell : XCUIElement = app.tables["App Center"].cell(containing: "Log URL")


### PR DESCRIPTION
Sasquatch UI test "testMiscellaneousInfo" is failed for testing application SasquatchSwift and SasquatchObjC, but it's passed for SasquatchPuppet. 

![screenshot 2018-09-24 at 12 46 16](https://user-images.githubusercontent.com/40772628/45956676-da110a80-c01b-11e8-8800-efa4fd41b5d8.png)

I excluded appSecret check for Swift and ObjC Sasquatch, because AppSecret key is available only in Puppet application.