### PR TITLE
Move appSecret to MSHttpIngestion

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.h
@@ -5,7 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class MSAppCenterIngestion;
+@class MSHttpIngestion;
 @protocol MSStorage;
 
 /**
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  * An ingestion instance that is used to send batches of log items to the
  * backend.
  */
-@property(nonatomic, strong, nullable) MSAppCenterIngestion *ingestion;
+@property(nonatomic, strong, nullable) MSHttpIngestion *ingestion;
 
 /**
  * A storage instance to store and read enqueued log items.

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -20,7 +20,7 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
   return self;
 }
 
-- (instancetype)initWithIngestion:(nullable MSAppCenterIngestion *)ingestion {
+- (instancetype)initWithIngestion:(nullable MSHttpIngestion *)ingestion {
   if ((self = [self init])) {
     dispatch_queue_t serialQueue = dispatch_queue_create(kMSlogsDispatchQueue, DISPATCH_QUEUE_SERIAL);
     _logsDispatchQueue = serialQueue;

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
@@ -1,6 +1,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
-@class MSAppCenterIngestion;
+@class MSHttpIngestion;
 
 @interface MSChannelGroupDefault ()
 
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A new `MSChannelGroupDefault` instance.
  */
-- (instancetype)initWithIngestion:(nullable MSAppCenterIngestion *)ingestion;
+- (instancetype)initWithIngestion:(nullable MSHttpIngestion *)ingestion;
 
 @end
 

--- a/AppCenter/AppCenter/Internals/Ingestion/MSAppCenterIngestion.h
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSAppCenterIngestion.h
@@ -7,11 +7,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MSAppCenterIngestion : MSHttpIngestion
 
 /**
- * The app secret.
- */
-@property(nonatomic, copy) NSString *appSecret;
-
-/**
  * Initialize the Ingestion.
  *
  * @param baseUrl Base url.

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.h
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.h
@@ -28,6 +28,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic) NSDictionary *httpHeaders;
 
 /**
+ * The app secret.
+ */
+@property(nonatomic, copy) NSString *appSecret;
+
+/**
  * Pending http calls.
  */
 @property NSMutableDictionary<NSString *, MSIngestionCall *> *pendingCalls;

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
@@ -17,6 +17,7 @@ static NSString *const kMSPartialURLComponentsName[] = {
 @synthesize apiPath = _apiPath;
 @synthesize reachability = _reachability;
 @synthesize suspended = _suspended;
+@synthesize appSecret = _appSecret;
 
 #pragma mark - Initialize
 

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -1,10 +1,10 @@
 #import "MSAbstractLogInternal.h"
-#import "MSAppCenterIngestion.h"
 #import "MSChannelDelegate.h"
 #import "MSChannelGroupDefault.h"
 #import "MSChannelGroupDefaultPrivate.h"
 #import "MSChannelUnitConfiguration.h"
 #import "MSChannelUnitDefault.h"
+#import "MSHttpIngestionPrivate.h"
 #import "MSIngestionProtocol.h"
 #import "MSMockLog.h"
 #import "MSStorage.h"
@@ -144,7 +144,7 @@
 - (void)testSetEnabled {
 
   // If
-  MSAppCenterIngestion *ingestionMock = OCMClassMock(MSAppCenterIngestion.class);
+  MSHttpIngestion *ingestionMock = OCMClassMock(MSHttpIngestion.class);
   id<MSChannelUnitProtocol> channelMock =
       OCMProtocolMock(@protocol(MSChannelUnitProtocol));
   id<MSChannelDelegate> delegateMock =
@@ -167,7 +167,7 @@
 - (void)testResume {
 
   // If
-  MSAppCenterIngestion *ingestionMock = OCMClassMock(MSAppCenterIngestion.class);
+  MSHttpIngestion *ingestionMock = OCMClassMock(MSHttpIngestion.class);
   id<MSChannelUnitProtocol> channelMock =
       OCMProtocolMock(@protocol(MSChannelUnitProtocol));
   MSChannelGroupDefault *sut =
@@ -187,7 +187,7 @@
 - (void)testSuspend {
 
   // If
-  MSAppCenterIngestion *ingestionMock = OCMClassMock(MSAppCenterIngestion.class);
+  MSHttpIngestion *ingestionMock = OCMClassMock(MSHttpIngestion.class);
   id<MSChannelUnitProtocol> channelMock =
       OCMProtocolMock(@protocol(MSChannelUnitProtocol));
   MSChannelGroupDefault *sut =

--- a/AppCenterDistribute/AppCenterDistribute/Internals/Ingestion/MSDistributeIngestion.h
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/Ingestion/MSDistributeIngestion.h
@@ -12,11 +12,6 @@ static NSString *const kMSHeaderUpdateApiToken = @"x-api-token";
 @interface MSDistributeIngestion : MSHttpIngestion
 
 /**
- * AppSecret for the application.
- */
-@property(nonatomic) NSString *appSecret;
-
-/**
  * Initialize the Ingestion.
  *
  * @param baseUrl Base url.

--- a/AppCenterDistribute/AppCenterDistribute/Internals/Ingestion/MSDistributeIngestion.m
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/Ingestion/MSDistributeIngestion.m
@@ -6,6 +6,8 @@
 
 @implementation MSDistributeIngestion
 
+@synthesize appSecret = _appSecret;
+
 /**
  * The API paths for latest release requests.
  */


### PR DESCRIPTION
Move appSecret to MSHttpIngestion to allow ChannelGroupDefault to allow ChannelGroupDefault to have a generic MSHttpIngestion.