### PR TITLE
Change MSChannelGroupDefault to use generic ingestion object

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.h
@@ -5,7 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class MSAppCenterIngestion;
+@class MSHttpIngestion;
 @protocol MSStorage;
 
 /**
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  * An ingestion instance that is used to send batches of log items to the
  * backend.
  */
-@property(nonatomic, strong, nullable) MSAppCenterIngestion *ingestion;
+@property(nonatomic, strong, nullable) MSHttpIngestion *ingestion;
 
 /**
  * A storage instance to store and read enqueued log items.

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -20,7 +20,7 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
   return self;
 }
 
-- (instancetype)initWithIngestion:(nullable MSAppCenterIngestion *)ingestion {
+- (instancetype)initWithIngestion:(nullable MSHttpIngestion *)ingestion {
   if ((self = [self init])) {
     dispatch_queue_t serialQueue = dispatch_queue_create(kMSlogsDispatchQueue, DISPATCH_QUEUE_SERIAL);
     _logsDispatchQueue = serialQueue;
@@ -213,7 +213,9 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 }
 
 - (void)setAppSecret:(NSString *)appSecret {
-  self.ingestion.appSecret = appSecret;
+  if([self.ingestion isKindOfClass:[MSAppCenterIngestion class]]) {
+    ((MSAppCenterIngestion *)self.ingestion).appSecret = appSecret;
+  }
 }
 
 - (void)setMaxStorageSize:(long)sizeInBytes completionHandler:(nullable void (^)(BOOL))completionHandler {

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
@@ -1,6 +1,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
-@class MSAppCenterIngestion;
+@class MSHttpIngestion;
 
 @interface MSChannelGroupDefault ()
 
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A new `MSChannelGroupDefault` instance.
  */
-- (instancetype)initWithIngestion:(nullable MSAppCenterIngestion *)ingestion;
+- (instancetype)initWithIngestion:(nullable MSHttpIngestion *)ingestion;
 
 @end
 

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -144,7 +144,7 @@
 - (void)testSetEnabled {
 
   // If
-  MSAppCenterIngestion *ingestionMock = OCMClassMock(MSAppCenterIngestion.class);
+  MSHttpIngestion *ingestionMock = OCMClassMock(MSHttpIngestion.class);
   id<MSChannelUnitProtocol> channelMock =
       OCMProtocolMock(@protocol(MSChannelUnitProtocol));
   id<MSChannelDelegate> delegateMock =
@@ -167,7 +167,7 @@
 - (void)testResume {
 
   // If
-  MSAppCenterIngestion *ingestionMock = OCMClassMock(MSAppCenterIngestion.class);
+  MSHttpIngestion *ingestionMock = OCMClassMock(MSHttpIngestion.class);
   id<MSChannelUnitProtocol> channelMock =
       OCMProtocolMock(@protocol(MSChannelUnitProtocol));
   MSChannelGroupDefault *sut =
@@ -187,7 +187,7 @@
 - (void)testSuspend {
 
   // If
-  MSAppCenterIngestion *ingestionMock = OCMClassMock(MSAppCenterIngestion.class);
+  MSHttpIngestion *ingestionMock = OCMClassMock(MSHttpIngestion.class);
   id<MSChannelUnitProtocol> channelMock =
       OCMProtocolMock(@protocol(MSChannelUnitProtocol));
   MSChannelGroupDefault *sut =


### PR DESCRIPTION
* Make `MSChannelGroupDefault` use `MSHttpIngestion` instead of `MSAppCenterIngestion` (was introduced in #1122 
* Make @jaelim-ms happy ❤️