### PR TITLE
Update max storage size field in case it was changed by sdk automatically

### DIFF
--- a/Sasquatch/Sasquatch/Constants.h
+++ b/Sasquatch/Sasquatch/Constants.h
@@ -29,3 +29,4 @@ static NSString *const kMSObjCRuntimeTargetToken = @"1aa046cfdc8f49bdbd64190290c
 static NSString *const kMSStartTargetKey = @"startTarget";
 static NSString *const kMSStorageMaxSizeKey = @"storageMaxSize";
 static NSNotificationName const kUpdateAnalyticsResultNotification = @"updateAnalyticsResult";
+static int const kMSStoragePageSize = 4096;

--- a/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -73,9 +73,8 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
   if (storageMaxSize) {
     [MSAppCenter setMaxStorageSize:storageMaxSize.integerValue
                  completionHandler:^(BOOL success) {
-                   if (!success) {
-                     dispatch_async(dispatch_get_main_queue(), ^{
-
+                   dispatch_async(dispatch_get_main_queue(), ^{
+                     if (!success) {
                        // Remove invalid value.
                        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kMSStorageMaxSizeKey];
 
@@ -86,8 +85,11 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
                                                                                          preferredStyle:UIAlertControllerStyleAlert];
                        [alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
                        [self.window.rootViewController presentViewController:alertController animated:YES completion:nil];
-                     });
-                   }
+                     } else {
+                       long realStorageSize = (long)(ceil([storageMaxSize doubleValue] / kMSStoragePageSize) * kMSStoragePageSize);
+                       [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithLong:realStorageSize] forKey:kMSStorageMaxSizeKey];
+                     }
+                   });
                  }];
   }
 

--- a/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -74,7 +74,11 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
     [MSAppCenter setMaxStorageSize:storageMaxSize.integerValue
                  completionHandler:^(BOOL success) {
                    dispatch_async(dispatch_get_main_queue(), ^{
-                     if (!success) {
+                     if (success) {
+                       long realStorageSize = (long)(ceil([storageMaxSize doubleValue] / kMSStoragePageSize) * kMSStoragePageSize);
+                       [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithLong:realStorageSize] forKey:kMSStorageMaxSizeKey];
+                     } else {
+
                        // Remove invalid value.
                        [[NSUserDefaults standardUserDefaults] removeObjectForKey:kMSStorageMaxSizeKey];
 
@@ -85,9 +89,6 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
                                                                                          preferredStyle:UIAlertControllerStyleAlert];
                        [alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
                        [self.window.rootViewController presentViewController:alertController animated:YES completion:nil];
-                     } else {
-                       long realStorageSize = (long)(ceil([storageMaxSize doubleValue] / kMSStoragePageSize) * kMSStoragePageSize);
-                       [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithLong:realStorageSize] forKey:kMSStorageMaxSizeKey];
                      }
                    });
                  }];

--- a/Sasquatch/SasquatchSwift/AppDelegate.swift
+++ b/Sasquatch/SasquatchSwift/AppDelegate.swift
@@ -38,18 +38,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MSCrashesDelegate, MSDist
     let storageMaxSize = UserDefaults.standard.object(forKey: kMSStorageMaxSizeKey) as? Int
     if storageMaxSize != nil {
       MSAppCenter.setMaxStorageSize(storageMaxSize!, completionHandler: { success in
-        if !success {
-          DispatchQueue.main.async {
-
+        DispatchQueue.main.async {
+          if !success {
             // Remove invalid value.
             UserDefaults.standard.removeObject(forKey: kMSStorageMaxSizeKey)
 
             // Show alert.
             let alertController = UIAlertController(title: "Warning!",
-                    message: "The maximum size of the internal storage could not be set.",
-                    preferredStyle: .alert)
+                                                    message: "The maximum size of the internal storage could not be set.",
+                                                    preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: "OK", style: .default))
             self.window?.rootViewController?.present(alertController, animated: true)
+          } else {
+            let realSize = Int64((ceil(Double(storageMaxSize!) / Double(kMSStoragePageSize)))) * Int64(kMSStoragePageSize)
+            UserDefaults.standard.set(realSize, forKey: kMSStorageMaxSizeKey)
           }
         }
       })

--- a/Sasquatch/SasquatchSwift/AppDelegate.swift
+++ b/Sasquatch/SasquatchSwift/AppDelegate.swift
@@ -39,7 +39,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MSCrashesDelegate, MSDist
     if storageMaxSize != nil {
       MSAppCenter.setMaxStorageSize(storageMaxSize!, completionHandler: { success in
         DispatchQueue.main.async {
-          if !success {
+          if success {
+            let realSize = Int64(ceil(Double(storageMaxSize!) / Double(kMSStoragePageSize))) * Int64(kMSStoragePageSize)
+            UserDefaults.standard.set(realSize, forKey: kMSStorageMaxSizeKey)
+          } else {
+
             // Remove invalid value.
             UserDefaults.standard.removeObject(forKey: kMSStorageMaxSizeKey)
 
@@ -49,9 +53,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MSCrashesDelegate, MSDist
                                                     preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: "OK", style: .default))
             self.window?.rootViewController?.present(alertController, animated: true)
-          } else {
-            let realSize = Int64((ceil(Double(storageMaxSize!) / Double(kMSStoragePageSize)))) * Int64(kMSStoragePageSize)
-            UserDefaults.standard.set(realSize, forKey: kMSStorageMaxSizeKey)
           }
         }
       })


### PR DESCRIPTION
* [ ] ~Has `CHANGELOG.md` been updated?~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

When setting max storage size, SDK could increase value that was provided by user due to page size used by storage. In this case test apps were displaying incorrect value for storage size, this PR fixes it.
