### PR TITLE
Validate invalid number in custom properties

### DIFF
--- a/AppCenter/AppCenter/MSCustomProperties.m
+++ b/AppCenter/AppCenter/MSCustomProperties.m
@@ -88,6 +88,12 @@ static const int maxPropertyValueLength = 128;
         MSLogError([MSAppCenter logTag], @"Custom property value length cannot be longer than \"%d\" characters.", maxPropertyValueLength);
         return NO;
       }
+    } else if ([value isKindOfClass:[NSNumber class]]) {
+      double number = [(NSNumber *)value doubleValue];
+      if (number == (double)INFINITY || number == -(double)INFINITY || number != number) {
+        MSLogError([MSAppCenter logTag], @"Custom property value cannot be NaN or infinite.");
+        return NO;
+      }
     }
   } else {
     MSLogError([MSAppCenter logTag], @"Custom property value cannot be null, did you mean to call clear?");
@@ -97,7 +103,7 @@ static const int maxPropertyValueLength = 128;
 }
 
 - (NSDictionary<NSString *, NSObject *> *)propertiesImmutableCopy {
-  @synchronized (self.properties) {
+  @synchronized(self.properties) {
     return [[NSDictionary alloc] initWithDictionary:self.properties];
   }
 }

--- a/AppCenter/AppCenterTests/MSCustomPropertiesTests.m
+++ b/AppCenter/AppCenterTests/MSCustomPropertiesTests.m
@@ -226,6 +226,42 @@
   assertThat([customProperties propertiesImmutableCopy][key], is(normalValue));
 }
 
+- (void)testSetInvalidNumber {
+
+  // If
+  NSString *key = @"test";
+
+  // When
+  MSCustomProperties *customProperties = [MSCustomProperties new];
+
+  // Then
+  assertThat([customProperties propertiesImmutableCopy], hasCountOf(0));
+
+  // NaN value.
+  // When
+  NSNumber *nanValue = [NSNumber numberWithDouble:NAN];
+  [customProperties setNumber:nanValue forKey:key];
+
+  // Then
+  assertThat([customProperties propertiesImmutableCopy], hasCountOf(0));
+
+  // Positive infinite value.
+  // When
+  NSNumber *positiveInfiniteValue = [NSNumber numberWithDouble:INFINITY];
+  [customProperties setNumber:positiveInfiniteValue forKey:key];
+
+  // Then
+  assertThat([customProperties propertiesImmutableCopy], hasCountOf(0));
+
+  // Negative infinite value.
+  // When
+  NSNumber *negativeInfiniteValue = [NSNumber numberWithDouble:-INFINITY];
+  [customProperties setNumber:negativeInfiniteValue forKey:key];
+
+  // Then
+  assertThat([customProperties propertiesImmutableCopy], hasCountOf(0));
+}
+
 - (void)testSetBool {
 
   // If

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### AppCenter
 
 * **[Fix]** Fix an issue where concurrent modification of custom properties was not thread safe.
+* **[Fix]** Fix validating and discarding Not a Number (NaN) and infinite double values for custom properties.
 
 ___
 


### PR DESCRIPTION
* [X] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you add unit tests?

## Description

Custom properties couldn't take NaN or positive and negative infinite numbers as a value. Fixing validation logic to check this condition.

## Related PRs or issues

https://github.com/Microsoft/AppCenter-SDK-Android/pull/828/files
