### PR TITLE
Fix test app common property UI

### DIFF
--- a/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsTypedPropertyTableViewCell.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsTypedPropertyTableViewCell.swift
@@ -54,7 +54,7 @@ import UIKit
     set(value) {
       switch type {
       case .String, .Double, .Long:
-        valueTextField.text = value as? String
+        valueTextField.text = "\(value)"
       case .Boolean:
         boolValue.isOn = value as! Bool
       case .DateTime:


### PR DESCRIPTION
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Add a Double and a Long property to transmission target "Child 1" in the common properties in transmission target, switch target to "Child 2", switch back to "Child 1": the value of the Double and Long properties disappeared.
