### PR TITLE
Logs not associated to the right target keys

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
@@ -85,9 +85,7 @@ NSString *const kMSLogNameRegex = @"^[a-zA-Z0-9]((\\.(?!(\\.|$)))|[_a-zA-Z0-9]){
   if ([(NSObject *)log isKindOfClass:[MSCommonSchemaLog class]] && ![self isOneCollectorGroup:groupId]) {
     oneCollectorChannelUnit = self.oneCollectorChannels[groupId];
     if (oneCollectorChannelUnit) {
-      dispatch_async(oneCollectorChannelUnit.logsDispatchQueue, ^{
         [oneCollectorChannelUnit enqueueItem:log];
-      });
     }
     return;
   }
@@ -101,9 +99,7 @@ NSString *const kMSLogNameRegex = @"^[a-zA-Z0-9]((\\.(?!(\\.|$)))|[_a-zA-Z0-9]){
   id<MSLogConversion> logConversion = (id<MSLogConversion>)log;
   NSArray<MSCommonSchemaLog *> *commonSchemaLogs = [logConversion toCommonSchemaLogs];
   for (MSCommonSchemaLog *commonSchemaLog in commonSchemaLogs) {
-    dispatch_async(oneCollectorChannelUnit.logsDispatchQueue, ^{
       [oneCollectorChannelUnit enqueueItem:commonSchemaLog];
-    });
   }
 }
 

--- a/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
@@ -1,11 +1,11 @@
 #import "MSAbstractLogInternal.h"
 #import "MSAppCenterInternal.h"
-#import "MSChannelUnitConfiguration.h"
-#import "MSChannelUnitProtocol.h"
-#import "MSConstants+Internal.h"
 #import "MSCSData.h"
 #import "MSCSEpochAndSeq.h"
 #import "MSCSExtensions.h"
+#import "MSChannelUnitConfiguration.h"
+#import "MSChannelUnitProtocol.h"
+#import "MSConstants+Internal.h"
 #import "MSOneCollectorChannelDelegatePrivate.h"
 #import "MSOneCollectorIngestion.h"
 #import "MSSDKExtension.h"
@@ -46,8 +46,8 @@ NSString *const kMSLogNameRegex = @"^[a-zA-Z0-9]((\\.(?!(\\.|$)))|[_a-zA-Z0-9]){
     NSString *oneCollectorGroupId = [NSString stringWithFormat:@"%@%@", channel.configuration.groupId, kMSOneCollectorGroupIdSuffix];
     MSChannelUnitConfiguration *channelUnitConfiguration =
         [[MSChannelUnitConfiguration alloc] initDefaultConfigurationWithGroupId:oneCollectorGroupId];
-    id<MSChannelUnitProtocol> channelUnit =
-        [channelGroup addChannelUnitWithConfiguration:channelUnitConfiguration withIngestion:self.oneCollectorIngestion];
+    id<MSChannelUnitProtocol> channelUnit = [channelGroup addChannelUnitWithConfiguration:channelUnitConfiguration
+                                                                            withIngestion:self.oneCollectorIngestion];
     self.oneCollectorChannels[groupId] = channelUnit;
   }
 }
@@ -85,7 +85,7 @@ NSString *const kMSLogNameRegex = @"^[a-zA-Z0-9]((\\.(?!(\\.|$)))|[_a-zA-Z0-9]){
   if ([(NSObject *)log isKindOfClass:[MSCommonSchemaLog class]] && ![self isOneCollectorGroup:groupId]) {
     oneCollectorChannelUnit = self.oneCollectorChannels[groupId];
     if (oneCollectorChannelUnit) {
-        [oneCollectorChannelUnit enqueueItem:log];
+      [oneCollectorChannelUnit enqueueItem:log];
     }
     return;
   }
@@ -99,7 +99,7 @@ NSString *const kMSLogNameRegex = @"^[a-zA-Z0-9]((\\.(?!(\\.|$)))|[_a-zA-Z0-9]){
   id<MSLogConversion> logConversion = (id<MSLogConversion>)log;
   NSArray<MSCommonSchemaLog *> *commonSchemaLogs = [logConversion toCommonSchemaLogs];
   for (MSCommonSchemaLog *commonSchemaLog in commonSchemaLogs) {
-      [oneCollectorChannelUnit enqueueItem:commonSchemaLog];
+    [oneCollectorChannelUnit enqueueItem:commonSchemaLog];
   }
 }
 

--- a/AppCenter/AppCenterTests/MSOneCollectorChannelDelegateTests.m
+++ b/AppCenter/AppCenterTests/MSOneCollectorChannelDelegateTests.m
@@ -267,6 +267,7 @@ static NSString *const kMSOneCollectorGroupId = @"baseGroupId/one";
   OCMStub([mockLog toCommonSchemaLogs]).andReturn(@[ commonSchemaLog ]);
   OCMStub(mockLog.transmissionTargetTokens).andReturn(transmissionTargetTokens);
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+  
   /*
    * Make sure that the common schema log is enqueued synchronously by putting a task on the log queue that won't return
    * by the time verify is called.

--- a/AppCenter/AppCenterTests/MSOneCollectorChannelDelegateTests.m
+++ b/AppCenter/AppCenterTests/MSOneCollectorChannelDelegateTests.m
@@ -266,13 +266,13 @@ static NSString *const kMSOneCollectorGroupId = @"baseGroupId/one";
   id<MSMockLogWithConversion> mockLog = OCMProtocolMock(@protocol(MSMockLogWithConversion));
   OCMStub([mockLog toCommonSchemaLogs]).andReturn(@[ commonSchemaLog ]);
   OCMStub(mockLog.transmissionTargetTokens).andReturn(transmissionTargetTokens);
-
+  dispatch_semaphore_t sem = dispatch_semaphore_create(0);
   /*
    * Make sure that the common schema log is enqueued synchronously by putting a task on the log queue that won't return
    * by the time verify is called.
    */
   dispatch_async(oneCollectorChannelUnitMock.logsDispatchQueue, ^{
-    sleep(1);
+    dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
   });
 
   // When
@@ -281,6 +281,7 @@ static NSString *const kMSOneCollectorGroupId = @"baseGroupId/one";
 
   // Then
   OCMVerify([oneCollectorChannelUnitMock enqueueItem:commonSchemaLog]);
+  dispatch_semaphore_signal(sem);
 }
 
 - (void)testDidNotEnqueueLogToOneCollectorChannelWhenLogDoesNotConformToMSLogConversionProtocol {

--- a/AppCenter/AppCenterTests/MSOneCollectorChannelDelegateTests.m
+++ b/AppCenter/AppCenterTests/MSOneCollectorChannelDelegateTests.m
@@ -7,8 +7,8 @@
 #import "MSIngestionProtocol.h"
 #import "MSMockLogObject.h"
 #import "MSMockLogWithConversion.h"
-#import "MSOneCollectorIngestion.h"
 #import "MSOneCollectorChannelDelegatePrivate.h"
+#import "MSOneCollectorIngestion.h"
 #import "MSSDKExtension.h"
 #import "MSStorage.h"
 #import "MSTestFrameworks.h"
@@ -345,7 +345,7 @@ static NSString *const kMSOneCollectorGroupId = @"baseGroupId/one";
   NSMutableSet *transmissionTargetTokens = [NSMutableSet new];
   id<MSMockLogWithConversion> mockLog = OCMProtocolMock(@protocol(MSMockLogWithConversion));
   OCMStub(mockLog.transmissionTargetTokens).andReturn(transmissionTargetTokens);
-  OCMStub([mockLog toCommonSchemaLogs]).andReturn(@[ [MSCommonSchemaLog new] ]);
+  OCMStub([mockLog toCommonSchemaLogs]).andReturn(@ [[MSCommonSchemaLog new]]);
   OCMStub([mockLog isKindOfClass:[MSCommonSchemaLog class]]).andReturn(NO);
 
   // Then
@@ -367,7 +367,7 @@ static NSString *const kMSOneCollectorGroupId = @"baseGroupId/one";
   id<MSMockLogWithConversion> mockLog = OCMProtocolMock(@protocol(MSMockLogWithConversion));
   OCMStub([mockLog isKindOfClass:[MSCommonSchemaLog class]]).andReturn(NO);
   OCMStub(mockLog.transmissionTargetTokens).andReturn(nil);
-  OCMStub([mockLog toCommonSchemaLogs]).andReturn(@[ [MSCommonSchemaLog new] ]);
+  OCMStub([mockLog toCommonSchemaLogs]).andReturn(@ [[MSCommonSchemaLog new]]);
 
   // Then
   OCMReject([oneCollectorChannelUnitMock enqueueItem:OCMOCK_ANY]);
@@ -481,7 +481,7 @@ static NSString *const kMSOneCollectorGroupId = @"baseGroupId/one";
   // Valid data.
   log.name = @"valid.CS.event.name";
   log.data = [MSCSData new];
-  log.data.properties = @{ @"validkey" : @"validvalue" };
+  log.data.properties = @{@"validkey" : @"validvalue"};
 
   // Then
   XCTAssertTrue([self.sut validateLog:log]);

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
@@ -5,20 +5,14 @@
 #import "MSAnalyticsTransmissionTargetPrivate.h"
 #import "MSAppCenterInternal.h"
 #import "MSAppExtension.h"
-#import "MSCSExtensions.h"
-#import "MSChannelGroupDefault.h"
-#import "MSChannelGroupDefaultPrivate.h"
 #import "MSChannelUnitDefault.h"
+#import "MSCSExtensions.h"
 #import "MSEventLog.h"
 #import "MSEventPropertiesInternal.h"
 #import "MSMockUserDefaults.h"
 #import "MSPropertyConfiguratorPrivate.h"
-#import "MSProtocolExtension.h"
 #import "MSStringTypedProperty.h"
 #import "MSTestFrameworks.h"
-#import "MSAppCenterIngestion.h"
-#import "MSOneCollectorChannelDelegate.h"
-#import "../../../../../../Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestDefines.h"
 
 static NSString *const kMSTestTransmissionToken = @"TestTransmissionToken";
 static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
@@ -94,7 +88,7 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
                                                                                                  parentTarget:nil
                                                                                                  channelGroup:self.channelGroupMock];
   NSString *eventName = @"event";
-  NSDictionary *properties = @{@"prop1" : @"val1", @"prop2" : @"val2"};
+  NSDictionary *properties = @{ @"prop1" : @"val1", @"prop2" : @"val2" };
 
   // When
   [sut trackEvent:eventName withProperties:properties];
@@ -141,21 +135,18 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
   // Then
   XCTAssertNotEqualObjects(parentTransmissionTarget, childTransmissionTarget3);
   XCTAssertEqualObjects(childTransmissionTarget3, parentTransmissionTarget.childTransmissionTargets[kMSTestTransmissionToken]);
-  OCMVerify(ClassMethod([self.analyticsClassMock trackEvent:event1
-                                             withProperties:properties
-                                      forTransmissionTarget:childTransmissionTarget]));
-  OCMVerify(ClassMethod([self.analyticsClassMock trackEvent:event2
-                                             withProperties:properties
-                                      forTransmissionTarget:childTransmissionTarget2]));
-  OCMVerify(ClassMethod([self.analyticsClassMock trackEvent:event3
-                                             withProperties:properties
-                                      forTransmissionTarget:childTransmissionTarget3]));
+  OCMVerify(
+      ClassMethod([self.analyticsClassMock trackEvent:event1 withProperties:properties forTransmissionTarget:childTransmissionTarget]));
+  OCMVerify(
+      ClassMethod([self.analyticsClassMock trackEvent:event2 withProperties:properties forTransmissionTarget:childTransmissionTarget2]));
+  OCMVerify(
+      ClassMethod([self.analyticsClassMock trackEvent:event3 withProperties:properties forTransmissionTarget:childTransmissionTarget3]));
 }
 
 - (void)testTransmissionTargetEnabledState {
 
   // If
-  NSDictionary *properties = @{@"prop1" : @"val1", @"prop2" : @"val2"};
+  NSDictionary *properties = @{ @"prop1" : @"val1", @"prop2" : @"val2" };
   NSString *event1 = @"event1";
   NSString *event2 = @"event2";
   NSString *event3 = @"event3";
@@ -437,8 +428,8 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
   // Then
   XCTAssertEqualObjects(target.propertyConfigurator.eventProperties, commonProperties);
   OCMVerify(ClassMethod([self.analyticsClassMock
-          trackEvent:eventName
-      withProperties:(@{propCommonKey : propCommonValue, propTrackKey : propTrackValue, propTrackKey2 : propTrackValue2})
+                 trackEvent:eventName
+             withProperties:(@{propCommonKey : propCommonValue, propTrackKey : propTrackValue, propTrackKey2 : propTrackValue2})
       forTransmissionTarget:target]));
 }
 

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
@@ -5,14 +5,19 @@
 #import "MSAnalyticsTransmissionTargetPrivate.h"
 #import "MSAppCenterInternal.h"
 #import "MSAppExtension.h"
-#import "MSChannelUnitDefault.h"
 #import "MSCSExtensions.h"
+#import "MSChannelGroupDefault.h"
+#import "MSChannelGroupDefaultPrivate.h"
+#import "MSChannelUnitDefault.h"
 #import "MSEventLog.h"
 #import "MSEventPropertiesInternal.h"
 #import "MSMockUserDefaults.h"
 #import "MSPropertyConfiguratorPrivate.h"
+#import "MSProtocolExtension.h"
 #import "MSStringTypedProperty.h"
 #import "MSTestFrameworks.h"
+#import "MSAppCenterIngestion.h"
+#import "MSOneCollectorChannelDelegate.h"
 
 static NSString *const kMSTestTransmissionToken = @"TestTransmissionToken";
 static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
@@ -88,7 +93,7 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
                                                                                                  parentTarget:nil
                                                                                                  channelGroup:self.channelGroupMock];
   NSString *eventName = @"event";
-  NSDictionary *properties = @{ @"prop1" : @"val1", @"prop2" : @"val2" };
+  NSDictionary *properties = @{@"prop1" : @"val1", @"prop2" : @"val2"};
 
   // When
   [sut trackEvent:eventName withProperties:properties];
@@ -135,18 +140,21 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
   // Then
   XCTAssertNotEqualObjects(parentTransmissionTarget, childTransmissionTarget3);
   XCTAssertEqualObjects(childTransmissionTarget3, parentTransmissionTarget.childTransmissionTargets[kMSTestTransmissionToken]);
-  OCMVerify(
-      ClassMethod([self.analyticsClassMock trackEvent:event1 withProperties:properties forTransmissionTarget:childTransmissionTarget]));
-  OCMVerify(
-      ClassMethod([self.analyticsClassMock trackEvent:event2 withProperties:properties forTransmissionTarget:childTransmissionTarget2]));
-  OCMVerify(
-      ClassMethod([self.analyticsClassMock trackEvent:event3 withProperties:properties forTransmissionTarget:childTransmissionTarget3]));
+  OCMVerify(ClassMethod([self.analyticsClassMock trackEvent:event1
+                                             withProperties:properties
+                                      forTransmissionTarget:childTransmissionTarget]));
+  OCMVerify(ClassMethod([self.analyticsClassMock trackEvent:event2
+                                             withProperties:properties
+                                      forTransmissionTarget:childTransmissionTarget2]));
+  OCMVerify(ClassMethod([self.analyticsClassMock trackEvent:event3
+                                             withProperties:properties
+                                      forTransmissionTarget:childTransmissionTarget3]));
 }
 
 - (void)testTransmissionTargetEnabledState {
 
   // If
-  NSDictionary *properties = @{ @"prop1" : @"val1", @"prop2" : @"val2" };
+  NSDictionary *properties = @{@"prop1" : @"val1", @"prop2" : @"val2"};
   NSString *event1 = @"event1";
   NSString *event2 = @"event2";
   NSString *event3 = @"event3";
@@ -428,8 +436,8 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
   // Then
   XCTAssertEqualObjects(target.propertyConfigurator.eventProperties, commonProperties);
   OCMVerify(ClassMethod([self.analyticsClassMock
-                 trackEvent:eventName
-             withProperties:(@{propCommonKey : propCommonValue, propTrackKey : propTrackValue, propTrackKey2 : propTrackValue2})
+          trackEvent:eventName
+      withProperties:(@{propCommonKey : propCommonValue, propTrackKey : propTrackValue, propTrackKey2 : propTrackValue2})
       forTransmissionTarget:target]));
 }
 
@@ -799,6 +807,72 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
 
   // Then
   XCTAssertEqual(provider, MSAnalyticsTransmissionTarget.authenticationProvider);
+}
+
+- (void)testTicketKeysDontApplyRetroactively {
+
+  // If
+  __block NSArray<NSString *> *ticketKeysEvent1;
+  __block NSArray<NSString *> *ticketKeysEvent2;
+  MSAnalyticsTransmissionTarget *sut = [MSAnalytics transmissionTargetForToken:kMSTestTransmissionToken];
+  id deviceMock = OCMPartialMock([MSDevice new]);
+  OCMStub([deviceMock isValid]).andReturn(YES);
+  id deviceTrackerMock = OCMClassMock([MSDeviceTracker class]);
+  OCMStub([deviceTrackerMock sharedInstance]).andReturn(deviceTrackerMock);
+  OCMStub([deviceTrackerMock device]).andReturn(deviceMock);
+  id appCenterMock = OCMClassMock([MSAppCenter class]);
+  OCMStub([appCenterMock sharedInstance]).andReturn(appCenterMock);
+  OCMStub([appCenterMock sdkConfigured]).andReturn(YES);
+  OCMStub(ClassMethod([appCenterMock isEnabled])).andReturn(YES);
+  MSChannelGroupDefault *channelGroupMock = [[MSChannelGroupDefault alloc] initWithIngestion:OCMPartialMock([MSAppCenterIngestion new])];
+  id<MSChannelUnitProtocol> oneCollectorChannelUnitMock = OCMProtocolMock(@protocol(MSChannelUnitProtocol));
+  MSOneCollectorChannelDelegate *oneCollectorChannelDelegate = [[MSOneCollectorChannelDelegate alloc] initWithInstallId:[NSUUID new]];
+  [channelGroupMock addDelegate:oneCollectorChannelDelegate];
+  OCMStub([channelGroupMock channelUnitForGroupId:@"Analytics/one"]).andReturn(oneCollectorChannelUnitMock);
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:nil
+                              transmissionTargetToken:kMSTestTransmissionToken
+                                      fromApplication:NO];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Enqueue log is called twice"];
+  OCMStub([oneCollectorChannelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSCommonSchemaLog class]]]).andDo(^(NSInvocation *invocation) {
+    MSCommonSchemaLog *log;
+    static int count = 0;
+    [invocation getArgument:&log atIndex:2];
+    if ([log.name isEqualToString:@"testEvent1"]) {
+      ticketKeysEvent1 = [log.ext.protocolExt ticketKeys];
+      count++;
+    } else if ([log.name isEqualToString:@"testEvent2"]) {
+      ticketKeysEvent2 = [log.ext.protocolExt ticketKeys];
+      count++;
+    }
+    if (count == 2) {
+      [expectation fulfill];
+    }
+  });
+  MSAnalyticsAuthenticationProvider *provider1 = OCMPartialMock([MSAnalyticsAuthenticationProvider new]);
+  OCMStub(provider1.ticketKey).andReturn(@"ticketKey1");
+  MSAnalyticsAuthenticationProvider *provider2 = OCMPartialMock([MSAnalyticsAuthenticationProvider new]);
+  OCMStub(provider2.ticketKey).andReturn(@"ticketKey2");
+
+  // When
+  [sut trackEvent:@"testEvent1"];
+  [MSAnalyticsTransmissionTarget addAuthenticationProvider:provider1];
+  [sut trackEvent:@"testEvent2"];
+  [MSAnalyticsTransmissionTarget addAuthenticationProvider:provider2];
+
+  // Then
+  [self waitForExpectationsWithTimeout:5
+                               handler:^(NSError *error) {
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+
+                                 // Then
+                                 XCTAssertNotNil(ticketKeysEvent1);
+                                 XCTAssertNotNil(ticketKeysEvent2);
+                               }];
+  [appCenterMock stopMocking];
+  [deviceTrackerMock stopMocking];
 }
 
 - (void)testPauseSucceedsWhenTargetIsEnabled {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

*~[ ] Has `CHANGELOG.md` been updated?~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fixes an issue where an event created before setting an authentication provider would use the subsequently added provider instead of what was set prior to the log being sent.

Found that is not harmful to remove the `dispatch_async`s from surrounding the `enqueueItem` in the `MSOneCollectorChannelDelegate` because `enqueueItem` is not a blocking method (in `trackEvent` the SDK is already calling `enqueueItem` on the calling thread).

## Related PRs or issues

https://github.com/Microsoft/AppCenter-SDK-Android/pull/837
