### PR TITLE
Fix a bug in clang format script where Git Diff is confused with `--name-only` option with its parameters

### DIFF
--- a/clang-format-changed-files.sh
+++ b/clang-format-changed-files.sh
@@ -5,7 +5,7 @@
 upstream=$(git remote -v | grep "Microsoft/" | awk '{print $1}' | uniq)
 git fetch $upstream
 i=0
-for modified_file in $(git diff $upstream/develop --name-only *.h *.m *.mm)
+for modified_file in $(git diff $upstream/develop --name-only -- *.h *.m *.mm)
 do 
   clang-format -i -style=file $modified_file
   exit_code=$?


### PR DESCRIPTION

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [ ] ~Are tests passing locally?~
* [ ] ~Are the files formatted correctly?~
* [ ] ~Did you add unit tests?~
* [ ] ~Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?~

## Description

`git diff $upstream/develop --name-only -- *.h *.m *.mm` 
Use double dash (`--`) to separate Git option `--name-only` from parameters `*.h *.m *.mm` to avoid issues with this command.
