### PR TITLE
Modify strong typed api names for swift

### DIFF
--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.h
@@ -88,7 +88,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * - The full event size when encoded as a JSON string cannot be larger than 1.9MB.
  */
-+ (void)trackEvent:(NSString *)eventName withTypedProperties:(nullable MSEventProperties *)properties;
++ (void)trackEvent:(NSString *)eventName
+    withTypedProperties:(nullable MSEventProperties *)properties NS_SWIFT_NAME(trackEvent(_:withProperties:));
 
 /**
  * Pause transmission of Analytics logs. While paused, Analytics logs are saved to disk.

--- a/AppCenterAnalytics/AppCenterAnalytics/MSEventProperties.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSEventProperties.h
@@ -13,15 +13,14 @@ NS_ASSUME_NONNULL_BEGIN
  * @param value Property value.
  * @param key Property key.
  */
-- (instancetype)setString:(NSString *)value forKey:(NSString *)key;
-
+- (instancetype)setString:(NSString *)value forKey:(NSString *)key NS_SWIFT_NAME(setEventProperty(_:forKey:));
 /**
  * Set a double property.
  *
  * @param value Property value. Must be finite (`NAN` and `INFINITY` not allowed).
  * @param key Property key.
  */
-- (instancetype)setDouble:(double)value forKey:(NSString *)key;
+- (instancetype)setDouble:(double)value forKey:(NSString *)key NS_SWIFT_NAME(setEventProperty(_:forKey:));
 
 /**
  * Set a 64-bit integer property.
@@ -29,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param value Property value.
  * @param key Property key.
  */
-- (instancetype)setInt64:(int64_t)value forKey:(NSString *)key;
+- (instancetype)setInt64:(int64_t)value forKey:(NSString *)key NS_SWIFT_NAME(setEventProperty(_:forKey:));
 
 /**
  * Set a boolean property.
@@ -37,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param value Property value.
  * @param key Property key.
  */
-- (instancetype)setBool:(BOOL)value forKey:(NSString *)key;
+- (instancetype)setBool:(BOOL)value forKey:(NSString *)key NS_SWIFT_NAME(setEventProperty(_:forKey:));
 
 /**
  * Set a date property.
@@ -45,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param value Property value.
  * @param key Property key.
  */
-- (instancetype)setDate:(NSDate *)value forKey:(NSString *)key;
+- (instancetype)setDate:(NSDate *)value forKey:(NSString *)key NS_SWIFT_NAME(setEventProperty(_:forKey:));
 
 @end
 

--- a/AppCenterAnalytics/AppCenterAnalytics/MSEventProperties.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSEventProperties.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param key Property key.
  */
 - (instancetype)setString:(NSString *)value forKey:(NSString *)key NS_SWIFT_NAME(setEventProperty(_:forKey:));
+
 /**
  * Set a double property.
  *

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
@@ -54,7 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * - The full event size when encoded as a JSON string cannot be larger than 1.9MB.
  */
-- (void)trackEvent:(NSString *)eventName withTypedProperties:(nullable MSEventProperties *)properties;
+- (void)trackEvent:(NSString *)eventName
+    withTypedProperties:(nullable MSEventProperties *)properties NS_SWIFT_NAME(trackEvent(_:withProperties:));
 
 /**
  * Get a nested transmission target.

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSPropertyConfigurator.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSPropertyConfigurator.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  * properties passed to the `trackEvent:withProperties:` or `trackEvent:withTypedProperties:` override any property with the same key from
  * the transmission target itself or its parents.
  */
-- (void)setEventPropertyString:(NSString *)propertyValue forKey:(NSString *)propertyKey;
+- (void)setEventPropertyString:(NSString *)propertyValue forKey:(NSString *)propertyKey NS_SWIFT_NAME(setEventProperty(_:forKey:));
 
 /**
  * Set a double event property to be attached to events tracked by this transmission target and its child transmission targets.
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
  * properties passed to the `trackEvent:withProperties:` or `trackEvent:withTypedProperties:` override any property with the same key from
  * the transmission target itself or its parents.
  */
-- (void)setEventPropertyDouble:(double)propertyValue forKey:(NSString *)propertyKey;
+- (void)setEventPropertyDouble:(double)propertyValue forKey:(NSString *)propertyKey NS_SWIFT_NAME(setEventProperty(_:forKey:));
 
 /**
  * Set a 64-bit integer event property to be attached to events tracked by this transmission target and its child transmission targets.
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
  * properties passed to the `trackEvent:withProperties:` or `trackEvent:withTypedProperties:` override any property with the same key from
  * the transmission target itself or its parents.
  */
-- (void)setEventPropertyInt64:(int64_t)propertyValue forKey:(NSString *)propertyKey;
+- (void)setEventPropertyInt64:(int64_t)propertyValue forKey:(NSString *)propertyKey NS_SWIFT_NAME(setEventProperty(_:forKey:));
 
 /**
  * Set a boolean event property to be attached to events tracked by this transmission target and its child transmission targets.
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
  * properties passed to the `trackEvent:withProperties:` or `trackEvent:withTypedProperties:` override any property with the same key from
  * the transmission target itself or its parents.
  */
-- (void)setEventPropertyBool:(BOOL)propertyValue forKey:(NSString *)propertyKey;
+- (void)setEventPropertyBool:(BOOL)propertyValue forKey:(NSString *)propertyKey NS_SWIFT_NAME(setEventProperty(_:forKey:));
 
 /**
  * Set a date event property to be attached to events tracked by this transmission target and its child transmission targets.
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
  * properties passed to the `trackEvent:withProperties:` or `trackEvent:withTypedProperties:` override any property with the same key from
  * the transmission target itself or its parents.
  */
-- (void)setEventPropertyDate:(NSDate *)propertyValue forKey:(NSString *)propertyKey;
+- (void)setEventPropertyDate:(NSDate *)propertyValue forKey:(NSString *)propertyKey NS_SWIFT_NAME(setEventProperty(_:forKey:));
 
 /**
  * Remove an event property from this transmission target.
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @discussion This won't remove properties with the same name declared in other nested transmission targets.
  */
-- (void)removeEventPropertyForKey:(NSString *)propertyKey;
+- (void)removeEventPropertyForKey:(NSString *)propertyKey NS_SWIFT_NAME(removeEventProperty(forKey:));
 
 /**
  * Once called, the App Center SDK will automatically add UIDevice.identifierForVendor to common schema logs.

--- a/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsViewController.swift
@@ -45,6 +45,8 @@ class MSAnalyticsViewController: UITableViewController, AppCenterProtocol {
     let eventProperties = eventPropertiesSection.eventProperties()
     if (MSTransmissionTargets.shared.defaultTargetShouldSendAnalyticsEvents()) {
       if let properties = eventProperties as? MSEventProperties {
+
+        // The AppCenterDelegate uses the argument label "withTypedProperties," but the underlying swift API simply uses "withProperties."
         appCenter.trackEvent(name, withTypedProperties: properties)
       } else if let dictionary = eventProperties as? [String: String] {
         appCenter.trackEvent(name, withProperties: dictionary)
@@ -56,7 +58,7 @@ class MSAnalyticsViewController: UITableViewController, AppCenterProtocol {
       if MSTransmissionTargets.shared.targetShouldSendAnalyticsEvents(targetToken: targetToken) {
         let target = MSTransmissionTargets.shared.transmissionTargets[targetToken]
         if let properties = eventProperties as? MSEventProperties {
-          target!.trackEvent(name, withTypedProperties: properties)
+          target!.trackEvent(name, withProperties: properties)
         } else if let dictionary = eventProperties as? [String: String] {
           target!.trackEvent(name, withProperties: dictionary)
         } else {

--- a/Sasquatch/Sasquatch/ViewControllers/Sections/EventPropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/EventPropertiesTableSection.swift
@@ -41,19 +41,19 @@ class EventPropertiesTableSection : PropertiesTableSection {
     for property in typedProperties {
       switch property.type {
       case .String:
-        eventProperties.setString(property.value as! String, forKey:property.key)
+        eventProperties.setEventProperty(property.value as! String, forKey: property.key);
         propertyDictionary[property.key] = (property.value as! String)
       case .Double:
-        eventProperties.setDouble(property.value as! Double, forKey:property.key)
+        eventProperties.setEventProperty(property.value as! Double, forKey: property.key)
         onlyStrings = false
       case .Long:
-        eventProperties.setInt64(property.value as! Int64, forKey:property.key)
+        eventProperties.setEventProperty(property.value as! Int64, forKey: property.key)
         onlyStrings = false
       case .Boolean:
-        eventProperties.setBool(property.value as! Bool, forKey:property.key)
+        eventProperties.setEventProperty(property.value as! Bool, forKey: property.key)
         onlyStrings = false
       case .DateTime:
-        eventProperties.setDate(property.value as! Date, forKey:property.key)
+        eventProperties.setEventProperty(property.value as! Date, forKey: property.key)
         onlyStrings = false
       }
     }

--- a/Sasquatch/Sasquatch/ViewControllers/Sections/TargetPropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/TargetPropertiesTableSection.swift
@@ -73,15 +73,15 @@ class TargetPropertiesTableSection : PropertiesTableSection {
   func setEventPropertyState(_ state: PropertyState, forTarget target: MSAnalyticsTransmissionTarget) {
     switch state.type {
     case .String:
-      target.propertyConfigurator.setEventPropertyString(state.value as! String, forKey: state.key)
+      target.propertyConfigurator.setEventProperty(state.value as! String, forKey: state.key)
     case .Boolean:
-      target.propertyConfigurator.setEventPropertyBool(state.value as! Bool, forKey: state.key)
+      target.propertyConfigurator.setEventProperty(state.value as! Bool, forKey: state.key)
     case .Double:
-      target.propertyConfigurator.setEventPropertyDouble(state.value as! Double, forKey: state.key)
+      target.propertyConfigurator.setEventProperty(state.value as! Double, forKey: state.key)
     case .Long:
-      target.propertyConfigurator.setEventPropertyInt64(state.value as! Int64, forKey: state.key)
+      target.propertyConfigurator.setEventProperty(state.value as! Int64, forKey: state.key)
     case .DateTime:
-      target.propertyConfigurator.setEventPropertyDate(state.value as! Date, forKey: state.key)
+      target.propertyConfigurator.setEventProperty(state.value as! Date, forKey: state.key)
     }
   }
 

--- a/Sasquatch/SasquatchSwift/AppCenterDelegateSwift.swift
+++ b/Sasquatch/SasquatchSwift/AppCenterDelegateSwift.swift
@@ -103,7 +103,7 @@ class AppCenterDelegateSwift: AppCenterDelegate {
   }
 
   func trackEvent(_ eventName: String, withTypedProperties properties: MSEventProperties) {
-    MSAnalytics.trackEvent(eventName, withTypedProperties: properties)
+    MSAnalytics.trackEvent(eventName, withProperties: properties)
   }
 
   func trackPage(_ pageName: String) {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests?~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Changed swift API signatures. Examples:

- For `MSPropertyConfigurator` and `MSEventProperties`, setting properties looks like: `prop.setEventProperty("propertyValue", forKey:"propertyKey");`. 
  - For `MSEventProperties`, my first instinct was to match Android's `set(key, value)`, but this is a bit unusual for Swift. So looking at other APIs I decided that `setValue("value", forKey:"key")` made sense, but this is actually a method that exists in `NSObject`. So I settled on `setEventProperty("value", forKey:"key")`, because that is consistent with Swift conventions and aligns with `MSPropertyConfigurator`'s API.
- Changed `MSAnalytics` and `MSAnalyticsTransmissionTarget` track event with typed properties to be `trackEvent("eventName", withProperties:{properties});`.



