### PR TITLE
Fix a bug in clang format script where deleted files are not ignored by clang-format

### DIFF
--- a/clang-format-changed-files.sh
+++ b/clang-format-changed-files.sh
@@ -5,7 +5,7 @@
 upstream=$(git remote -v | grep "Microsoft/" | awk '{print $1}' | uniq)
 git fetch $upstream
 i=0
-for modified_file in $(git diff $upstream/develop --name-only -- *.h *.m *.mm)
+for modified_file in $(git diff $upstream/develop --diff-filter=ACMR --name-only -- *.h *.m *.mm)
 do 
   clang-format -i -style=file $modified_file
   exit_code=$?


### PR DESCRIPTION
* ~[ ] Has `CHANGELOG.md` been updated?~
* ~[ ] Are tests passing locally?~
* ~[ ] Are the files formatted correctly?~
* ~[ ] Did you add unit tests?~
* ~[ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?~

## Description

Fix a bug in clang format script where deleted files are not ignored by clang-format. 

Use `--diff-filter=ACMR` to only show "Added" (A), "Copied" (C), "Modified" (M) and "Renamed" (R) files.
