### PR TITLE
Min database size changed with index

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupProtocol.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupProtocol.h
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion The default maximum database size is 10485760 bytes (10 MiB).
  *
  * @param sizeInBytes Maximum size of the internal storage in bytes. This will be rounded up to the nearest multiple of a SQLite page size
- * (default is 4096 bytes). Values below 20480 bytes (20 KiB) will be ignored.
+ * (default is 4096 bytes). Values below 24576 bytes (24 KiB) will be ignored.
  * @param completionHandler Callback that is invoked when the database size has been set. The `BOOL` parameter is `YES` if changing the size
  * is successful, and `NO` otherwise.
  */

--- a/AppCenter/AppCenter/Internals/Storage/MSStorage.h
+++ b/AppCenter/AppCenter/Internals/Storage/MSStorage.h
@@ -75,7 +75,7 @@ typedef void (^MSLoadDataCompletionHandler)(NSArray<id<MSLog>> *_Nullable logArr
  * Set the maximum size of the internal storage. This method must be called before App Center is started.
  *
  * @param sizeInBytes Maximum size of the internal storage in bytes. This will be rounded up to the nearest multiple of a SQLite page size
- * (default is 4096 bytes). Values below 20480 bytes (20 KiB) will be ignored.
+ * (default is 4096 bytes). Values below 24576 bytes (24 KiB) will be ignored.
  * @param completionHandler Callback that is invoked when the database size has been set. The `BOOL` parameter is `YES` if changing the size
  * is successful, and `NO` otherwise.
  *

--- a/AppCenter/AppCenter/MSAppCenter.m
+++ b/AppCenter/AppCenter/MSAppCenter.m
@@ -41,8 +41,8 @@ static NSString *const kMSServiceName = @"AppCenter";
 static NSString *const kMSGroupId = @"AppCenter";
 
 /**
- * The minimum storage size.
- * 24 KiB to be able send default logs (start service, start session, push installation), limited by SQLite.
+ * The minimum storage size, limited by SQLite.
+ * 24 KiB to be able to send the default logs (start service, start session, push installation).
  */
 static const long kMSMinUpperSizeLimitInBytes = 24 * 1024;
 

--- a/AppCenter/AppCenter/MSAppCenter.m
+++ b/AppCenter/AppCenter/MSAppCenter.m
@@ -42,9 +42,9 @@ static NSString *const kMSGroupId = @"AppCenter";
 
 /**
  * The minimum storage size.
- * 20 KiB to be consistent with Android SDK, limited by SQLite.
+ * 24 KiB to be able send default logs (start service, start session, push installation), limited by SQLite.
  */
-static const long kMSMinUpperSizeLimitInBytes = 20 * 1024;
+static const long kMSMinUpperSizeLimitInBytes = 24 * 1024;
 
 @implementation MSAppCenter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for iOS and macOS Change Log
 
+## Version 1.12.0 (Under active development)
+
+### AppCenter
+
+* **[Fix]** Fix minimum storage size verification to match actual value.
+
+___
+
 ## Version 1.11.0
 
 ### AppCenter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # App Center SDK for iOS and macOS Change Log
 
-## Version 1.12.0 (Under active development)
+## Version 1.11.1 (Under active development)
 
 ### AppCenter
 


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix minimum storage size verification to match actual value.
The minimum storage size is 24 KiB to be able to send the default logs (start service, start session, push installation).
