### PR TITLE
Not dropping all logs and disgard a new log when the log size is exactly same as max storage size

### DIFF
--- a/AppCenter/AppCenter/Internals/Storage/MSLogDBStorage.m
+++ b/AppCenter/AppCenter/Internals/Storage/MSLogDBStorage.m
@@ -69,7 +69,7 @@ static const NSUInteger kMSSchemaVersion = 3;
   return [self executeQueryUsingBlock:^int(void *db) {
            // Check maximum size.
            NSUInteger maxSize = [MSDBStorage getMaxPageCountInOpenedDatabase:db] * self.pageSize;
-           if (base64Data.length > maxSize) {
+           if (base64Data.length >= maxSize) {
              MSLogError([MSAppCenter logTag],
                         @"Log is too large (%tu bytes) to store in database. Current maximum database size is %tu bytes.",
                         base64Data.length, maxSize);


### PR DESCRIPTION
* [ ] ~Has `CHANGELOG.md` been updated?~
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] ~Did you add unit tests?~
* [ ] ~Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?~

## Description

We definitely know that a log will be discarded when the size is same as storage max size due to additional information that also being stored in the storage with the log.
