### PR TITLE
Increased sleep durations to stabilize testDisableSDKPersistence UITest

### DIFF
--- a/Sasquatch/SasquatchUITests/AppCenterUITests.swift
+++ b/Sasquatch/SasquatchUITests/AppCenterUITests.swift
@@ -96,12 +96,12 @@ class AppCenterUITests: XCTestCase {
     XCTAssertFalse(appCenterButton.boolValue)
     
     // Several attempts for sure.
-    for i in 0..<10 {
+    for i in 0..<3 {
       
       // Restart application.
-      sleep(1)
+      sleep(5)
       XCUIDevice().press(.home)
-      sleep(1)
+      sleep(5)
       app.launch()
       
       appCenterButton = app.tables["App Center"].switches["Set Enabled"]
@@ -113,9 +113,9 @@ class AppCenterUITests: XCTestCase {
       XCTAssertTrue(appCenterButton.boolValue)
       
       // Restart application.
-      sleep(1)
+      sleep(5)
       XCUIDevice().press(XCUIDeviceButton.home)
-      sleep(1)
+      sleep(5)
       app.launch()
       
       appCenterButton = app.tables["App Center"].switches["Set Enabled"]


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [X] Did you check UI tests on the sample app? They are not executed on CI.
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Increased sleep duration to stabilize `testDisableSDKPersistence` in `AppCenterUITest` test suite.