### PR TITLE
Implement AppCenter.setUserId for 1st party customer

### DIFF
--- a/AppCenter/AppCenter/Internals/History/UserId/MSUserIdContext.h
+++ b/AppCenter/AppCenter/Internals/History/UserId/MSUserIdContext.h
@@ -49,6 +49,24 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)clearUserIdHistory;
 
+/**
+ * Check if userId is valid for App Center.
+ *
+ * @param userId The user Id.
+ *
+ * @return YES if valid, NO otherwise.
+ */
++ (BOOL)checkUserIdValidForAppCenter:(nullable NSString *)userId;
+
+/**
+ * Check if userId is valid for One Collector.
+ *
+ * @param userId The user Id.
+ *
+ * @return YES if valid, NO otherwise.
+ */
++ (BOOL)checkUserIdValidForOneCollector:(nullable NSString *)userId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenter/AppCenter/Internals/History/UserId/MSUserIdContext.m
+++ b/AppCenter/AppCenter/Internals/History/UserId/MSUserIdContext.m
@@ -121,7 +121,7 @@ static dispatch_once_t onceToken;
     return YES;
   }
   NSRange separator = [userId rangeOfString:@":"];
-  if (separator.location == userId.length - 1) {
+  if (userId.length == 0 || separator.location == userId.length - 1) {
     MSLogError([MSAppCenter logTag], @"userId must not be empty.");
     return NO;
   }

--- a/AppCenter/AppCenter/Internals/Model/CommonSchema/MSCSModelConstants.h
+++ b/AppCenter/AppCenter/Internals/Model/CommonSchema/MSCSModelConstants.h
@@ -22,6 +22,7 @@ extern NSString *const kMSFieldDelimiter;
 
 #pragma mark - MSUserExtension
 
+extern NSString *const kMSUserLocalId;
 extern NSString *const kMSUserLocale;
 
 #pragma mark - MSDeviceExtension

--- a/AppCenter/AppCenter/Internals/Model/CommonSchema/MSCSModelConstants.m
+++ b/AppCenter/AppCenter/Internals/Model/CommonSchema/MSCSModelConstants.m
@@ -22,6 +22,7 @@ NSString *const kMSFieldDelimiter = @"f";
 
 #pragma mark - MSUserExtension
 
+NSString *const kMSUserLocalId = @"localId";
 NSString *const kMSUserLocale = @"locale";
 
 #pragma mark - MSDeviceExtension

--- a/AppCenter/AppCenter/Internals/Model/CommonSchema/MSUserExtension.h
+++ b/AppCenter/AppCenter/Internals/Model/CommonSchema/MSUserExtension.h
@@ -9,6 +9,11 @@
 @interface MSUserExtension : NSObject <MSSerializableObject, MSModel>
 
 /**
+ * Local Id.
+ */
+@property(nonatomic, copy) NSString *localId;
+
+/**
  * User's locale.
  */
 @property(nonatomic, copy) NSString *locale;

--- a/AppCenter/AppCenter/Internals/Model/CommonSchema/MSUserExtension.m
+++ b/AppCenter/AppCenter/Internals/Model/CommonSchema/MSUserExtension.m
@@ -6,13 +6,14 @@
 #pragma mark - MSSerializableObject
 
 - (NSMutableDictionary *)serializeToDictionary {
-  NSMutableDictionary *dict;
-  if (self.locale) {
-    dict = [NSMutableDictionary new];
+  NSMutableDictionary *dict = [NSMutableDictionary new];
+  if (self.localId) {
     dict[kMSUserLocalId] = self.localId;
+  }
+  if (self.locale) {
     dict[kMSUserLocale] = self.locale;
   }
-  return dict;
+  return dict.count == 0 ? nil : dict;
 }
 
 #pragma mark - MSModel

--- a/AppCenter/AppCenter/Internals/Model/CommonSchema/MSUserExtension.m
+++ b/AppCenter/AppCenter/Internals/Model/CommonSchema/MSUserExtension.m
@@ -9,6 +9,7 @@
   NSMutableDictionary *dict;
   if (self.locale) {
     dict = [NSMutableDictionary new];
+    dict[kMSUserLocalId] = self.localId;
     dict[kMSUserLocale] = self.locale;
   }
   return dict;
@@ -29,19 +30,22 @@
     return NO;
   }
   MSUserExtension *userExt = (MSUserExtension *)object;
-  return (!self.locale && !userExt.locale) || [self.locale isEqualToString:userExt.locale];
+  return ((!self.localId && !userExt.localId) || [self.localId isEqualToString:userExt.localId]) &&
+         ((!self.locale && !userExt.locale) || [self.locale isEqualToString:userExt.locale]);
 }
 
 #pragma mark - NSCoding
 
 - (instancetype)initWithCoder:(NSCoder *)coder {
   if ((self = [super init])) {
+    _localId = [coder decodeObjectForKey:kMSUserLocalId];
     _locale = [coder decodeObjectForKey:kMSUserLocale];
   }
   return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
+  [coder encodeObject:self.localId forKey:kMSUserLocalId];
   [coder encodeObject:self.locale forKey:kMSUserLocale];
 }
 

--- a/AppCenter/AppCenter/Internals/Model/MSAbstractLog.m
+++ b/AppCenter/AppCenter/Internals/Model/MSAbstractLog.m
@@ -186,6 +186,7 @@
   csLog.ext.appExt.appId = [NSString stringWithFormat:@"I:%@", self.device.appNamespace];
   csLog.ext.appExt.ver = self.device.appVersion;
   csLog.ext.appExt.locale = [[[NSBundle mainBundle] preferredLocalizations] firstObject];
+  csLog.ext.appExt.userId = self.userId;
 
   // Network extension.
   csLog.ext.netExt = [MSNetExtension new];

--- a/AppCenter/AppCenter/Internals/Util/MSConstants+Internal.h
+++ b/AppCenter/AppCenter/Internals/Util/MSConstants+Internal.h
@@ -157,13 +157,3 @@ static NSString *const kMSOneCollectorGroupIdSuffix = @"/one";
  * Bit mask for persistence flags.
  */
 static const NSUInteger kMSPersistenceFlagsMask = 0xFF;
-
-/**
- * Maximum userId length.
- */
-static const int kMSMaxUserIdLength = 256;
-
-/*
- * Valid application userId for One Collector.
- */
-static NSString *const kAppUserIdPattern = @"^[cidw]:.*$";

--- a/AppCenter/AppCenter/MSAppCenter.m
+++ b/AppCenter/AppCenter/MSAppCenter.m
@@ -464,20 +464,10 @@ static const long kMSMinUpperSizeLimitInBytes = 24 * 1024;
     return;
   }
   if (userId) {
-    if (self.appSecret && [userId length] > kMSMaxUserIdLength) {
-      MSLogError([MSAppCenter logTag], @"userId is limited to %d characters.", kMSMaxUserIdLength);
+    if (self.appSecret && ![MSUserIdContext checkUserIdValidForAppCenter:userId]) {
       return;
     }
-    NSError *error = nil;
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:kAppUserIdPattern options:(NSRegularExpressionOptions)0 error:&error];
-    if (!regex) {
-      MSLogError([MSAppCenter logTag], @"Couldn't create regular expression with pattern\"%@\": %@", kAppUserIdPattern,
-                 error.localizedDescription);
-      return;
-    }
-    if (self.defaultTransmissionTargetToken &&
-        ![regex matchesInString:userId options:(NSMatchingOptions)0 range:NSMakeRange(0, userId.length)].count) {
-      MSLogError([MSAppCenter logTag], @"userId must match the %@ regular expression.", kAppUserIdPattern);
+    if (self.defaultTransmissionTargetToken && ![MSUserIdContext checkUserIdValidForOneCollector:userId]) {
       return;
     }
   }

--- a/AppCenter/AppCenter/MSAppCenter.m
+++ b/AppCenter/AppCenter/MSAppCenter.m
@@ -461,15 +461,12 @@ static const long kMSMinUpperSizeLimitInBytes = 24 * 1024;
       MSLogError([MSAppCenter logTag], @"userId is limited to %d characters.", kMSMaxUserIdLength);
       return;
     }
-    static NSRegularExpression *regex = nil;
+    NSError *error = nil;
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:kAppUserIdPattern options:(NSRegularExpressionOptions)0 error:&error];
     if (!regex) {
-      NSError *error = nil;
-      regex = [NSRegularExpression regularExpressionWithPattern:kAppUserIdPattern options:(NSRegularExpressionOptions)0 error:&error];
-      if (!regex) {
-        MSLogError([MSAppCenter logTag], @"Couldn't create regular expression with pattern\"%@\": %@", kAppUserIdPattern,
-                   error.localizedDescription);
-        return;
-      }
+      MSLogError([MSAppCenter logTag], @"Couldn't create regular expression with pattern\"%@\": %@", kAppUserIdPattern,
+                 error.localizedDescription);
+      return;
     }
     if (self.defaultTransmissionTargetToken &&
         ![regex matchesInString:userId options:(NSMatchingOptions)0 range:NSMakeRange(0, userId.length)].count) {

--- a/AppCenter/AppCenterTests/MSAbstractLogTests.m
+++ b/AppCenter/AppCenterTests/MSAbstractLogTests.m
@@ -279,6 +279,7 @@
     XCTAssertEqualObjects(log.ext.appExt.appId, expectedAppId);
     XCTAssertEqualObjects(log.ext.appExt.ver, self.sut.device.appVersion);
     XCTAssertEqualObjects(log.ext.appExt.locale, expectedAppLocale);
+    XCTAssertEqualObjects(log.ext.appExt.userId, self.sut.userId);
 
     // Network extension.
     XCTAssertNotNil(log.ext.netExt);

--- a/AppCenter/AppCenterTests/MSAppCenterTests.m
+++ b/AppCenter/AppCenterTests/MSAppCenterTests.m
@@ -17,7 +17,7 @@
 #import "MSOneCollectorChannelDelegate.h"
 #import "MSStartServiceLog.h"
 #import "MSTestFrameworks.h"
-#import "MSUserIdContext.h"
+#import "MSUserIdContextPrivate.h"
 
 static NSString *const kMSInstallIdStringExample = @"F18499DA-5C3D-4F05-B4E8-D8C9C06A6F09";
 
@@ -37,6 +37,7 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 - (void)setUp {
   [super setUp];
   [MSAppCenter resetSharedInstance];
+  [MSUserIdContext resetSharedInstance];
 
   // System Under Test.
   self.sut = [[MSAppCenter alloc] init];

--- a/AppCenter/AppCenterTests/MSAppCenterTests.m
+++ b/AppCenter/AppCenterTests/MSAppCenterTests.m
@@ -732,10 +732,21 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
   [MSAppCenter setUserId:userId];
 
   // Then
-  XCTAssertEqual([[MSUserIdContext sharedInstance] userId], userId);
-}
+  XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
 
-- (void)testSetNilUserId {
+  // When
+  [MSAppCenter startFromLibraryWithServices:@[ MSMockService.class ]];
+  [MSAppCenter setUserId:userId];
+
+  // Then
+  XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
+
+  // When
+  [MSAppCenter configureWithAppSecret:@"AppSecret"];
+  [MSAppCenter setUserId:userId];
+
+  // Then
+  XCTAssertEqual([[MSUserIdContext sharedInstance] userId], userId);
 
   // When
   [MSAppCenter setUserId:nil];
@@ -744,7 +755,7 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
   XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
 }
 
-- (void)testSetInvalidUserId {
+- (void)testSetInvalidUserIdForAppCenter {
 
   // If
   NSString *userId = @"";
@@ -758,6 +769,54 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 
   // Then
   XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
+}
+
+- (void)testSetInvalidUserIdForTransmissionTarget {
+
+  // If
+  [MSAppCenter configureWithAppSecret:@"target=transmissionTargetToken"];
+
+  // When
+  [MSAppCenter setUserId:@""];
+
+  // Then
+  XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
+
+  // When
+  [MSAppCenter setUserId:@"alice"];
+
+  // Then
+  XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
+
+  // When
+  [MSAppCenter setUserId:@"p:test"];
+
+  // Then
+  XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
+
+  // When
+  [MSAppCenter setUserId:@"c:alice"];
+
+  // Then
+  XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"c:alice");
+
+  // When
+  [MSAppCenter setUserId:@"i:user@microsoft.com"];
+
+  // Then
+  XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"i:user@microsoft.com");
+
+  // When
+  [MSAppCenter setUserId:@"d:adc44f2dc6915cc8823711a90dbe802a93845625cc3ad75bab6c033a230855c1"];
+
+  // Then
+  XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"d:adc44f2dc6915cc8823711a90dbe802a93845625cc3ad75bab6c033a230855c1");
+
+  // When
+  [MSAppCenter setUserId:@"w:1BD8FC6E-98CE-E03D-B19D-BFD5A9BA712D"];
+
+  // Then
+  XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"w:1BD8FC6E-98CE-E03D-B19D-BFD5A9BA712D");
 }
 
 @end

--- a/AppCenter/AppCenterTests/MSAppCenterTests.m
+++ b/AppCenter/AppCenterTests/MSAppCenterTests.m
@@ -797,6 +797,19 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
   XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
 }
 
+
+- (void)testSetUserIdWithoutSecret {
+  // If
+  NSString *userId = @"user123";
+
+  // When
+  [MSAppCenter configure];
+  [MSAppCenter setUserId:userId];
+
+  // Then
+  XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
+}
+
 - (void)testSetInvalidUserIdForAppCenter {
 
   // If
@@ -828,37 +841,13 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
   [MSAppCenter setUserId:@"alice"];
 
   // Then
-  XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
-
-  // When
-  [MSAppCenter setUserId:@"p:test"];
-
-  // Then
-  XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
+  XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"alice");
 
   // When
   [MSAppCenter setUserId:@"c:alice"];
 
   // Then
   XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"c:alice");
-
-  // When
-  [MSAppCenter setUserId:@"i:user@microsoft.com"];
-
-  // Then
-  XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"i:user@microsoft.com");
-
-  // When
-  [MSAppCenter setUserId:@"d:adc44f2dc6915cc8823711a90dbe802a93845625cc3ad75bab6c033a230855c1"];
-
-  // Then
-  XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"d:adc44f2dc6915cc8823711a90dbe802a93845625cc3ad75bab6c033a230855c1");
-
-  // When
-  [MSAppCenter setUserId:@"w:1BD8FC6E-98CE-E03D-B19D-BFD5A9BA712D"];
-
-  // Then
-  XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"w:1BD8FC6E-98CE-E03D-B19D-BFD5A9BA712D");
 }
 
 - (void)testNoUserIdWhenSetUserIdIsNotCalledInNextVersion {

--- a/AppCenter/AppCenterTests/MSAppCenterTests.m
+++ b/AppCenter/AppCenterTests/MSAppCenterTests.m
@@ -801,7 +801,7 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 
   // If
   NSString *userId = @"";
-  for (int i = 0; i < kMSMaxUserIdLength + 1; i++) {
+  for (int i = 0; i < 257; i++) {
     userId = [userId stringByAppendingString:@"x"];
   }
   [MSAppCenter configureWithAppSecret:@"AppSecret"];

--- a/AppCenter/AppCenterTests/MSCSExtensionsTests.m
+++ b/AppCenter/AppCenterTests/MSCSExtensionsTests.m
@@ -257,6 +257,7 @@
 
   // Then
   XCTAssertNotNil(dict);
+  XCTAssertEqualObjects(dict[kMSUserLocalId], self.userExtDummyValues[kMSUserLocalId]);
   XCTAssertEqualObjects(dict[kMSUserLocale], self.userExtDummyValues[kMSUserLocale]);
 }
 
@@ -270,6 +271,7 @@
   XCTAssertNotNil(actualUserExt);
   XCTAssertEqualObjects(self.userExt, actualUserExt);
   XCTAssertTrue([actualUserExt isMemberOfClass:[MSUserExtension class]]);
+  XCTAssertEqualObjects(actualUserExt.localId, self.userExtDummyValues[kMSUserLocalId]);
   XCTAssertEqualObjects(actualUserExt.locale, self.userExtDummyValues[kMSUserLocale]);
 }
 
@@ -298,6 +300,13 @@
 
   // If
   anotherUserExt.locale = @"fr-fr";
+
+  // Then
+  XCTAssertNotEqualObjects(anotherUserExt, self.userExt);
+
+  // If
+  anotherUserExt.locale = self.userExtDummyValues[kMSUserLocale];
+  anotherUserExt.localId = @"42";
 
   // Then
   XCTAssertNotEqualObjects(anotherUserExt, self.userExt);

--- a/AppCenter/AppCenterTests/MSModelTestsUtililty.m
+++ b/AppCenter/AppCenterTests/MSModelTestsUtililty.m
@@ -83,7 +83,7 @@
 }
 
 + (NSDictionary *)userExtensionDummies {
-  return @{kMSUserLocale : @"en-us"};
+  return @{kMSUserLocalId : @"bob", kMSUserLocale : @"en-us"};
 }
 
 + (NSDictionary *)locExtensionDummies {
@@ -183,6 +183,7 @@
 
 + (MSUserExtension *)userExtensionWithDummyValues:(NSDictionary *)dummyValues {
   MSUserExtension *userExt = [MSUserExtension new];
+  userExt.localId = dummyValues[kMSUserLocalId];
   userExt.locale = dummyValues[kMSUserLocale];
   return userExt;
 }

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -14,6 +14,7 @@
 #import "MSServiceAbstractProtected.h"
 #import "MSStringTypedProperty.h"
 #import "MSTypedProperty.h"
+#import "MSUserIdContext.h"
 #import "MSUtility+StringFormatting.h"
 
 // Service name for initialization.
@@ -307,6 +308,7 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
     if (transmissionTarget.isEnabled) {
       [log addTransmissionTargetToken:[transmissionTarget transmissionTargetToken]];
       log.tag = transmissionTarget;
+      log.userId = [[MSUserIdContext sharedInstance] userId];
     } else {
       MSLogError([MSAnalytics logTag], @"This transmission target is disabled.");
       return;

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -308,7 +308,9 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
     if (transmissionTarget.isEnabled) {
       [log addTransmissionTargetToken:[transmissionTarget transmissionTargetToken]];
       log.tag = transmissionTarget;
-      log.userId = [[MSUserIdContext sharedInstance] userId];
+      if (transmissionTarget == self.defaultTransmissionTarget) {
+        log.userId = [[MSUserIdContext sharedInstance] userId];
+      }
     } else {
       MSLogError([MSAnalytics logTag], @"This transmission target is disabled.");
       return;

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSPropertyConfigurator.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSPropertyConfigurator.m
@@ -18,6 +18,7 @@
 #import "MSLogger.h"
 #import "MSPropertyConfiguratorPrivate.h"
 #import "MSStringTypedProperty.h"
+#import "MSUserIdContext.h"
 
 @implementation MSPropertyConfigurator
 
@@ -48,21 +49,7 @@ static const char deviceIdPrefix = 'i';
 }
 
 - (void)setAppUserId:(NSString *)appUserId {
-  @synchronized([MSAnalytics sharedInstance]) {
-    static NSRegularExpression *regex = nil;
-    if (!regex) {
-      NSError *error = nil;
-      regex = [NSRegularExpression regularExpressionWithPattern:kAppUserIdPattern options:(NSRegularExpressionOptions)0 error:&error];
-      if (!regex) {
-        MSLogError([MSAnalytics logTag], @"Couldn't create regular expression with pattern\"%@\": %@", kAppUserIdPattern,
-                   error.localizedDescription);
-        return;
-      }
-    }
-    if (appUserId && ![regex matchesInString:appUserId options:(NSMatchingOptions)0 range:NSMakeRange(0, appUserId.length)].count) {
-      MSLogError([MSAnalytics logTag], @"appUserId must match the %@ regular expression.", kAppUserIdPattern);
-      return;
-    }
+  if ([MSUserIdContext checkUserIdValidForOneCollector:appUserId]) {
     _appUserId = appUserId;
   }
 }

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
@@ -1206,8 +1206,8 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
   // If
   MSAnalyticsTransmissionTarget *target = [MSAnalytics transmissionTargetForToken:@"invalidUserAppIdTest"];
 
-  // Set invalid user identifier (no prefix).
-  [target.propertyConfigurator setAppUserId:@"invalid"];
+  // Set invalid user identifier.
+  [target.propertyConfigurator setAppUserId:@"invalid:invalid"];
 
   // Set a log.
   MSCommonSchemaLog *log = [MSCommonSchemaLog new];
@@ -1287,7 +1287,7 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
   // If
 
   // Set invalid userId on existing target having a valid userId.
-  [target.propertyConfigurator setAppUserId:@"invalid"];
+  [target.propertyConfigurator setAppUserId:@"invalid:invalid"];
 
   // Reset a log.
   log = [MSCommonSchemaLog new];

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
@@ -18,6 +18,7 @@
 #import "MSPropertyConfiguratorPrivate.h"
 #import "MSStringTypedProperty.h"
 #import "MSTestFrameworks.h"
+#import "MSUserIdContextPrivate.h"
 
 static NSString *const kMSTypeEvent = @"event";
 static NSString *const kMSTestTransmissionToken = @"TestTransmissionToken";
@@ -35,6 +36,7 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
 
 - (void)setUp {
   [super setUp];
+  [MSUserIdContext resetSharedInstance];
 
   // Mock NSUserDefaults
   self.settingsMock = [MSMockUserDefaults new];
@@ -383,10 +385,10 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
 
   // If
   __block MSEventLog *log;
-  [MSAppCenter setUserId:@"c:test"];
-  id channelUnitMock = OCMProtocolMock(@protocol(MSChannelUnitProtocol));
-  id channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
-  OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
+  [[MSUserIdContext sharedInstance] setUserId:@"c:test"];
+  [MSAnalytics resetSharedInstance];
+  id<MSChannelUnitProtocol> channelUnitMock = OCMProtocolMock(@protocol(MSChannelUnitProtocol));
+  OCMStub([self.channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
   [[MSAnalytics sharedInstance] startWithChannelGroup:self.channelGroupMock
                                             appSecret:@"appsecret"
                               transmissionTargetToken:@"token"

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTransmissionTargetTests.m
@@ -379,6 +379,30 @@ static NSString *const kMSTestTransmissionToken2 = @"TestTransmissionToken2";
   XCTAssertEqual(actualFlags, MSFlagsPersistenceNormal);
 }
 
+- (void)testTrackEventSetsUserIdForTransmissionTarget {
+
+  // If
+  __block MSEventLog *log;
+  [MSAppCenter setUserId:@"c:test"];
+  id channelUnitMock = OCMProtocolMock(@protocol(MSChannelUnitProtocol));
+  id channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
+  OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andReturn(channelUnitMock);
+  [[MSAnalytics sharedInstance] startWithChannelGroup:self.channelGroupMock
+                                            appSecret:@"appsecret"
+                              transmissionTargetToken:@"token"
+                                      fromApplication:YES];
+  OCMStub([channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSEventLog class]] flags:MSFlagsDefault]).andDo(^(NSInvocation *invocation) {
+    [invocation getArgument:&log atIndex:2];
+  });
+
+  // When
+  [MSAnalytics trackEvent:@"Some event"];
+
+  // Then
+  XCTAssertNotNil(log);
+  XCTAssertEqual(log.userId, @"c:test");
+}
+
 - (void)testTransmissionTargetForToken {
 
   // If


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

If userId is set via `[MSAppCenter setUserId]` and the default target is One Collector or both, then the value of userId must be set in the user.localId field of Common Schema.

## Related PRs or issues

#1234