### PR TITLE
Improve error message when 1DS userId has only an invalid prefix and nothing after the prefix

### DIFF
--- a/AppCenter/AppCenter/Internals/History/UserId/MSUserIdContext.m
+++ b/AppCenter/AppCenter/Internals/History/UserId/MSUserIdContext.m
@@ -122,7 +122,7 @@ static dispatch_once_t onceToken;
     return YES;
   }
   NSRange separator = [userId rangeOfString:kMSCommonSchemaPrefixSeparator];
-  if (userId.length == 0 || separator.location == userId.length - 1) {
+  if (userId.length == 0) {
     MSLogError([MSAppCenter logTag], @"userId must not be empty.");
     return NO;
   }
@@ -130,6 +130,9 @@ static dispatch_once_t onceToken;
     NSString *prefix = [userId substringToIndex:separator.location];
     if (![prefix isEqualToString:kMSUserIdCustomPrefix]) {
       MSLogError([MSAppCenter logTag], @"userId prefix must be '%@', '%@' is not supported.", kMSUserIdCustomPrefix, prefix);
+      return NO;
+    } else if (separator.location == userId.length - 1) {
+      MSLogError([MSAppCenter logTag], @"userId must not be empty.");
       return NO;
     }
   }

--- a/AppCenter/AppCenterTests/MSAppCenterTests.m
+++ b/AppCenter/AppCenterTests/MSAppCenterTests.m
@@ -765,7 +765,7 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
                                }];
 }
 
-- (void)testSetValidUserId {
+- (void)testSetValidUserIdForAppCenter {
 
   // If
   NSString *userId = @"user123";
@@ -798,6 +798,7 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
 }
 
 - (void)testSetUserIdWithoutSecret {
+
   // If
   NSString *userId = @"user123";
 
@@ -870,7 +871,7 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
   [MSAppCenter setUserId:@"foobar:alice"];
 
   // Then
-  // Current userId shouldn't be overridden by invliad one.
+  // Current userId shouldn't be overridden by the invalid one.
   XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"c:alice");
 }
 

--- a/AppCenter/AppCenterTests/MSAppCenterTests.m
+++ b/AppCenter/AppCenterTests/MSAppCenterTests.m
@@ -797,7 +797,6 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
   XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
 }
 
-
 - (void)testSetUserIdWithoutSecret {
   // If
   NSString *userId = @"user123";
@@ -832,21 +831,46 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
   [MSAppCenter configureWithAppSecret:@"target=transmissionTargetToken"];
 
   // When
+  // Set an empty userId
   [MSAppCenter setUserId:@""];
 
   // Then
   XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
 
   // When
+  // Set another empty userId
+  [MSAppCenter setUserId:@"c:"];
+
+  // Then
+  XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
+
+  // When
+  // Set a userId with invalid prefix
+  [MSAppCenter setUserId:@"foobar:alice"];
+
+  // Then
+  XCTAssertNil([[MSUserIdContext sharedInstance] userId]);
+
+  // When
+  // Set a valid userId without prefix
   [MSAppCenter setUserId:@"alice"];
 
   // Then
   XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"alice");
 
   // When
+  // Set a valid userId with prefix c:
   [MSAppCenter setUserId:@"c:alice"];
 
   // Then
+  XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"c:alice");
+
+  // When
+  // Set a userId with invalid prefix again
+  [MSAppCenter setUserId:@"foobar:alice"];
+
+  // Then
+  // Current userId shouldn't be overridden by invliad one.
   XCTAssertEqual([[MSUserIdContext sharedInstance] userId], @"c:alice");
 }
 


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
When 1DS userId is like `x:` that has an invalid prefix `x` with nothing after the `:`, the error log message is "userId must not be empty."

Now it is "userId prefix must be 'c', 'x' is not supported.".

