### PR TITLE
Free error message after executing SQL query

### DIFF
--- a/AppCenter/AppCenter/Internals/Storage/MSDBStorage.m
+++ b/AppCenter/AppCenter/Internals/Storage/MSDBStorage.m
@@ -156,7 +156,7 @@
 }
 
 + (int)executeNonSelectionQuery:(NSString *)query inOpenedDatabase:(void *)db {
-  char *errMsg;
+  char *errMsg = NULL;
   int result = sqlite3_exec(db, [query UTF8String], NULL, NULL, &errMsg);
   if (result == SQLITE_FULL) {
     MSLogDebug([MSAppCenter logTag], @"Query failed with error: %d - %@", result, [[NSString alloc] initWithUTF8String:errMsg]);
@@ -164,6 +164,9 @@
   else if (result != SQLITE_OK) {
     MSLogError([MSAppCenter logTag], @"Query \"%@\" failed with error: %d - %@", query, result,
                [[NSString alloc] initWithUTF8String:errMsg]);
+  }
+  if (errMsg) {
+    sqlite3_free(errMsg);
   }
   return result;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * **[Fix]** Do not delete old logs when trying to add a log larger than the maximum storage capacity.
 * **[Fix]** Fix minimum storage size verification to match minimum possible value.
 * **[Fix]** Fix reporting carrier information using new iOS 12 APIs when running on iOS 12+.
-* **[Fix]** Fix memory leak issue during executing SQL queries.
+* **[Fix]** Fix a memory leak issue during executing SQL queries.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * **[Fix]** Do not delete old logs when trying to add a log larger than the maximum storage capacity.
 * **[Fix]** Fix minimum storage size verification to match minimum possible value.
 * **[Fix]** Fix reporting carrier information using new iOS 12 APIs when running on iOS 12+.
+* **[Fix]** Fix memory leak issue during executing SQL queries.
 
 ___
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
During executing SQL queries a memory leak can occur due to not freeing memory allocated for error message. This PR fixes this issue.


