### PR TITLE
Fix/userid for target

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -104,9 +104,6 @@
   if (item && !item.device) {
     item.device = [[MSDeviceTracker sharedInstance] device];
   }
-  if (item && !item.userId) {
-    item.userId = [[MSUserIdContext sharedInstance] userId];
-  }
   if (!item || ![item isValid]) {
     MSLogWarning([MSAppCenter logTag], @"Log is not valid.");
     return;

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -1340,44 +1340,6 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                }];
 }
 
-- (void)testEnqueueItemSetUserIdToLog {
-
-  // If
-  [self initChannelEndJobExpectation];
-  id<MSLog> enqueuedLog = [self getValidMockLog];
-  NSString *expectedUserId = @"Fake-UserId";
-  __block NSString *actualUserId;
-  id userIdContextMock = OCMClassMock([MSUserIdContext class]);
-  OCMStub([userIdContextMock sharedInstance]).andReturn(userIdContextMock);
-  OCMStub([userIdContextMock userId]).andReturn(expectedUserId);
-  self.storageMock = OCMProtocolMock(@protocol(MSStorage));
-  OCMStub([self.storageMock saveLog:OCMOCK_ANY withGroupId:OCMOCK_ANY flags:MSFlagsPersistenceNormal])
-      .andDo(^(NSInvocation *invocation) {
-        MSAbstractLog *log;
-        [invocation getArgument:&log atIndex:2];
-        actualUserId = log.userId;
-        [self enqueueChannelEndJobExpectation];
-      })
-      .andReturn(YES);
-  self.sut = [[MSChannelUnitDefault alloc] initWithIngestion:self.ingestionMock
-                                                     storage:self.storageMock
-                                               configuration:self.configMock
-                                           logsDispatchQueue:self.logsDispatchQueue];
-
-  // When
-  [self.sut enqueueItem:enqueuedLog flags:MSFlagsDefault];
-
-  // Then
-  [self waitForExpectationsWithTimeout:1
-                               handler:^(NSError *_Nullable error) {
-                                 if (error) {
-                                   XCTFail(@"Expectation Failed with error: %@", error);
-                                 }
-                                 XCTAssertEqual(actualUserId, expectedUserId);
-                               }];
-  [userIdContextMock stopMocking];
-}
-
 - (void)testEnqueueItemDoesNotSetUserIdWhenItAlreadyHasOne {
 
   // If

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSPropertyConfigurator.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSPropertyConfigurator.m
@@ -51,7 +51,8 @@ static const char deviceIdPrefix = 'i';
 
 - (void)setUserId:(NSString *)userId {
   if ([MSUserIdContext isUserIdValidForOneCollector:userId]) {
-    _userId = userId;
+    NSString *prefixedUserId = [MSUserIdContext prefixedUserIdFromUserId:userId];
+    _userId = prefixedUserId;
   }
 }
 

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSPropertyConfiguratorTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSPropertyConfiguratorTests.m
@@ -12,6 +12,7 @@
 #import "MSPropertyConfiguratorPrivate.h"
 #import "MSStringTypedProperty.h"
 #import "MSTestFrameworks.h"
+#import "MSUserExtension.h"
 
 @interface MSPropertyConfiguratorTests : XCTestCase
 
@@ -202,6 +203,7 @@
   MSCommonSchemaLog *csLog = [MSCommonSchemaLog new];
   csLog.ext = [MSCSExtensions new];
   csLog.ext.appExt = [MSAppExtension new];
+  csLog.ext.userExt = [MSUserExtension new];
   [csLog addTransmissionTargetToken:self.targetToken];
   [self.sut setAppLocale:@"en-US"];
   [self.sut setAppVersion:@"1.0.0"];
@@ -215,7 +217,22 @@
   XCTAssertNil(csLog.ext.appExt.ver);
   XCTAssertNil(csLog.ext.appExt.locale);
   XCTAssertNil(csLog.ext.appExt.name);
-  XCTAssertNil(csLog.ext.appExt.userId);
+  XCTAssertNil(csLog.ext.userExt.localId);
+}
+
+- (void)testSetUserId {
+
+  // When
+  [self.sut setUserId:@"alice"];
+
+  // Then
+  XCTAssertEqualObjects(self.sut.userId, @"c:alice");
+
+  // When
+  [self.sut setUserId:@"c:bob"];
+
+  // Then
+  XCTAssertEqualObjects(self.sut.userId, @"c:bob");
 }
 
 @end


### PR DESCRIPTION
* [ ] ~Has `CHANGELOG.md` been updated?~
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you add unit tests?
* [ ] ~Did you check UI tests on the sample app? They are not executed on CI.~
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix bugs
1. UserId override issue when target has no userId but default target has.
2. Add a prefix in setUserId in MSPropertyConfigurator