### PR TITLE
Fix compilation issue with Xibs when using Xcode 8.3.3

### DIFF
--- a/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsPropertyTableViewCell.xib
+++ b/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsPropertyTableViewCell.xib
@@ -5,6 +5,7 @@
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
+        <development version="8000" identifier="xcode"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsTransmissionTargetSelectorViewCell.xib
+++ b/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsTransmissionTargetSelectorViewCell.xib
@@ -5,6 +5,7 @@
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
+        <development version="8000" identifier="xcode"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsTypedPropertyTableViewCell.xib
+++ b/Sasquatch/Sasquatch/ViewControllers/MSAnalyticsTypedPropertyTableViewCell.xib
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <development version="8000" identifier="xcode"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

~* [ ] Has `CHANGELOG.md` been updated?~
* [x ] Are tests passing locally?
* [ x] Are the files formatted correctly?
~* [ ] Did you add unit tests?~
~* [ ] Did you check UI tests on the sample app? They are not executed on CI.~
* [x ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

I ran into compilation issues because one of our XIBs was not created with Xcode 8 compatibility.