### PR TITLE
Fix Keychain permission issue in macOS

### DIFF
--- a/AppCenter/AppCenter/Internals/Storage/MSLogDBStorage.m
+++ b/AppCenter/AppCenter/Internals/Storage/MSLogDBStorage.m
@@ -34,7 +34,7 @@ static const NSUInteger kMSSchemaVersion = 3;
     _logColumnIndex = ((NSNumber *)columnIndexes[kMSLogTableName][kMSLogColumnName]).unsignedIntegerValue;
     _targetTokenColumnIndex = ((NSNumber *)columnIndexes[kMSLogTableName][kMSTargetTokenColumnName]).unsignedIntegerValue;
     _batches = [NSMutableDictionary<NSString *, NSArray<NSNumber *> *> new];
-    _targetTokenEncrypter = [[MSEncrypter alloc] initWithDefaultKey];
+    _targetTokenEncrypter = [[MSEncrypter alloc] init];
   }
   return self;
 }

--- a/AppCenter/AppCenter/Internals/Storage/MSLogDBStorage.m
+++ b/AppCenter/AppCenter/Internals/Storage/MSLogDBStorage.m
@@ -34,7 +34,7 @@ static const NSUInteger kMSSchemaVersion = 3;
     _logColumnIndex = ((NSNumber *)columnIndexes[kMSLogTableName][kMSLogColumnName]).unsignedIntegerValue;
     _targetTokenColumnIndex = ((NSNumber *)columnIndexes[kMSLogTableName][kMSTargetTokenColumnName]).unsignedIntegerValue;
     _batches = [NSMutableDictionary<NSString *, NSArray<NSNumber *> *> new];
-    _targetTokenEncrypter = [[MSEncrypter alloc] init];
+    _targetTokenEncrypter = [MSEncrypter new];
   }
   return self;
 }

--- a/AppCenter/AppCenter/Internals/Util/MSEncrypter.h
+++ b/AppCenter/AppCenter/Internals/Util/MSEncrypter.h
@@ -8,10 +8,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface MSEncrypter : NSObject
 
-- (instancetype)initWithDefaultKey;
-
-- (instancetype)initWithKey:(NSData *)key;
-
 - (NSString *_Nullable)encryptString:(NSString *)string;
 
 - (NSString *_Nullable)decryptString:(NSString *)string;

--- a/AppCenter/AppCenter/Internals/Util/MSEncrypter.m
+++ b/AppCenter/AppCenter/Internals/Util/MSEncrypter.m
@@ -40,8 +40,6 @@ static NSString *kMSEncryptionKeyTag = @"kMSEncryptionKeyTag";
   // Load a key with keyTag.
   NSData *key = [MSEncrypter loadKeyFromKeychainWithTag:keyTag];
   if (!key) {
-
-    // Generate a new one if it doesn't exist.
     key = [MSEncrypter generateKeyWithTag:keyTag];
   }
 

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -258,7 +258,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
                                                                       flushInterval:1.0
                                                                      batchSizeLimit:1
                                                                 pendingBatchesLimit:3];
-    _targetTokenEncrypter = [[MSEncrypter alloc] initWithDefaultKey];
+    _targetTokenEncrypter = [[MSEncrypter alloc] init];
 
     /*
      * Using our own queue with high priority as the default main queue is slower and we want the files to be created as quickly as possible

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -241,7 +241,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 
 - (instancetype)init {
   if ((self = [super init])) {
-    _crashFiles = [[NSMutableArray alloc] init];
+    _crashFiles = [NSMutableArray new];
     _crashesPathComponent = [MSCrashesUtil crashesDir];
     _logBufferPathComponent = [MSCrashesUtil logBufferDir];
     _analyzerInProgressFilePathComponent = [NSString stringWithFormat:@"%@/%@", [MSCrashesUtil crashesDir], kMSAnalyzerFilename];
@@ -258,7 +258,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
                                                                       flushInterval:1.0
                                                                      batchSizeLimit:1
                                                                 pendingBatchesLimit:3];
-    _targetTokenEncrypter = [[MSEncrypter alloc] init];
+    _targetTokenEncrypter = [MSEncrypter new];
 
     /*
      * Using our own queue with high priority as the default main queue is slower and we want the files to be created as quickly as possible
@@ -352,7 +352,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 + (instancetype)sharedInstance {
   dispatch_once(&onceToken, ^{
     if (sharedInstance == nil) {
-      sharedInstance = [[MSCrashes alloc] init];
+      sharedInstance = [MSCrashes new];
     }
   });
   return sharedInstance;
@@ -681,13 +681,13 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
     return;
   }
   NSError *error = nil;
-  self.unprocessedReports = [[NSMutableArray alloc] init];
-  self.unprocessedLogs = [[NSMutableArray alloc] init];
-  self.unprocessedFilePaths = [[NSMutableArray alloc] init];
+  self.unprocessedReports = [NSMutableArray new];
+  self.unprocessedLogs = [NSMutableArray new];
+  self.unprocessedFilePaths = [NSMutableArray new];
 
   // First save all found crash reports for use in correlation step.
-  NSMutableDictionary *foundCrashReports = [[NSMutableDictionary alloc] init];
-  NSMutableDictionary *foundErrorReports = [[NSMutableDictionary alloc] init];
+  NSMutableDictionary *foundCrashReports = [NSMutableDictionary new];
+  NSMutableDictionary *foundErrorReports = [NSMutableDictionary new];
   for (NSURL *fileURL in self.crashFiles) {
     NSData *crashFileData = [NSData dataWithContentsOfURL:fileURL];
     if ([crashFileData length] > 0) {
@@ -799,9 +799,9 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
  * Resumes processing for a given subset of the unprocessed reports. Returns YES if should "AlwaysSend".
  */
 - (BOOL)sendCrashReportsOrAwaitUserConfirmationForFilteredIds:(NSArray<NSString *> *)filteredIds {
-  NSMutableArray *filteredOutLogs = [[NSMutableArray alloc] init];
-  NSMutableArray *filteredOutReports = [[NSMutableArray alloc] init];
-  NSMutableArray *filteredOutFilePaths = [[NSMutableArray alloc] init];
+  NSMutableArray *filteredOutLogs = [NSMutableArray new];
+  NSMutableArray *filteredOutReports = [NSMutableArray new];
+  NSMutableArray *filteredOutFilePaths = [NSMutableArray new];
   for (NSUInteger i = 0; i < [self.unprocessedReports count]; i++) {
     MSErrorReport *report = self.unprocessedReports[i];
     MSErrorReport *foundReport = nil;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * **[Fix]** Fix minimum storage size verification to match minimum possible value.
 * **[Fix]** Fix reporting carrier information using new iOS 12 APIs when running on iOS 12+.
 * **[Fix]** Fix a memory leak issue during executing SQL queries.
+* **[Fix]** Fix a keychain permission issue on macOS applications.
 
 ___
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [X] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] ~Did you add unit tests?~
* [ ] ~Did you check UI tests on the sample app? They are not executed on CI.~
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

MacOS SDK doesn't require any permissions to access keychain but it asks the permission since we share core code base with other Apple platforms and storage/crashes classes initialize MSEncrypter for transmission target token encryption/decryption.
This change will delay Keychain access until the SDK actually encrypts/decrypts transmission target tokens so that it couldn't ask the permission to users whoever use applications that don't send any logs to One Collector.
This will also improve user experience for iOS, any applications that are not sending logs to One Collector will not ask this permission unless the applications use "Distribute" service.
