### PR TITLE
Fix editing user id callback

### DIFF
--- a/Sasquatch/Sasquatch/Base.lproj/Main.storyboard
+++ b/Sasquatch/Sasquatch/Base.lproj/Main.storyboard
@@ -1081,7 +1081,7 @@
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                                                     <connections>
                                                         <action selector="dismissKeyboard:" destination="9Ck-4D-Ozb" eventType="editingDidEndOnExit" id="ZFL-NZ-9Bu"/>
-                                                        <action selector="userIdChanged:" destination="9Ck-4D-Ozb" eventType="editingChanged" id="BB2-Wi-ISZ"/>
+                                                        <action selector="userIdChanged:" destination="9Ck-4D-Ozb" eventType="editingDidEnd" id="sOz-Yn-aJX"/>
                                                     </connections>
                                                 </textField>
                                             </subviews>

--- a/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
@@ -126,7 +126,7 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
   }
 
   @IBAction func userIdChanged(_ sender: UITextField) {
-    let userId = sender.text
+    let userId = sender.text?.count ?? 0 > 0 ? sender.text : nil
     UserDefaults.standard.set(userId, forKey: kMSUserIdKey)
     appCenter.setUserId(userId)
   }

--- a/Sasquatch/Sasquatch/ViewControllers/Sections/SimplePropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/SimplePropertiesTableSection.swift
@@ -13,8 +13,8 @@ class SimplePropertiesTableSection : PropertiesTableSection {
     cell.valueField.text = property.value
 
     // Set cell to respond to being edited.
-    cell.keyField.addTarget(self, action: #selector(propertyKeyChanged), for: .editingChanged)
-    cell.valueField.addTarget(self, action: #selector(propertyValueChanged), for: .editingChanged)
+    cell.keyField.addTarget(self, action: #selector(propertyKeyChanged), for: .editingDidEnd)
+    cell.valueField.addTarget(self, action: #selector(propertyValueChanged), for: .editingDidEnd)
 
     return cell
   }


### PR DESCRIPTION
* [x] Are the files formatted correctly?
* [x] Did you check UI tests on the sample app? They are not executed on CI.

## Description

Sasquatch set userId UI has a quirky behavior: it calls set userId every time you type a character. 
The problem is you can't unset the userId unless restart the app.