### PR TITLE
Clear unprocessed reports after processing

### DIFF
--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -344,6 +344,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
     [self emptyLogBufferFiles];
     [self removeAnalyzerFile];
     [self.plCrashReporter purgePendingCrashReport];
+    [self clearUnprocessedReports];
     [self clearContextHistoryAndKeepCurrentSession];
     MSLogInfo([MSCrashes logTag], @"Crashes service has been disabled.");
   }

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -1153,7 +1153,14 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
     [MSWrapperExceptionManager deleteWrapperExceptionWithUUIDString:report.incidentIdentifier];
     [self.crashFiles removeObject:fileURL];
   }
+  [self clearUnprocessedReports];
   [self clearContextHistoryAndKeepCurrentSession];
+}
+
+- (void)clearUnprocessedReports {
+  [self.unprocessedReports removeAllObjects];
+  [self.unprocessedLogs removeAllObjects];
+  [self.unprocessedFilePaths removeAllObjects];
 }
 
 + (void)resetSharedInstance {

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -1112,6 +1112,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
     }
 
     // Return and do not continue with crash processing.
+    [self clearUnprocessedReports];
     [self clearContextHistoryAndKeepCurrentSession];
     return;
   } else if (userConfirmation == MSUserConfirmationAlways) {

--- a/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
@@ -1059,6 +1059,23 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   }
 }
 
+- (void)testStartingCrashesWithAutomaticProcessing {
+
+  // Wait for creation of buffers to avoid corruption on OCMPartialMock.
+  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+
+  // If
+  self.sut = OCMPartialMock(self.sut);
+  id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
+  [self startCrashes:self.sut withReports:YES withChannelGroup:channelGroupMock];
+
+  // When
+  NSArray *retrievedReports = [self.sut unprocessedCrashReports];
+
+  // Then
+  XCTAssertEqual([retrievedReports count], 0U);
+}
+
 - (void)testCrashesSetCorrectUserIdToLogs {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.


### PR DESCRIPTION
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
Fixes a bug with duplicate logs being sent from React-Native wrapper when automatic processing is on.


