### PR TITLE
Fix changelog about PLCR in Crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### AppCenterCrashes
 
-* **[Feature]** Add preview support for arm64e CPU architecture by using PLCrashReporter 1.2.3-rc1. PLCrashReporter 1.2.3-rc1 is a fork of the official repository and can be found at [https://github.com/Microsoft/PLCrashReporter](https://github.com/Microsoft/PLCrashReporter). It is based on version It is maintained by the [App Center](https://appcenter.ms) team and based on PLCrashReporter 1.2.1 (commit [fda23306](https://github.com/Microsoft/PLCrashReporter/tree/fda233062b5586f5d01cc527af643168665226c0)) with additional fixes and changes.
+* **[Feature]** Add preview support for arm64e CPU architecture by using PLCrashReporter 1.2.3-rc1. PLCrashReporter 1.2.3-rc1 is a fork of the official repository and can be found at [https://github.com/Microsoft/PLCrashReporter](https://github.com/Microsoft/PLCrashReporter). It is maintained by the [App Center](https://appcenter.ms) team and based on PLCrashReporter 1.2.1 (commit [fda23306](https://github.com/Microsoft/PLCrashReporter/tree/fda233062b5586f5d01cc527af643168665226c0)) with additional fixes and changes.
 
 ### AppCenterDistribute
 


### PR DESCRIPTION
I found a little grammar mixup in our change log. I updated the release already but figured that it's good to have the change in the change log file, too.