### PR TITLE
Escape all paths in pbxproj shell scripts that use SRCROOT

### DIFF
--- a/AppCenter/AppCenter.xcodeproj/project.pbxproj
+++ b/AppCenter/AppCenter.xcodeproj/project.pbxproj
@@ -2340,7 +2340,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenter\n./build-appcenter-tvos-framework.sh\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenter\"\n./build-appcenter-tvos-framework.sh\n";
 		};
 		0485AFE71EAA937000C10CAF /* Build framework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2354,7 +2354,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenter\n./build-appcenter-macos-framework.sh";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenter\"\n./build-appcenter-macos-framework.sh\n";
 		};
 		04FD114F1EF2F5F0000C5A5C /* Build docs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2368,7 +2368,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh macOS AppCenter\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh macOS AppCenter\n";
 			showEnvVarsInLog = 0;
 		};
 		04FD116A1EF2FE1D000C5A5C /* Build docs */ = {
@@ -2383,7 +2383,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh tvOS AppCenter\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh tvOS AppCenter\n";
 			showEnvVarsInLog = 0;
 		};
 		B23355C7210F8EC900999632 /* Build docs */ = {
@@ -2398,7 +2398,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh iOS AppCenter\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh iOS AppCenter\n";
 			showEnvVarsInLog = 0;
 		};
 		B2DA6594210F7FA2003541A3 /* Build framework */ = {
@@ -2414,7 +2414,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenter\n./build-appcenter-ios-framework.sh\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenter\"\n./build-appcenter-ios-framework.sh\n";
 		};
 		F8B8EAD021105B37004BCECB /* Verify no buildSettings */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2428,7 +2428,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		F8B8EAD221105B46004BCECB /* Verify no buildSettings */ = {
@@ -2443,7 +2443,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 		F8EBA2722110516400A91468 /* Verify no buildSettings */ = {
@@ -2458,7 +2458,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/AppCenterAnalytics/AppCenterAnalytics.xcodeproj/project.pbxproj
+++ b/AppCenterAnalytics/AppCenterAnalytics.xcodeproj/project.pbxproj
@@ -1061,7 +1061,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenterAnalytics\n./build-appcenteranalytics-tvos-framework.sh";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenterAnalytics\"\n./build-appcenteranalytics-tvos-framework.sh";
 		};
 		0485AFF01EAAADAC00C10CAF /* Build framework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1075,7 +1075,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenterAnalytics\n./build-appcenteranalytics-macos-framework.sh";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenterAnalytics\"\n./build-appcenteranalytics-macos-framework.sh";
 		};
 		04FD11581EF2F818000C5A5C /* Build docs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1089,7 +1089,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh macOS AppCenterAnalytics\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh macOS AppCenterAnalytics\n";
 			showEnvVarsInLog = 0;
 		};
 		04FD11731EF2FE43000C5A5C /* Build docs */ = {
@@ -1104,7 +1104,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh tvOS AppCenterAnalytics\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh tvOS AppCenterAnalytics\n";
 			showEnvVarsInLog = 0;
 		};
 		E85547E81D2D6827002DF6E2 /* Build framework */ = {
@@ -1119,7 +1119,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenterAnalytics\n./build-appcenteranalytics-ios-framework.sh";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenterAnalytics\"\n./build-appcenteranalytics-ios-framework.sh";
 		};
 		E85547ED1D2D68CF002DF6E2 /* Build docs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1133,7 +1133,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh iOS AppCenterAnalytics\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh iOS AppCenterAnalytics\n";
 			showEnvVarsInLog = 0;
 		};
 		F8B8EAD421105B77004BCECB /* Verify no buildSettings */ = {
@@ -1148,7 +1148,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 		F8B8EAD621105B84004BCECB /* Verify no buildSettings */ = {
@@ -1163,7 +1163,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 		F8B8EAD821105B95004BCECB /* Verify no buildSettings */ = {
@@ -1178,7 +1178,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/AppCenterCrashes/AppCenterCrashes.xcodeproj/project.pbxproj
+++ b/AppCenterCrashes/AppCenterCrashes.xcodeproj/project.pbxproj
@@ -1561,7 +1561,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenterCrashes\n./build-appcentercrashes-macos-framework.sh";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenterCrashes\"\n./build-appcentercrashes-macos-framework.sh\n";
 		};
 		04EBBEEA1F01C0E10006B8AE /* Build framework */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1575,7 +1575,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenterCrashes\n./build-appcentercrashes-tvos-framework.sh";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenterCrashes\"\n./build-appcentercrashes-tvos-framework.sh\n";
 		};
 		04EBBEF41F01C7100006B8AE /* Build docs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1589,7 +1589,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh tvOS AppCenterCrashes\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh tvOS AppCenterCrashes\n";
 			showEnvVarsInLog = 0;
 		};
 		04FD11611EF2FA04000C5A5C /* Build docs */ = {
@@ -1604,7 +1604,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh macOS AppCenterCrashes\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh macOS AppCenterCrashes\n";
 			showEnvVarsInLog = 0;
 		};
 		6E37297B1D1DE85000F1E4AE /* Build framework */ = {
@@ -1619,7 +1619,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenterCrashes\n./build-appcentercrashes-ios-framework.sh";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenterCrashes\"\n./build-appcentercrashes-ios-framework.sh\n";
 		};
 		6E6BFC3A1D23505600DF7617 /* Build docs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1633,7 +1633,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh iOS AppCenterCrashes\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh iOS AppCenterCrashes\n";
 			showEnvVarsInLog = 0;
 		};
 		F8B8EADA21105BA6004BCECB /* Verify no buildSettings */ = {
@@ -1648,7 +1648,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		F8B8EADC21105BB3004BCECB /* Verify no buildSettings */ = {
@@ -1663,7 +1663,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		F8B8EADE21105BC1004BCECB /* Verify no buildSettings */ = {
@@ -1678,7 +1678,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
+++ b/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
@@ -725,7 +725,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenterDistribute\n./build-appcenterdistribute-ios-framework.sh";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenterDistribute\"\n./build-appcenterdistribute-ios-framework.sh";
 		};
 		04FD4A401E4536B0009B4468 /* Build docs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -739,7 +739,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh iOS AppCenterDistribute\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh iOS AppCenterDistribute\n";
 			showEnvVarsInLog = 0;
 		};
 		F8B8EAE021105BD3004BCECB /* Verify no buildSettings */ = {
@@ -754,7 +754,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/AppCenterPush/AppCenterPush.xcodeproj/project.pbxproj
+++ b/AppCenterPush/AppCenterPush.xcodeproj/project.pbxproj
@@ -643,7 +643,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenterPush\n./build-appcenterpush-macos-framework.sh";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenterPush\"\n./build-appcenterpush-macos-framework.sh\n";
 		};
 		0469642A1F2A55A600F9D31F /* Build docs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -657,7 +657,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh macOS AppCenterPush\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh macOS AppCenterPush\n";
 			showEnvVarsInLog = 0;
 		};
 		D3AD5F261E5C9588001627AB /* Build framework */ = {
@@ -672,7 +672,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts/AppCenterPush\n./build-appcenterpush-ios-framework.sh";
+			shellScript = "cd \"${SRCROOT}/../Scripts/AppCenterPush\"\n./build-appcenterpush-ios-framework.sh\n";
 		};
 		D3AD5F2B1E5C9636001627AB /* Build docs */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -686,7 +686,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${SRCROOT}/../Scripts\n./build-docs.sh iOS AppCenterPush\n";
+			shellScript = "cd \"${SRCROOT}/../Scripts\"\n./build-docs.sh iOS AppCenterPush\n";
 			showEnvVarsInLog = 0;
 		};
 		F8B8EAE221105C11004BCECB /* Verify no buildSettings */ = {
@@ -701,7 +701,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		F8B8EAE421105C1D004BCECB /* Verify no buildSettings */ = {
@@ -716,7 +716,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # App Center SDK for iOS and macOS Change Log
 
-## Version 1.12.1
+## Version 1.12.1 (Under active development)
 
 ### AppCenter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for iOS and macOS Change Log
 
+## Version 1.12.1
+
+### AppCenter
+
+* **[Fix]** Fix issue where the SDK source could not be built in a directory that contains escaped characters (applies to all modules).
+
+___
+
 ## Version 1.12.0
 
 ### AppCenter

--- a/CrashLib/CrashLib.xcodeproj/project.pbxproj
+++ b/CrashLib/CrashLib.xcodeproj/project.pbxproj
@@ -578,7 +578,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		C2B2102A21B6C30B00F116BD /* Verify no buildSettings */ = {
@@ -597,7 +597,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		C2B2102B21B6C31C00F116BD /* Verify no buildSettings */ = {
@@ -616,7 +616,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
+++ b/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
@@ -1972,7 +1972,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		8099A5D62112198F008E1466 /* Verify no build settings */ = {
@@ -1987,7 +1987,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		F84923BB21119AE100E14DBE /* Verify no buildSettings */ = {
@@ -2002,7 +2002,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		F84923E72111C28C00E14DBE /* Verify no buildSettings */ = {
@@ -2017,7 +2017,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 		F84923E92111C2AD00E14DBE /* Verify no buildSettings */ = {
@@ -2032,7 +2032,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		F84923EA2111C2C100E14DBE /* Verify no buildSettings */ = {
@@ -2047,7 +2047,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 		F84923EB2111C2C800E14DBE /* Verify no buildSettings */ = {
@@ -2062,7 +2062,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
+++ b/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
@@ -557,7 +557,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 		F849248C2112FDF000E14DBE /* Verify no buildSettings */ = {
@@ -572,7 +572,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 		F849248D2112FDFA00E14DBE /* Verify no buildSettings */ = {
@@ -587,7 +587,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		F8AA112B2112FEB20068B52C /* Verify no buildSettings */ = {
@@ -602,7 +602,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/SasquatchTV/SasquatchTV.xcodeproj/project.pbxproj
+++ b/SasquatchTV/SasquatchTV.xcodeproj/project.pbxproj
@@ -693,7 +693,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
 			showEnvVarsInLog = 0;
 		};
 		F84BA0BA21133F460020F13B /* Verify no buildSettings */ = {
@@ -708,7 +708,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 		F84BA0BB21133F4C0020F13B /* Verify no buildSettings */ = {
@@ -723,7 +723,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 		F84BA0BD21133F5B0020F13B /* Verify no buildSettings */ = {
@@ -738,7 +738,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Scripts/build-docs.sh
+++ b/Scripts/build-docs.sh
@@ -2,9 +2,9 @@
 
 OS_NAME=$1
 FMK_NAME=$2
-PRODUCTS_DIR=${SRCROOT}/../AppCenter-SDK-Apple/$1
-INSTALL_DIR=${PRODUCTS_DIR}/${FMK_NAME}.framework
-DOCUMENTATION_DIR=${PRODUCTS_DIR}/Documentation/${FMK_NAME}
+PRODUCTS_DIR="${SRCROOT}/../AppCenter-SDK-Apple/$1"
+INSTALL_DIR="${PRODUCTS_DIR}/${FMK_NAME}.framework"
+DOCUMENTATION_DIR="${PRODUCTS_DIR}/Documentation/${FMK_NAME}"
 
 if [ ! -x "$(command -v jazzy)" ]
 then
@@ -12,7 +12,7 @@ echo "Couldn't find jazzy. Install jazzy before building frameworks"
 exit 1
 fi
 
-jazzy --config ${SRCROOT}/../Documentation/${OS_NAME}/${FMK_NAME}/.jazzy.yaml
+jazzy --config "${SRCROOT}/../Documentation/${OS_NAME}/${FMK_NAME}/.jazzy.yaml"
 
 # Create Documentation directory within folder.
 if [ ! -d "${DOCUMENTATION_DIR}" ]


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] ~Are tests passing locally?~
* [ ] ~Are the files formatted correctly?~
* [ ] ~Did you add unit tests?~
* [ ] ~Did you check UI tests on the sample app? They are not executed on CI.~
* [ ] ~Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?~

Was able to reproduce, then verify fix locally.

## Description

Enable the SDK frameworks to be built when the absolute path of the source contains escaped characters.

## Related PRs or issues

Issue #1269.