### PR TITLE
Fix signal handler setup when starting Crashes in background in Xamarin

### DIFF
--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -281,6 +281,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
   // Enabling.
   if (isEnabled) {
     id<MSCrashHandlerSetupDelegate> crashSetupDelegate = [MSWrapperCrashesHelper getCrashHandlerSetupDelegate];
+    MSLogDebug([MSCrashes logTag], @"Crashes setup delegate object=%@", crashSetupDelegate);
 
     // Check if a wrapper SDK has a preference for uncaught exception handling.
     BOOL enableUncaughtExceptionHandler = YES;

--- a/AppCenterCrashes/AppCenterCrashes/WrapperSDKUtilities/MSWrapperCrashesHelper.m
+++ b/AppCenterCrashes/AppCenterCrashes/WrapperSDKUtilities/MSWrapperCrashesHelper.m
@@ -1,9 +1,15 @@
-#import "MSCrashesInternal.h"
 #import "MSWrapperCrashesHelper.h"
+#import "MSCrashesInternal.h"
+#import "MSLogger.h"
 
 @interface MSWrapperCrashesHelper ()
 
-@property(weak, nonatomic) id<MSCrashHandlerSetupDelegate> crashHandlerSetupDelegate;
+/**
+ * Crash handler setup delegate.
+ * If weak and setting it in background thread, the reference is freed too early when we need it at start time.
+ * Since this can be read/write from different threads we also set it atomic.
+ */
+@property(strong, atomic) id<MSCrashHandlerSetupDelegate> crashHandlerSetupDelegate;
 
 @end
 
@@ -22,6 +28,7 @@
 }
 
 + (void)setCrashHandlerSetupDelegate:(id<MSCrashHandlerSetupDelegate>)delegate {
+  MSLogDebug([MSCrashes logTag], @"setCrashHandlerSetupDelegate:%@", delegate);
   [[MSWrapperCrashesHelper sharedInstance] setCrashHandlerSetupDelegate:delegate];
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # App Center SDK for iOS and macOS Change Log
 
+## Version 1.13.1 (Not yet released)
+
+### AppCenterCrashes
+
+* **[Fix]** Fix an issue where the crash setup handler could be freed before it could be used, this affects the Xamarin SDK.
+
 ## Version 1.13.0
 
 ### AppCenter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * **[Fix]** Fix an issue where the crash setup handler could be freed before it could be used, this affects the Xamarin SDK.
 
+___
+
 ## Version 1.13.0
 
 ### AppCenter


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fixes the bug described at https://github.com/Microsoft/AppCenter-SDK-DotNet/issues/759#issuecomment-458920638. And add some logging that was used to find the fix.

The crash delegate was freed before it could even be used.