### PR TITLE
Fix script not to format third-party libraries

### DIFF
--- a/clang-format-changed-files.sh
+++ b/clang-format-changed-files.sh
@@ -6,14 +6,17 @@ upstream=$(git remote -v | grep "Microsoft/" | awk '{print $1}' | uniq)
 git fetch $upstream
 i=0
 for modified_file in $(git diff $upstream/develop --diff-filter=ACMR --name-only -- *.h *.m *.mm)
-do 
-  clang-format -i -style=file $modified_file
-  exit_code=$?
-  if [ $exit_code -ne 0 ]
+do
+  if [[ $modified_file != *"Vendor/"* ]]
   then
-    echo "Failed to format file: "$modified_file
-  else
-    ((i++))
+    clang-format -i -style=file $modified_file
+    exit_code=$?
+    if [ $exit_code -ne 0 ]
+    then
+      echo "Failed to format file: "$modified_file
+    else
+      ((i++))
+    fi
   fi
 done
 echo "Formatted "$i" file(s)."


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Change format script to exclude Vendor folder
