### PR TITLE
Fix deadlock on start from background thread

### DIFF
--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
@@ -73,9 +73,6 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
     // Hookup to reachability.
     [MS_NOTIFICATION_CENTER addObserver:self selector:@selector(networkStateChanged:) name:kMSReachabilityChangedNotification object:nil];
     [self.reachability startNotifier];
-
-    // Apply current network state.
-    [self networkStateChanged];
   }
   return self;
 }
@@ -110,9 +107,6 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
       self.enabled = isEnabled;
       if (isEnabled) {
         [self.reachability startNotifier];
-
-        // Apply current network state, this will resume if network state allows it.
-        [self networkStateChanged];
       } else {
         [self.reachability stopNotifier];
         [self pause];

--- a/AppCenter/AppCenter/Internals/Vendor/Reachability/MS_Reachability.h
+++ b/AppCenter/AppCenter/Internals/Vendor/Reachability/MS_Reachability.h
@@ -39,15 +39,10 @@ extern NSString *kMSReachabilityChangedNotification;
  */
 + (instancetype)reachabilityForInternetConnection;
 
-#pragma mark reachabilityForLocalWiFi
-// reachabilityForLocalWiFi has been removed from the sample.  See ReadMe.md for
-// more information.
-//+ (instancetype)reachabilityForLocalWiFi;
-
 /*!
  * Start listening for reachability notifications on the current run loop.
  */
-- (BOOL)startNotifier;
+- (void)startNotifier;
 - (void)stopNotifier;
 
 - (NetworkStatus)currentReachabilityStatus;

--- a/AppCenter/AppCenter/Internals/Vendor/Reachability/MS_Reachability.m
+++ b/AppCenter/AppCenter/Internals/Vendor/Reachability/MS_Reachability.m
@@ -121,15 +121,9 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
   return [self reachabilityWithAddress:(const struct sockaddr *)&zeroAddress];
 }
 
-#pragma mark reachabilityForLocalWiFi
-// reachabilityForLocalWiFi has been removed from the sample.  See ReadMe.md for
-// more information.
-//+ (instancetype)reachabilityForLocalWiFi
-
 #pragma mark - Start and stop notifier
 
-- (BOOL)startNotifier {
-  __block BOOL returnValue = NO;
+- (void)startNotifier {
   dispatch_block_t block = ^{
     SCNetworkReachabilityContext context = {0, (__bridge void *)(self), NULL,
                                             NULL, NULL};
@@ -138,16 +132,16 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
       if (SCNetworkReachabilityScheduleWithRunLoop(self.reachabilityRef,
                                                    CFRunLoopGetCurrent(),
                                                    kCFRunLoopDefaultMode)) {
-        returnValue = YES;
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMSReachabilityChangedNotification
+                                                            object:self];
       }
     }
   };
   if ([NSThread isMainThread]) {
     block();
   } else {
-    dispatch_sync(dispatch_get_main_queue(), block);
+    dispatch_async(dispatch_get_main_queue(), block);
   }
-  return returnValue;
 }
 
 - (void)stopNotifier {
@@ -160,7 +154,7 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
   if ([NSThread isMainThread]) {
     block();
   } else {
-    dispatch_sync(dispatch_get_main_queue(), block);
+    dispatch_async(dispatch_get_main_queue(), block);
   }
 }
 

--- a/AppCenter/AppCenter/Internals/Vendor/Reachability/MS_Reachability.m
+++ b/AppCenter/AppCenter/Internals/Vendor/Reachability/MS_Reachability.m
@@ -65,7 +65,7 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
 #pragma mark - Reachability implementation
 
 /*
- * Instantiation, deallocation and starting/stopping notifier for reachability
+ * Starting and stopping notifier for reachability
  * instance are enforced to run in main thread. MS_Reachability is not
  * thread-safe so stopNotifier doesn't properly unschedule jobs from the loop
  * when it is called from a different thread, and this generates unexpected
@@ -81,17 +81,11 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
 #pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
 
 + (instancetype)reachabilityWithHostName:(NSString *)hostName {
-  __block MS_Reachability *returnValue = NULL;
+  MS_Reachability *returnValue = NULL;
   SCNetworkReachabilityRef reachability =
       SCNetworkReachabilityCreateWithName(NULL, [hostName UTF8String]);
   if (reachability != NULL) {
-    if ([NSThread isMainThread]) {
-      returnValue = [[MS_Reachability alloc] init];
-    } else {
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        returnValue = [[MS_Reachability alloc] init];
-      });
-    }
+    returnValue = [[MS_Reachability alloc] init];
     if (returnValue != NULL) {
       returnValue.reachabilityRef = reachability;
     } else {
@@ -104,17 +98,11 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
 #pragma clang diagnostic pop
 
 + (instancetype)reachabilityWithAddress:(const struct sockaddr *)hostAddress {
-  __block MS_Reachability *returnValue = NULL;
+  MS_Reachability *returnValue = NULL;
   SCNetworkReachabilityRef reachability =
       SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, hostAddress);
   if (reachability != NULL) {
-    if ([NSThread isMainThread]) {
-      returnValue = [[MS_Reachability alloc] init];
-    } else {
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        returnValue = [[MS_Reachability alloc] init];
-      });
-    }
+    returnValue = [[MS_Reachability alloc] init];
     if (returnValue != NULL) {
       returnValue.reachabilityRef = reachability;
     } else {

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -599,6 +599,7 @@ static NSURL *sfURL;
 - (void)testShowConfirmationAlertForMandatoryUpdateWhileNoNetwork {
 
   // If
+  self.sut.appSecret = kMSTestAppSecret;
   XCTestExpectation *expectation = [self expectationWithDescription:@"Confirmation alert for private distribution has been displayed"];
 
   // Mock alert.
@@ -692,6 +693,7 @@ static NSURL *sfURL;
 - (void)testDontShowConfirmationAlertIfNoMandatoryReleaseWhileNoNetwork {
 
   // If
+  self.sut.appSecret = kMSTestAppSecret;
   XCTestExpectation *expectation = [self expectationWithDescription:@"Confirmation alert for private distribution has been displayed"];
 
   // Mock alert.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for iOS and macOS Change Log
 
+## Version 1.13.1 (Not yet released)
+
+### AppCenter
+
+* **[Fix]** Fix a possible deadlock if the SDK is started from a background thread.
+
+___
+
 ## Version 1.13.0
 
 ### AppCenter


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

A deadlock may occur if the AppCenter is started from a background thread.