### PR TITLE
Swizzle openURL: in MSIdentity

### DIFF
--- a/AppCenter.podspec
+++ b/AppCenter.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name              = 'AppCenter'
-  s.version           = '1.13.0'
+  s.version           = '1.13.1'
 
   s.summary           = 'Visual Studio App Center is your continuous integration, delivery and learning solution for iOS and macOS apps.'
   s.description       = <<-DESC

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
@@ -85,9 +85,6 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
     // Hookup to reachability.
     [MS_NOTIFICATION_CENTER addObserver:self selector:@selector(networkStateChanged:) name:kMSReachabilityChangedNotification object:nil];
     [self.reachability startNotifier];
-
-    // Apply current network state.
-    [self networkStateChanged];
   }
   return self;
 }
@@ -126,9 +123,6 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
       self.enabled = isEnabled;
       if (isEnabled) {
         [self.reachability startNotifier];
-
-        // Apply current network state, this will resume if network state allows it.
-        [self networkStateChanged];
       } else {
         [self.reachability stopNotifier];
         [self pause];

--- a/AppCenter/AppCenter/Internals/Vendor/Reachability/MS_Reachability.h
+++ b/AppCenter/AppCenter/Internals/Vendor/Reachability/MS_Reachability.h
@@ -39,15 +39,10 @@ extern NSString *kMSReachabilityChangedNotification;
  */
 + (instancetype)reachabilityForInternetConnection;
 
-#pragma mark reachabilityForLocalWiFi
-// reachabilityForLocalWiFi has been removed from the sample.  See ReadMe.md for
-// more information.
-//+ (instancetype)reachabilityForLocalWiFi;
-
 /*!
  * Start listening for reachability notifications on the current run loop.
  */
-- (BOOL)startNotifier;
+- (void)startNotifier;
 - (void)stopNotifier;
 
 - (NetworkStatus)currentReachabilityStatus;

--- a/AppCenter/AppCenter/Internals/Vendor/Reachability/MS_Reachability.m
+++ b/AppCenter/AppCenter/Internals/Vendor/Reachability/MS_Reachability.m
@@ -65,7 +65,7 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
 #pragma mark - Reachability implementation
 
 /*
- * Instantiation, deallocation and starting/stopping notifier for reachability
+ * Starting and stopping notifier for reachability
  * instance are enforced to run in main thread. MS_Reachability is not
  * thread-safe so stopNotifier doesn't properly unschedule jobs from the loop
  * when it is called from a different thread, and this generates unexpected
@@ -81,17 +81,11 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
 #pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
 
 + (instancetype)reachabilityWithHostName:(NSString *)hostName {
-  __block MS_Reachability *returnValue = NULL;
+  MS_Reachability *returnValue = NULL;
   SCNetworkReachabilityRef reachability =
       SCNetworkReachabilityCreateWithName(NULL, [hostName UTF8String]);
   if (reachability != NULL) {
-    if ([NSThread isMainThread]) {
-      returnValue = [[MS_Reachability alloc] init];
-    } else {
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        returnValue = [[MS_Reachability alloc] init];
-      });
-    }
+    returnValue = [[MS_Reachability alloc] init];
     if (returnValue != NULL) {
       returnValue.reachabilityRef = reachability;
     } else {
@@ -104,17 +98,11 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
 #pragma clang diagnostic pop
 
 + (instancetype)reachabilityWithAddress:(const struct sockaddr *)hostAddress {
-  __block MS_Reachability *returnValue = NULL;
+  MS_Reachability *returnValue = NULL;
   SCNetworkReachabilityRef reachability =
       SCNetworkReachabilityCreateWithAddress(kCFAllocatorDefault, hostAddress);
   if (reachability != NULL) {
-    if ([NSThread isMainThread]) {
-      returnValue = [[MS_Reachability alloc] init];
-    } else {
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        returnValue = [[MS_Reachability alloc] init];
-      });
-    }
+    returnValue = [[MS_Reachability alloc] init];
     if (returnValue != NULL) {
       returnValue.reachabilityRef = reachability;
     } else {
@@ -133,15 +121,9 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
   return [self reachabilityWithAddress:(const struct sockaddr *)&zeroAddress];
 }
 
-#pragma mark reachabilityForLocalWiFi
-// reachabilityForLocalWiFi has been removed from the sample.  See ReadMe.md for
-// more information.
-//+ (instancetype)reachabilityForLocalWiFi
-
 #pragma mark - Start and stop notifier
 
-- (BOOL)startNotifier {
-  __block BOOL returnValue = NO;
+- (void)startNotifier {
   dispatch_block_t block = ^{
     SCNetworkReachabilityContext context = {0, (__bridge void *)(self), NULL,
                                             NULL, NULL};
@@ -150,16 +132,16 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
       if (SCNetworkReachabilityScheduleWithRunLoop(self.reachabilityRef,
                                                    CFRunLoopGetCurrent(),
                                                    kCFRunLoopDefaultMode)) {
-        returnValue = YES;
+        [[NSNotificationCenter defaultCenter] postNotificationName:kMSReachabilityChangedNotification
+                                                            object:self];
       }
     }
   };
   if ([NSThread isMainThread]) {
     block();
   } else {
-    dispatch_sync(dispatch_get_main_queue(), block);
+    dispatch_async(dispatch_get_main_queue(), block);
   }
-  return returnValue;
 }
 
 - (void)stopNotifier {
@@ -172,7 +154,7 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target,
   if ([NSThread isMainThread]) {
     block();
   } else {
-    dispatch_sync(dispatch_get_main_queue(), block);
+    dispatch_async(dispatch_get_main_queue(), block);
   }
 }
 

--- a/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
+++ b/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
@@ -416,17 +416,17 @@
 		04FD4A321E453531009B4468 /* AppCenterDistributeTests */ = {
 			isa = PBXGroup;
 			children = (
-				9E8E3A38203E68B4001A23FD /* MSDistributionStartSessionLogTest.m */,
-				04FD4A351E453531009B4468 /* Info.plist */,
 				848860441E6EC32B003A9B96 /* MSBasicMachOParserTests.m */,
+				80324E2F1F4DC81E005F4E11 /* MSDistributeAppDelegateTests.m */,
 				386A69EF1FD88A9B0057B316 /* MSDistributeDataMigrationTests.m */,
+				586030B2AAEEE6A568D37CE9 /* MSDistributeInfoTrackerTests.m */,
+				040AF0291E52748D005C1174 /* MSDistributeIngestionTests.m */,
+				9E8E3A38203E68B4001A23FD /* MSDistributionStartSessionLogTest.m */,
 				04FD4A331E453531009B4468 /* MSDistributeTests.m */,
 				B20DE7B61E5F97330023075C /* MSDistributeUtilTests.m */,
-				040AF0291E52748D005C1174 /* MSDistributeIngestionTests.m */,
 				38A683631E774DCE00A63BC8 /* MSSemVerPreReleaseIdTest.m */,
 				38A683621E774DCE00A63BC8 /* MSSemVerTests.m */,
-				80324E2F1F4DC81E005F4E11 /* MSDistributeAppDelegateTests.m */,
-				586030B2AAEEE6A568D37CE9 /* MSDistributeInfoTrackerTests.m */,
+				04FD4A351E453531009B4468 /* Info.plist */,
 				040AF0101E523AC2005C1174 /* Fixtures */,
 				04FD4A491E453930009B4468 /* Frameworks */,
 				04A140BE1ECE84B7001CEE94 /* Model */,

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -599,6 +599,7 @@ static NSURL *sfURL;
 - (void)testShowConfirmationAlertForMandatoryUpdateWhileNoNetwork {
 
   // If
+  self.sut.appSecret = kMSTestAppSecret;
   XCTestExpectation *expectation = [self expectationWithDescription:@"Confirmation alert for private distribution has been displayed"];
 
   // Mock alert.
@@ -692,6 +693,7 @@ static NSURL *sfURL;
 - (void)testDontShowConfirmationAlertIfNoMandatoryReleaseWhileNoNetwork {
 
   // If
+  self.sut.appSecret = kMSTestAppSecret;
   XCTestExpectation *expectation = [self expectationWithDescription:@"Confirmation alert for private distribution has been displayed"];
 
   // Mock alert.

--- a/AppCenterIdentity/AppCenterIdentity.xcodeproj/project.pbxproj
+++ b/AppCenterIdentity/AppCenterIdentity.xcodeproj/project.pbxproj
@@ -108,6 +108,12 @@
 		995BA5D421EFEF6D000E3212 /* AppCenter+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */; };
 		995BA5DC21EFF414000E3212 /* MSIdentityPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5DB21EFF414000E3212 /* MSIdentityPrivate.h */; };
 		995BA5DD21EFF414000E3212 /* MSIdentityPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5DB21EFF414000E3212 /* MSIdentityPrivate.h */; };
+		B2B25642220B365A00716D6A /* MSIdentityAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B25640220B365A00716D6A /* MSIdentityAppDelegate.m */; };
+		B2B25643220B365A00716D6A /* MSIdentityAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B25640220B365A00716D6A /* MSIdentityAppDelegate.m */; };
+		B2B25644220B365A00716D6A /* MSIdentityAppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B2B25641220B365A00716D6A /* MSIdentityAppDelegate.h */; };
+		B2B25645220B365A00716D6A /* MSIdentityAppDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = B2B25641220B365A00716D6A /* MSIdentityAppDelegate.h */; };
+		B2B25647220B370200716D6A /* MSIdentityAppDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B25646220B370200716D6A /* MSIdentityAppDelegateTests.m */; };
+		B2B25648220B370200716D6A /* MSIdentityAppDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2B25646220B370200716D6A /* MSIdentityAppDelegateTests.m */; };
 		E85547C61D2D6253002DF6E2 /* MSIdentity.m in Sources */ = {isa = PBXBuildFile; fileRef = E85547C51D2D6253002DF6E2 /* MSIdentity.m */; };
 		E85547DA1D2D6723002DF6E2 /* libAppCenterIdentity.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E85547C01D2D6253002DF6E2 /* libAppCenterIdentity.a */; };
 		E85547F71D2D6A7D002DF6E2 /* AppCenterIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = E85547CC1D2D63EF002DF6E2 /* AppCenterIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -216,7 +222,7 @@
 		1A15692321F11B09001E9452 /* MSIdentityTests.m */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = MSIdentityTests.m; sourceTree = "<group>"; tabWidth = 2; };
 		358F9BC52019590100B9E22C /* MSLogWithProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSLogWithProperties.h; path = ../AppCenter/AppCenter/Model/MSLogWithProperties.h; sourceTree = "<group>"; };
 		358F9BC72019596400B9E22C /* MSAbstractLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSAbstractLog.h; path = ../AppCenter/AppCenter/Model/MSAbstractLog.h; sourceTree = "<group>"; };
-		3847ABE422028E3D008BC281 /* MSHttpTestUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSHttpTestUtil.h; path = ../../../AppCenter/AppCenterTests/Util/MSHttpTestUtil.h; sourceTree = "<group>"; };
+		3847ABE422028E3D008BC281 /* MSHttpTestUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSHttpTestUtil.h; sourceTree = "<group>"; };
 		3847ABE522028E3D008BC281 /* MSHttpTestUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MSHttpTestUtil.m; path = ../../../AppCenter/AppCenterTests/Util/MSHttpTestUtil.m; sourceTree = "<group>"; };
 		387C77041D6CC39400D68CC1 /* MSServiceAbstract.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSServiceAbstract.h; path = ../AppCenter/AppCenter/MSServiceAbstract.h; sourceTree = "<group>"; };
 		38D4204422012DAC006ECF44 /* MSTestFrameworks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSTestFrameworks.h; path = ../../../AppCenter/AppCenterTests/Util/MSTestFrameworks.h; sourceTree = "<group>"; };
@@ -231,6 +237,9 @@
 		995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "AppCenter+Internal.h"; path = "../../../AppCenter/AppCenter/Internals/AppCenter+Internal.h"; sourceTree = "<group>"; };
 		995BA5DB21EFF414000E3212 /* MSIdentityPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIdentityPrivate.h; sourceTree = "<group>"; };
 		B2812EF21DA3148000307DCE /* AppCenterIdentity Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "AppCenterIdentity Debug.xcconfig"; sourceTree = "<group>"; };
+		B2B25640220B365A00716D6A /* MSIdentityAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSIdentityAppDelegate.m; sourceTree = "<group>"; };
+		B2B25641220B365A00716D6A /* MSIdentityAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSIdentityAppDelegate.h; sourceTree = "<group>"; };
+		B2B25646220B370200716D6A /* MSIdentityAppDelegateTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSIdentityAppDelegateTests.m; sourceTree = "<group>"; };
 		E85547C01D2D6253002DF6E2 /* libAppCenterIdentity.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAppCenterIdentity.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E85547C31D2D6253002DF6E2 /* MSIdentity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSIdentity.h; sourceTree = "<group>"; };
 		E85547C51D2D6253002DF6E2 /* MSIdentity.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = MSIdentity.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -402,7 +411,8 @@
 				38D4204722012E1E006ECF44 /* MSMockUserDefaults.m */,
 				38D4204422012DAC006ECF44 /* MSTestFrameworks.h */,
 			);
-			path = Util;
+			name = Util;
+			path = ../../AppCenter/AppCenterTests/Util;
 			sourceTree = "<group>";
 		};
 		38F796C921F93E09007E7C15 /* Models */ = {
@@ -443,6 +453,8 @@
 		995BA5D621EFF01F000E3212 /* Internals */ = {
 			isa = PBXGroup;
 			children = (
+				B2B25641220B365A00716D6A /* MSIdentityAppDelegate.h */,
+				B2B25640220B365A00716D6A /* MSIdentityAppDelegate.m */,
 				0481A54821FA511C001FA9D8 /* Ingestion */,
 				38F796C921F93E09007E7C15 /* Models */,
 				995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */,
@@ -505,6 +517,7 @@
 			isa = PBXGroup;
 			children = (
 				E85547D91D2D6723002DF6E2 /* Info.plist */,
+				B2B25646220B370200716D6A /* MSIdentityAppDelegateTests.m */,
 				1A0D73FD2200CD540085FDE3 /* MSIdentityAuthorityTest.m */,
 				1A0D74022200EB400085FDE3 /* MSIdentityConfigTest.m */,
 				38EB8A6422038CE8005DBF5D /* MSIdentityConfigIngestionTests.m */,
@@ -526,6 +539,7 @@
 				3568A7ED201A9BBB00F3B860 /* MSAbstractLog.h in Headers */,
 				995BA5DD21EFF414000E3212 /* MSIdentityPrivate.h in Headers */,
 				995BA5D421EFEF6D000E3212 /* AppCenter+Internal.h in Headers */,
+				B2B25645220B365A00716D6A /* MSIdentityAppDelegate.h in Headers */,
 				3568A7EE201A9BBB00F3B860 /* MSLogWithProperties.h in Headers */,
 				3568A7EF201A9BBB00F3B860 /* MSService.h in Headers */,
 				38F796CD21F93E33007E7C15 /* MSIdentityConfig.h in Headers */,
@@ -544,6 +558,7 @@
 				358F9BC82019596500B9E22C /* MSAbstractLog.h in Headers */,
 				995BA5DC21EFF414000E3212 /* MSIdentityPrivate.h in Headers */,
 				995BA5D321EFEF6D000E3212 /* AppCenter+Internal.h in Headers */,
+				B2B25644220B365A00716D6A /* MSIdentityAppDelegate.h in Headers */,
 				04A082061F74BB8600DC776D /* MSService.h in Headers */,
 				358F9BC62019590200B9E22C /* MSLogWithProperties.h in Headers */,
 				38F796CC21F93E33007E7C15 /* MSIdentityConfig.h in Headers */,
@@ -781,6 +796,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B2B25648220B370200716D6A /* MSIdentityAppDelegateTests.m in Sources */,
 				F82E4C72217F1FA600EDAB34 /* sqlite3.c in Sources */,
 				04774645220112480045504A /* MSIdentityConfigTest.m in Sources */,
 				1A15692521F11B09001E9452 /* MSIdentityTests.m in Sources */,
@@ -798,6 +814,7 @@
 				0485AF6A1EAA79E300C10CAF /* MSIdentity.m in Sources */,
 				38F796D521F93ED6007E7C15 /* MSIdentityAuthority.m in Sources */,
 				0481A54E21FA51D7001FA9D8 /* MSIdentityConfigIngestion.m in Sources */,
+				B2B25643220B365A00716D6A /* MSIdentityAppDelegate.m in Sources */,
 				38F796CF21F93E33007E7C15 /* MSIdentityConfig.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -809,6 +826,7 @@
 				E85547C61D2D6253002DF6E2 /* MSIdentity.m in Sources */,
 				0481A54B21FA511C001FA9D8 /* MSIdentityConfigIngestion.m in Sources */,
 				38F796D421F93ED6007E7C15 /* MSIdentityAuthority.m in Sources */,
+				B2B25642220B365A00716D6A /* MSIdentityAppDelegate.m in Sources */,
 				38F796CE21F93E33007E7C15 /* MSIdentityConfig.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -817,6 +835,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B2B25647220B370200716D6A /* MSIdentityAppDelegateTests.m in Sources */,
 				F82E4C71217F1FA600EDAB34 /* sqlite3.c in Sources */,
 				1A0D74032200EB400085FDE3 /* MSIdentityConfigTest.m in Sources */,
 				1A15692421F11B09001E9452 /* MSIdentityTests.m in Sources */,

--- a/AppCenterIdentity/AppCenterIdentity/Internals/MSIdentityAppDelegate.h
+++ b/AppCenterIdentity/AppCenterIdentity/Internals/MSIdentityAppDelegate.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+#import "MSCustomApplicationDelegate.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSIdentityAppDelegate : NSObject <MSCustomApplicationDelegate>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AppCenterIdentity/AppCenterIdentity/Internals/MSIdentityAppDelegate.m
+++ b/AppCenterIdentity/AppCenterIdentity/Internals/MSIdentityAppDelegate.m
@@ -7,17 +7,17 @@
 
 #pragma mark - MSAppDelegate
 
-- (BOOL)application:(__attribute__((unused))UIApplication *)application
+- (BOOL)application:(__unused UIApplication *)application
               openURL:(NSURL *)url
-    sourceApplication:(__attribute__((unused))NSString *)sourceApplication
-           annotation:(__attribute__((unused))id)annotation
+    sourceApplication:(__unused NSString *)sourceApplication
+           annotation:(__unused id)annotation
         returnedValue:(BOOL)returnedValue {
   return [self openURL:url returnedValue:returnedValue];
 }
 
-- (BOOL)application:(__attribute__((unused))UIApplication *)application
+- (BOOL)application:(__unused UIApplication *)application
             openURL:(NSURL *)url
-            options:(__attribute__((unused))NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+            options:(__unused NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
       returnedValue:(BOOL)returnedValue {
   return [self openURL:url returnedValue:returnedValue];
 }
@@ -26,7 +26,7 @@
 
 - (BOOL)openURL:(NSURL *)url returnedValue:(BOOL)returnedValue {
 
-  MSLogDebug([MSIdentity logTag], @"Using swizzled opennURL:returnedValue: method.");
+  MSLogDebug([MSIdentity logTag], @"Using swizzled openURL:returnedValue: method.");
   BOOL returnValue = [MSIdentity openURL:url];
 
   // Return original value if url not handled by the SDK.

--- a/AppCenterIdentity/AppCenterIdentity/Internals/MSIdentityAppDelegate.m
+++ b/AppCenterIdentity/AppCenterIdentity/Internals/MSIdentityAppDelegate.m
@@ -1,0 +1,49 @@
+#import "MSIdentityAppDelegate.h"
+#import "MSAppCenterInternal.h"
+#import "MSAppDelegateForwarder.h"
+#import "MSIdentityPrivate.h"
+
+@implementation MSIdentityAppDelegate
+
+#pragma mark - MSAppDelegate
+
+- (BOOL)application:(__attribute__((unused))UIApplication *)application
+              openURL:(NSURL *)url
+    sourceApplication:(__attribute__((unused))NSString *)sourceApplication
+           annotation:(__attribute__((unused))id)annotation
+        returnedValue:(BOOL)returnedValue {
+  return [self openURL:url returnedValue:returnedValue];
+}
+
+- (BOOL)application:(__attribute__((unused))UIApplication *)application
+            openURL:(NSURL *)url
+            options:(__attribute__((unused))NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+      returnedValue:(BOOL)returnedValue {
+  return [self openURL:url returnedValue:returnedValue];
+}
+
+#pragma mark - Private
+
+- (BOOL)openURL:(NSURL *)url returnedValue:(BOOL)returnedValue {
+
+  MSLogDebug([MSIdentity logTag], @"Using swizzled opennURL:returnedValue: method.");
+  BOOL returnValue = [MSIdentity openURL:url];
+
+  // Return original value if url not handled by the SDK.
+  return (BOOL)(returnValue ?: returnedValue);
+}
+
+@end
+
+#pragma mark - Swizzling
+
+@implementation MSAppDelegateForwarder (MSIdentity)
+
++ (void)load {
+
+  // Register selectors to swizzle for Distribute.
+  [[MSAppDelegateForwarder sharedInstance] addDelegateSelectorToSwizzle:@selector(application:openURL:options:)];
+  [[MSAppDelegateForwarder sharedInstance] addDelegateSelectorToSwizzle:@selector(application:openURL:sourceApplication:annotation:)];
+}
+
+@end

--- a/AppCenterIdentity/AppCenterIdentity/Internals/MSIdentityAppDelegate.m
+++ b/AppCenterIdentity/AppCenterIdentity/Internals/MSIdentityAppDelegate.m
@@ -41,7 +41,7 @@
 
 + (void)load {
 
-  // Register selectors to swizzle for Distribute.
+  // Register selectors to swizzle for Identity.
   [[MSAppDelegateForwarder sharedInstance] addDelegateSelectorToSwizzle:@selector(application:openURL:options:)];
   [[MSAppDelegateForwarder sharedInstance] addDelegateSelectorToSwizzle:@selector(application:openURL:sourceApplication:annotation:)];
 }

--- a/AppCenterIdentity/AppCenterIdentity/Internals/MSIdentityPrivate.h
+++ b/AppCenterIdentity/AppCenterIdentity/Internals/MSIdentityPrivate.h
@@ -1,4 +1,5 @@
 #import "MSChannelDelegate.h"
+#import "MSCustomApplicationDelegate.h"
 #import "MSIdentity.h"
 #import "MSIdentityConfig.h"
 #import "MSServiceInternal.h"
@@ -31,6 +32,11 @@ static NSString *const kMSIdentityETagKey = @"MSIdentityETagKey";
  * The flag that indicates a user requested login before it is configured.
  */
 @property(nonatomic) BOOL loginDelayed;
+
+/**
+ * Custom application delegate dedicated to Identity.
+ */
+@property(nonatomic) id<MSCustomApplicationDelegate> appDelegate;
 
 /**
  * Rest singleton instance.

--- a/AppCenterIdentity/AppCenterIdentity/MSIdentity.h
+++ b/AppCenterIdentity/AppCenterIdentity/MSIdentity.h
@@ -8,11 +8,15 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MSIdentity : MSServiceAbstract
 
 /**
- * The callback method to be called when the app receives openURL response.
+ * Process URL request for the service.
  *
- * @param url URL from your application delegate's openURL handler into AppCenterIdentitiy for web authentication sessions
+ * @param url  The url with parameters.
+ *
+ * @return `YES` if the URL is intended for App Center Idenntity and your application, `NO` otherwise.
+ *
+ * @discussion Place this method call into your app delegate's openURL method.
  */
-+ (void)handleUrlResponse:(NSURL *)url;
++ (BOOL)openURL:(NSURL *)url;
 
 /**
  * Login to get user information.

--- a/AppCenterIdentity/AppCenterIdentity/MSIdentity.m
+++ b/AppCenterIdentity/AppCenterIdentity/MSIdentity.m
@@ -1,13 +1,14 @@
 #import "MSAppCenterInternal.h"
+#import "MSAppDelegateForwarder.h"
 #import "MSChannelGroupProtocol.h"
 #import "MSChannelUnitConfiguration.h"
 #import "MSChannelUnitProtocol.h"
 #import "MSConstants+Internal.h"
+#import "MSIdentityAppDelegate.h"
 #import "MSIdentityConfig.h"
 #import "MSIdentityConfigIngestion.h"
 #import "MSIdentityPrivate.h"
 #import "MSServiceAbstractProtected.h"
-#import "MSServiceInternal.h"
 #import "MSUtility+File.h"
 #import <MSAL/MSALPublicClientApplication.h>
 
@@ -38,11 +39,8 @@ static NSObject *lock = @"lock";
 
 - (instancetype)init {
   if ((self = [super init])) {
-
-    // Init channel configuration.
     _channelUnitConfiguration = [[MSChannelUnitConfiguration alloc] initDefaultConfigurationWithGroupId:[self groupId]];
-
-    // Create a path component for Identity.
+    _appDelegate = [MSIdentityAppDelegate new];
     [MSUtility createDirectoryForPathComponent:kMSIdentityPathComponent];
   }
   return self;
@@ -89,6 +87,7 @@ static NSObject *lock = @"lock";
   [super applyEnabledState:isEnabled];
   if (isEnabled) {
     [self.channelGroup addDelegate:self];
+    [[MSAppDelegateForwarder sharedInstance] addDelegate:self.appDelegate];
 
     // Read Identity config file.
     NSString *eTag = nil;
@@ -101,6 +100,7 @@ static NSObject *lock = @"lock";
     [self downloadConfigurationWithETag:eTag];
     MSLogInfo([MSIdentity logTag], @"Identity service has been enabled.");
   } else {
+    [[MSAppDelegateForwarder sharedInstance] removeDelegate:self.appDelegate];
     self.clientApplication = nil;
     self.accessToken = nil;
     [self clearConfigurationCache];
@@ -136,8 +136,8 @@ static NSObject *lock = @"lock";
   sharedInstance = nil;
 }
 
-+ (void)handleUrlResponse:(NSURL *)url {
-  [MSALPublicClientApplication handleMSALResponse:url];
++ (BOOL)openURL:(NSURL *)url {
+  return [MSALPublicClientApplication handleMSALResponse:url];
 }
 
 + (void)login {

--- a/AppCenterIdentity/AppCenterIdentityTests/MSIdentityAppDelegateTests.m
+++ b/AppCenterIdentity/AppCenterIdentityTests/MSIdentityAppDelegateTests.m
@@ -1,0 +1,36 @@
+#import "MSIdentityAppDelegate.h"
+#import "MSIdentityPrivate.h"
+#import "MSTestFrameworks.h"
+
+@interface MSIdentityAppDelegateTests : XCTestCase
+
+@end
+
+@implementation MSIdentityAppDelegateTests
+
+- (void)testOpenURLIsCalled {
+
+  // If
+  MSIdentityAppDelegate *appDelegate = [[MSIdentityAppDelegate alloc] init];
+  id identityMock = OCMPartialMock([MSIdentity sharedInstance]);
+  __block int count = 0;
+  OCMStub([identityMock openURL:OCMOCK_ANY]).andDo(^(__unused NSInvocation *invocation) {
+    count++;
+  });
+  NSURL *url = [[NSURL alloc] init];
+
+  // When
+  [appDelegate application:[UIApplication sharedApplication] openURL:url options:@{} returnedValue:YES];
+
+  // Then
+  OCMVerify([identityMock openURL:url]);
+
+  // When
+  [appDelegate application:[UIApplication sharedApplication] openURL:url sourceApplication:@"" annotation:@"" returnedValue:YES];
+
+  // Then
+  OCMVerify([identityMock openURL:url]);
+  XCTAssertEqual(count, 2);
+}
+
+@end

--- a/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
+++ b/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
@@ -245,10 +245,11 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   id msalMock = OCMClassMock([MSALPublicClientApplication class]);
 
   // When
-  [MSIdentity handleUrlResponse:expectedURL];
+  BOOL result = [MSIdentity openURL:expectedURL]; // TODO add more tests
 
   // Then
   OCMVerify([msalMock handleMSALResponse:expectedURL]);
+  XCTAssertFalse(result);
   [msalMock stopMocking];
 }
 

--- a/AppCenterPush/AppCenterPush/Internal/DelegateForwarder/MSUserNotificationCenterDelegateForwarder.m
+++ b/AppCenterPush/AppCenterPush/Internal/DelegateForwarder/MSUserNotificationCenterDelegateForwarder.m
@@ -28,7 +28,7 @@ static MSUserNotificationCenterDelegateForwarder *sharedInstance = nil;
 #endif
 }
 
-+ (void)doNothingButForceLoadTheClass{
++ (void)doNothingButForceLoadTheClass {
   // This method doesn't need to do anything it's purpose is just to force load this class into the runtime.
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # App Center SDK for iOS and macOS Change Log
 
+## Version 1.13.1
+
+### AppCenter
+
+* **[Fix]** Fix a possible deadlock if the SDK is started from a background thread.
+
+___
+
 ## Version 1.13.0
 
 ### AppCenter

--- a/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -312,8 +312,6 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
   return NO;
 }
 
-#pragma mark - Temporary Identity callbacks
-
 #pragma mark - Push callbacks
 
 // iOS 10 and later, called when a notification is delivered to an app that is in the foreground.

--- a/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -314,13 +314,6 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
 
 #pragma mark - Temporary Identity callbacks
 
-- (BOOL)application:(UIApplication *)application
-            openURL:(nonnull NSURL *)url
-            options:(nonnull NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
-  [MSIdentity handleUrlResponse:url];
-  return YES;
-}
-
 #pragma mark - Push callbacks
 
 // iOS 10 and later, called when a notification is delivered to an app that is in the foreground.

--- a/Sasquatch/SasquatchSwift/AppDelegate.swift
+++ b/Sasquatch/SasquatchSwift/AppDelegate.swift
@@ -145,7 +145,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MSCrashesDelegate, MSDist
    */
   func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
     // Forward the URL.
-    return MSDistribute.open(url)
+    return MSDistribute.open(url) && MSIdentity.open(url)
   }
 
   func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
@@ -164,7 +164,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MSCrashesDelegate, MSDist
       completionHandler(.noData)
     }
   }
-
+  
   func applicationWillResignActive(_ application: UIApplication) {
     // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
     // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* ~[ ] Has `CHANGELOG.md` been updated?~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* ~[] Did you check UI tests on the sample app? They are not executed on CI.~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This adds swizzling for the `openURL:` callback to MSIdentity.
It also renames MSIdentity's `handleUrlResponse:` to `openURL:` to be consistent with MSDistribute and cleans up some unnecessary comments and fixes references to files for `MSIdentity` tests.