### PR TITLE
Add class method that allows overriding the country code

### DIFF
--- a/AppCenter/AppCenter/Internals/History/Device/MSDeviceTracker.m
+++ b/AppCenter/AppCenter/Internals/History/Device/MSDeviceTracker.m
@@ -21,6 +21,7 @@ static NSUInteger const kMSMaxDevicesHistoryCount = 5;
 
 static BOOL needRefresh = YES;
 static MSWrapperSdk *wrapperSdkInformation = nil;
+static NSString *overrideCountryCode = nil;
 
 /**
  * Singleton.
@@ -69,6 +70,13 @@ static MSDeviceTracker *sharedInstance = nil;
 - (void)setWrapperSdk:(MSWrapperSdk *)wrapperSdk {
   @synchronized(self) {
     wrapperSdkInformation = wrapperSdk;
+    needRefresh = YES;
+  }
+}
+
+- (void)setCountryCode:(NSString *)countryCode {
+  @synchronized(self) {
+    overrideCountryCode = countryCode;
     needRefresh = YES;
   }
 }
@@ -171,12 +179,12 @@ static MSDeviceTracker *sharedInstance = nil;
     newDevice.screenSize = [self screenSize];
     newDevice.appVersion = [self appVersion:MS_APP_MAIN_BUNDLE];
 #if TARGET_OS_IOS
-    newDevice.carrierCountry = [self carrierCountry:carrier];
+    newDevice.carrierCountry = [self carrierCountry:carrier] ?: overrideCountryCode;
     newDevice.carrierName = [self carrierName:carrier];
 #else
 
-    // Carrier information is not available on macOS/tvOS.
-    newDevice.carrierCountry = nil;
+    // Carrier information is not available on macOS/tvOS, but if we have an override country code, use it.
+    newDevice.carrierCountry = overrideCountryCode;
     newDevice.carrierName = nil;
 #endif
     newDevice.appBuild = [self appBuild:MS_APP_MAIN_BUNDLE];

--- a/AppCenter/AppCenter/Internals/History/Device/MSDeviceTrackerPrivate.h
+++ b/AppCenter/AppCenter/Internals/History/Device/MSDeviceTrackerPrivate.h
@@ -163,6 +163,13 @@ static NSString *const kMSPastDevicesKey = @"pastDevicesKey";
 - (void)setWrapperSdk:(MSWrapperSdk *)wrapperSdk;
 
 /**
+ * Set country code to use when building device properties.
+ *
+ * @param countryCode The two-letter ISO country code. @see https://www.iso.org/obp/ui/#search for more information.
+ */
+- (void)setCountryCode:(NSString *)countryCode;
+
+/**
  * Return a new Instance of MSDevice.
  *
  * @returns A new Instance of MSDevice. @see MSDevice

--- a/AppCenter/AppCenter/MSAppCenter.h
+++ b/AppCenter/AppCenter/MSAppCenter.h
@@ -205,4 +205,11 @@
  */
 + (void)setUserId:(NSString *)userId;
 
+/**
+ * Sets the two-letter ISO country code to send to the backend.
+ *
+ * @param countryCode The two-letter ISO country code. See https://www.iso.org/obp/ui/#search for more information.
+ */
++ (void)setCountryCode:(NSString *)countryCode;
+
 @end

--- a/AppCenter/AppCenter/MSAppCenter.m
+++ b/AppCenter/AppCenter/MSAppCenter.m
@@ -212,6 +212,10 @@ static const long kMSMinUpperSizeLimitInBytes = 24 * 1024;
   [[MSAppCenter sharedInstance] setUserId:userId];
 }
 
++ (void)setCountryCode:(NSString *)countryCode {
+  [[MSDeviceTracker sharedInstance] setCountryCode:countryCode];
+}
+
 #pragma mark - private
 
 - (instancetype)init {

--- a/AppCenter/AppCenterTests/MSDeviceTrackerTests.m
+++ b/AppCenter/AppCenterTests/MSDeviceTrackerTests.m
@@ -351,6 +351,39 @@ static NSString *const kMSDeviceManufacturerTest = @"Apple";
   XCTAssertEqual(device.wrapperSdkVersion, wrapperSdk.wrapperSdkVersion);
 }
 
+- (void)testCountryCode {
+  // When
+  [[MSDeviceTracker sharedInstance] setCountryCode:@"AU"];
+  MSDevice *device = self.sut.device;
+
+  // Then
+  XCTAssertEqual(device.carrierCountry, @"AU");
+
+  // When
+  [[MSDeviceTracker sharedInstance] setCountryCode:@"GB"];
+
+  // Then
+  XCTAssertNotEqual(device.carrierCountry, @"GB");
+
+  // When
+  device = self.sut.device;
+
+  // Then
+  XCTAssertEqual(device.carrierCountry, @"GB");
+
+  // When
+  [[MSDeviceTracker sharedInstance] setCountryCode:nil];
+
+  // Then
+  XCTAssertNotEqual(device.carrierCountry, @"GB");
+
+  // When
+  device = self.sut.device;
+
+  // Then
+  XCTAssertNil(device.carrierCountry);
+}
+
 - (void)testCreationOfNewDeviceWorks {
 
   // When

--- a/AppCenter/AppCenterTests/MSDeviceTrackerTests.m
+++ b/AppCenter/AppCenterTests/MSDeviceTrackerTests.m
@@ -268,6 +268,35 @@ static NSString *const kMSDeviceManufacturerTest = @"Apple";
 }
 #endif
 
+#if TARGET_OS_IOS
+- (void)testCarrierCountryNotOverridden {
+
+  // If
+  NSString *expected = @"US";
+  CTCarrier *carrierMock = OCMClassMock([CTCarrier class]);
+  OCMStub([carrierMock isoCountryCode]).andReturn(expected);
+
+  // When
+  NSString *carrierCountry = [self.sut carrierCountry:carrierMock];
+
+  // Then
+  assertThat(carrierCountry, is(expected));
+
+  // If
+  [[MSDeviceTracker sharedInstance] setCountryCode:@"AU"];
+  MSDevice *device = self.sut.device;
+
+  // Then
+  XCTAssertEqual(device.carrierCountry, @"AU");
+
+  // When
+  carrierCountry = [self.sut carrierCountry:carrierMock];
+
+  // Then
+  assertThat(carrierCountry, is(expected));
+}
+#endif
+
 - (void)testAppVersion {
 
   // If
@@ -375,7 +404,7 @@ static NSString *const kMSDeviceManufacturerTest = @"Apple";
   [[MSDeviceTracker sharedInstance] setCountryCode:nil];
 
   // Then
-  XCTAssertNotEqual(device.carrierCountry, @"GB");
+  XCTAssertEqual(device.carrierCountry, @"GB");
 
   // When
   device = self.sut.device;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ___
 ### AppCenter
 
 * **[Fix]** Fix a possible deadlock if the SDK is started from a background thread.
+* **[Feature]** Add class method  `+ [MSAppCenter setCountryCode:]` that allows manually setting the country code on platforms where there is no carrier information available. 
 
 ___
 


### PR DESCRIPTION
## Description

This PR adds a class method `+ [MSAppCenter setCountryCode:]` that allows overriding the empty `carrierCountry` passed to the backend on platforms where there is no telephony information such as macOS.

It does not override the carrier information where it is available.

## Related PRs or issues

- Microsoft/AppCenter-SDK-Apple#190: Country data not captured by SDK