### PR TITLE
[iOS] Sasquatch app doesn't display userId value in Transmission Target tab when it switches to another target

### DIFF
--- a/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsPropertyTableViewCell.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsPropertyTableViewCell.swift
@@ -3,11 +3,10 @@ import UIKit
 @objc(MSAnalyticsPropertyTableViewCell) class MSAnalyticsPropertyTableViewCell: UITableViewCell {
   @IBOutlet weak var keyField: UITextField!
   @IBOutlet weak var valueField: UITextField!
+  var currentTarget: String = ""
 
   @IBAction func dismissKeyboard(_ sender: UITextField!) {
     sender.resignFirstResponder()
   }
-    
-  // MARK:variable
-  var curTarget: String = ""
+
 }

--- a/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsPropertyTableViewCell.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsPropertyTableViewCell.swift
@@ -7,4 +7,7 @@ import UIKit
   @IBAction func dismissKeyboard(_ sender: UITextField!) {
     sender.resignFirstResponder()
   }
+    
+    // MARK:variable
+    var curTarget: String = "Child 1"
 }

--- a/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsPropertyTableViewCell.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsPropertyTableViewCell.swift
@@ -8,6 +8,6 @@ import UIKit
     sender.resignFirstResponder()
   }
     
-    // MARK:variable
-    var curTarget: String = "Child 1"
+  // MARK:variable
+  var curTarget: String = ""
 }

--- a/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsPropertyTableViewCell.xib
+++ b/Sasquatch/Sasquatch/ViewControllers/Cells/MSAnalyticsPropertyTableViewCell.xib
@@ -5,9 +5,7 @@
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <development version="8000" identifier="xcode"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
-        <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -46,9 +44,6 @@
                         <userDefinedRuntimeAttributes>
                             <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Value"/>
                         </userDefinedRuntimeAttributes>
-                        <connections>
-                            <action selector="dismissKeyboard:" destination="VGz-Vf-G1h" eventType="editingDidEndOnExit" id="Faj-UP-bUt"/>
-                        </connections>
                     </textField>
                 </subviews>
                 <constraints>
@@ -64,6 +59,7 @@
                 <outlet property="keyField" destination="0w8-gH-9IR" id="tfg-PA-wxs"/>
                 <outlet property="valueField" destination="j3d-U5-snv" id="bJJ-Fe-A1Q"/>
             </connections>
+            <point key="canvasLocation" x="132" y="154.72263868065968"/>
         </tableViewCell>
     </objects>
 </document>

--- a/Sasquatch/Sasquatch/ViewControllers/Sections/CommonSchemaPropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/CommonSchemaPropertiesTableSection.swift
@@ -61,19 +61,17 @@ class CommonSchemaPropertiesTableSection : SimplePropertiesTableSection {
   }
   
   // Note down current target for using in End edit events
-  override func recordCurrentTarget(sender: UITextField!){
+  override func recordCurrentTarget(sender: UITextField!) {
     let curCell = sender.superview!.superview as! MSAnalyticsPropertyTableViewCell
     curCell.curTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget() ?? ""
-    }
+  }
     
-  // Add below method since tap out of the key textField will crash the app, that's a bad experience
-  override func propertyKeyChanged(sender: UITextField!){    
-    }
+// Add below method since tap out of the key textField will crash the app, that's a bad experience
+  override func propertyKeyChanged(sender: UITextField!) {    
+  }
     
   override func propertyValueChanged(sender: UITextField!) {
-    // when user changed value inside textfield by using virtual keyboard, then click a different target like 'Child 2'
-    // the textfield's events always happen after the switch target event, this will lead to set values to wrong target error
-    // Add below lines to check out whether the target have been changed, if so, change to use original target
+    // Check out whether the target have been changed, if so, change to use original target
     let curCell = sender.superview!.superview as! MSAnalyticsPropertyTableViewCell
     let curTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
     let selectedTarget = curCell.curTarget != curTarget ? curCell.curTarget : curTarget

--- a/Sasquatch/Sasquatch/ViewControllers/Sections/CommonSchemaPropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/CommonSchemaPropertiesTableSection.swift
@@ -59,22 +59,23 @@ class CommonSchemaPropertiesTableSection : SimplePropertiesTableSection {
       return cell
     }
   }
-  
-  // Note down current target for using in End edit events
+
+  // Note down current target for using in End edit events.
   override func recordCurrentTarget(sender: UITextField!) {
-    let curCell = sender.superview!.superview as! MSAnalyticsPropertyTableViewCell
-    curCell.curTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget() ?? ""
+    let Cell = sender.superview!.superview as! MSAnalyticsPropertyTableViewCell
+    Cell.currentTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget() ?? ""
   }
-    
-// Add below method since tap out of the key textField will crash the app, that's a bad experience
+
+  // Add below method since tap out of the key textField will crash the app, that's a bad experience.
   override func propertyKeyChanged(sender: UITextField!) {    
   }
-    
+
   override func propertyValueChanged(sender: UITextField!) {
-    // Check out whether the target have been changed, if so, change to use original target
-    let curCell = sender.superview!.superview as! MSAnalyticsPropertyTableViewCell
-    let curTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
-    let selectedTarget = curCell.curTarget != curTarget ? curCell.curTarget : curTarget
+
+    // Check out whether the target have been changed, if so, change to use original target.
+    let Cell = sender.superview!.superview as! MSAnalyticsPropertyTableViewCell
+    let currentTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
+    let selectedTarget = Cell.currentTarget != currentTarget ? Cell.currentTarget : currentTarget
     
     let propertyIndex = getCellRow(forTextField: sender) - self.propertyCellOffset
     let target = MSTransmissionTargets.shared.transmissionTargets[selectedTarget!]!

--- a/Sasquatch/Sasquatch/ViewControllers/Sections/CommonSchemaPropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/CommonSchemaPropertiesTableSection.swift
@@ -60,8 +60,24 @@ class CommonSchemaPropertiesTableSection : SimplePropertiesTableSection {
     }
   }
   
+  // Note down current target for using in End edit events
+  override func recordCurrentTarget(sender: UITextField!){
+    let curCell = sender.superview!.superview as! MSAnalyticsPropertyTableViewCell
+    curCell.curTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget() ?? ""
+    }
+    
+  // Add below method since tap out of the key textField will crash the app, that's a bad experience
+  override func propertyKeyChanged(sender: UITextField!){    
+    }
+    
   override func propertyValueChanged(sender: UITextField!) {
-    let selectedTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
+    // when user changed value inside textfield by using virtual keyboard, then click a different target like 'Child 2'
+    // the textfield's events always happen after the switch target event, this will lead to set values to wrong target error
+    // Add below lines to check out whether the target have been changed, if so, change to use original target
+    let curCell = sender.superview!.superview as! MSAnalyticsPropertyTableViewCell
+    let curTarget = transmissionTargetSelectorCell?.selectedTransmissionTarget()
+    let selectedTarget = curCell.curTarget != curTarget ? curCell.curTarget : curTarget
+    
     let propertyIndex = getCellRow(forTextField: sender) - self.propertyCellOffset
     let target = MSTransmissionTargets.shared.transmissionTargets[selectedTarget!]!
     propertyValues[selectedTarget!]![propertyIndex] = sender.text!
@@ -79,6 +95,7 @@ class CommonSchemaPropertiesTableSection : SimplePropertiesTableSection {
       target.propertyConfigurator.setUserId(sender.text!)
       break
     }
+    sender.resignFirstResponder()
   }
 
   override func propertyAtRow(row: Int) -> (String, String) {

--- a/Sasquatch/Sasquatch/ViewControllers/Sections/SimplePropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/SimplePropertiesTableSection.swift
@@ -43,7 +43,7 @@ class SimplePropertiesTableSection : PropertiesTableSection {
     preconditionFailure("This method is abstract")
   }
     
-  func recordCurrentTarget(sender: UITextField!) {
+ func recordCurrentTarget(sender: UITextField!) {
     preconditionFailure("This method is abstract")
   }
 

--- a/Sasquatch/Sasquatch/ViewControllers/Sections/SimplePropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/SimplePropertiesTableSection.swift
@@ -16,7 +16,6 @@ class SimplePropertiesTableSection : PropertiesTableSection {
     // Set cell to respond to being edited.
     cell.keyField.addTarget(self, action: #selector(propertyKeyChanged), for: .editingDidEnd)
     cell.keyField.addTarget(self, action: #selector(recordCurrentTarget), for: .editingDidBegin)
-    
     cell.valueField.addTarget(self, action: #selector(propertyValueChanged), for: .editingDidEnd)
     cell.valueField.addTarget(self, action: #selector(recordCurrentTarget), for: .editingDidBegin)
     return cell

--- a/Sasquatch/Sasquatch/ViewControllers/Sections/SimplePropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/SimplePropertiesTableSection.swift
@@ -15,8 +15,10 @@ class SimplePropertiesTableSection : PropertiesTableSection {
 
     // Set cell to respond to being edited.
     cell.keyField.addTarget(self, action: #selector(propertyKeyChanged), for: .editingDidEnd)
+    cell.keyField.addTarget(self, action: #selector(recordCurrentTarget), for: .editingDidBegin)
+    
     cell.valueField.addTarget(self, action: #selector(propertyValueChanged), for: .editingDidEnd)
-
+    cell.valueField.addTarget(self, action: #selector(recordCurrentTarget), for: .editingDidBegin)
     return cell
   }
 
@@ -38,6 +40,10 @@ class SimplePropertiesTableSection : PropertiesTableSection {
   }
 
   func propertyValueChanged(sender: UITextField!) {
+    preconditionFailure("This method is abstract")
+  }
+    
+  func recordCurrentTarget(sender: UITextField!) {
     preconditionFailure("This method is abstract")
   }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
In transmission tab, when editing in textfields using virtual keyboard, tap on another target will lead to value to be assigned to the new target.

The original design has below issues:
-- the call to propertyValueChanged() always happened after user switch out of a textfield to another target; so when the code inside the propertyValueChanged() try to get the current target supposed to be update its data with, it will get the one target just switch to, not the original one.
-- bind the call to textfields' resignFirstResponder() in editingDidEndOnExit event, which only happened when user press enter key in keyboard;

Fix:
-- make cell will note down current target when any key/value textfield control got focus;
-- in propertyValueChanged(), first compare the noted target with current target, if different, change to use original one; 
