### PR TITLE
[macOS] Sasquatch app doesn't display userId value in Transmission Target tab when it switches to another target

### DIFF
--- a/SasquatchMac/SasquatchMac/Base.lproj/SasquatchMac.storyboard
+++ b/SasquatchMac/SasquatchMac/Base.lproj/SasquatchMac.storyboard
@@ -2418,7 +2418,7 @@
                                                                                         </buttonCell>
                                                                                     </button>
                                                                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Jmc-cp-GZi">
-                                                                                        <rect key="frame" x="130" y="-4" width="440" height="20"/>
+                                                                                        <rect key="frame" x="130" y="-2" width="440" height="20"/>
                                                                                         <constraints>
                                                                                             <constraint firstAttribute="width" constant="440" id="sGu-KY-hHS"/>
                                                                                         </constraints>
@@ -2430,14 +2430,14 @@
                                                                                     </textField>
                                                                                 </subviews>
                                                                                 <constraints>
-                                                                                    <constraint firstItem="kGd-fj-i8S" firstAttribute="baseline" secondItem="Jmc-cp-GZi" secondAttribute="baseline" id="0JF-dq-5Wa"/>
+                                                                                    <constraint firstItem="kGd-fj-i8S" firstAttribute="baseline" secondItem="Jmc-cp-GZi" secondAttribute="baseline" constant="2" id="0JF-dq-5Wa"/>
                                                                                     <constraint firstAttribute="trailing" secondItem="Jmc-cp-GZi" secondAttribute="trailing" constant="25" id="M1s-mT-lxb"/>
                                                                                     <constraint firstItem="pz2-tc-7Rv" firstAttribute="top" secondItem="ChQ-Nb-OiO" secondAttribute="top" constant="2" id="MZc-HV-AAA"/>
                                                                                     <constraint firstAttribute="trailing" secondItem="pz2-tc-7Rv" secondAttribute="trailing" constant="67" id="XQp-8z-M9f"/>
                                                                                     <constraint firstItem="kGd-fj-i8S" firstAttribute="leading" secondItem="ChQ-Nb-OiO" secondAttribute="leading" constant="2" id="koG-ic-le3"/>
-                                                                                    <constraint firstItem="Jmc-cp-GZi" firstAttribute="top" secondItem="ChQ-Nb-OiO" secondAttribute="top" constant="2" id="oJz-44-ajP"/>
-                                                                                    <constraint firstItem="Jmc-cp-GZi" firstAttribute="centerY" secondItem="pz2-tc-7Rv" secondAttribute="centerY" constant="2" id="xAO-pL-7yY"/>
-                                                                                    <constraint firstItem="kGd-fj-i8S" firstAttribute="firstBaseline" secondItem="Jmc-cp-GZi" secondAttribute="firstBaseline" id="zMD-AD-840"/>
+                                                                                    <constraint firstItem="Jmc-cp-GZi" firstAttribute="top" secondItem="ChQ-Nb-OiO" secondAttribute="top" id="oJz-44-ajP"/>
+                                                                                    <constraint firstItem="Jmc-cp-GZi" firstAttribute="centerY" secondItem="pz2-tc-7Rv" secondAttribute="centerY" id="xAO-pL-7yY"/>
+                                                                                    <constraint firstItem="kGd-fj-i8S" firstAttribute="firstBaseline" secondItem="Jmc-cp-GZi" secondAttribute="firstBaseline" constant="2" id="zMD-AD-840"/>
                                                                                 </constraints>
                                                                             </tableCellView>
                                                                         </prototypeCellViews>

--- a/SasquatchMac/SasquatchMac/ViewControllers/TransmissionViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/TransmissionViewController.swift
@@ -1,6 +1,6 @@
 import Cocoa
 
-class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate {
+class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate, NSTextFieldDelegate {
 
   var appCenter: AppCenterDelegate = AppCenterProvider.shared().appCenter!
   var transmissionTargetMapping: [String]?
@@ -158,7 +158,6 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
     commonSelector.selectedSegment = 0
     propertySelector.selectedSegment = 0
 
-    NotificationCenter.default.addObserver(self, selector: #selector(self.editingDidEnd), name: .NSControlTextDidEndEditing, object: nil)
     let appName = Bundle.main.infoDictionary![kCFBundleNameKey as String] as! String
 
     // Default target section.
@@ -245,6 +244,7 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
           key.stringValue = property.key
           let value: NSTextField = cell.subviews[cellSubviews.valueText.rawValue] as! NSTextField
           value.stringValue = property.value
+          value.delegate = self
           cell.subviews[cellSubviews.valueCheck.rawValue].isHidden = true
           return cell
         case kAppVersionRow:
@@ -252,6 +252,7 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
           key.stringValue = property.key
           let value: NSTextField = cell.subviews[cellSubviews.valueText.rawValue] as! NSTextField
           value.stringValue = property.value
+          value.delegate = self
           cell.subviews[cellSubviews.valueCheck.rawValue].isHidden = true
           return cell
         case kAppLocaleRow:
@@ -259,6 +260,7 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
           key.stringValue = property.key
           let value: NSTextField = cell.subviews[cellSubviews.valueText.rawValue] as! NSTextField
           value.stringValue = property.value
+          value.delegate = self
           cell.subviews[cellSubviews.valueCheck.rawValue].isHidden = true
           return cell
         case kUserIdRow:
@@ -266,6 +268,7 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
           key.stringValue = property.key
           let value: NSTextField = cell.subviews[cellSubviews.valueText.rawValue] as! NSTextField
           value.stringValue = property.value
+          value.delegate = self
           cell.subviews[cellSubviews.valueCheck.rawValue].isHidden = true
           return cell
         default:
@@ -427,15 +430,12 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
     collectDeviceIdStates[selectedTarget!] = true
   }
 
-  @objc func editingDidEnd(notification : NSNotification) {
-    guard let textField = notification.object as? NSTextField else {
-      return
+  override func controlTextDidChange(_ obj: Notification) {
+    let text = obj.object as? NSTextField
+    let tag = getCellSection(forView: text!)
+    if(tag == Section.CommonSchemaProperties.rawValue) {
+      propertyValueChanged(sender: text)
     }
-    let tag = getCellSection(forView: textField)
-    if(tag == Section.CommonSchemaProperties.rawValue){
-      propertyValueChanged(sender: textField)
-    }
-    return
   }
 
   func getCellRow(forTextField textField: NSTextField!) -> Int {


### PR DESCRIPTION
## Description

1. Fix bug 57374 for macOS:

    Before: The  propertyValueChanged() is called when user press enter key to end textfield editing . This      cause the textfield value will be add to another target if you edit textfield and directly change target.

    After: Make propertyValueChanged() is called when textfield happens any change.

2. By the way, fix tiny truncation issue for textfield. 

## Related PRs or issues
https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/57374


