### PR TITLE
Fix calls of optional delegates

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -85,7 +85,7 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
     synchronizedDelegates = [self.delegates allObjects];
   }
   for (id<MSChannelDelegate> delegate in synchronizedDelegates) {
-    if (delegate && [delegate respondsToSelector:selector]) {
+    if ([delegate respondsToSelector:selector]) {
       block(delegate);
     }
   }

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -508,7 +508,7 @@
 - (void)enumerateDelegatesForSelector:(SEL)selector withBlock:(void (^)(id<MSChannelDelegate> delegate))block {
   @synchronized(self.delegates) {
     for (id<MSChannelDelegate> delegate in self.delegates) {
-      if (delegate && [delegate respondsToSelector:selector]) {
+      if ([delegate respondsToSelector:selector]) {
         block(delegate);
       }
     }
@@ -520,11 +520,11 @@
     for (id<MSChannelDelegate> delegate in self.delegates) {
 
       // Call willSendLog before didFailSendingLog
-      if (delegate && [delegate respondsToSelector:@selector(channel:willSendLog:)])
+      if ([delegate respondsToSelector:@selector(channel:willSendLog:)])
         [delegate channel:self willSendLog:item];
 
       // Call didFailSendingLog
-      if (delegate && [delegate respondsToSelector:@selector(channel:didFailSendingLog:withError:)])
+      if ([delegate respondsToSelector:@selector(channel:didFailSendingLog:withError:)])
         [delegate channel:self didFailSendingLog:item withError:error];
     }
   }

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
@@ -342,7 +342,7 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
 
 - (void)enumerateDelegatesForSelector:(SEL)selector withBlock:(void (^)(id<MSIngestionDelegate> delegate))block {
   for (id<MSIngestionDelegate> delegate in self.delegates) {
-    if (delegate && [delegate respondsToSelector:selector]) {
+    if ([delegate respondsToSelector:selector]) {
       block(delegate);
     }
   }

--- a/AppCenter/AppCenter/Internals/MSServiceCommon.h
+++ b/AppCenter/AppCenter/Internals/MSServiceCommon.h
@@ -41,6 +41,23 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, nonnull) NSString *defaultTransmissionTargetToken;
 
+@optional
+
+/**
+ * Service unique key for storage purpose.
+ *
+ * @discussion: IMPORTANT, This string is used to point to the right storage value for this service. Changing this string results in data
+ * lost if previous data is not migrated.
+ */
+@property(nonatomic, copy, readonly) NSString *groupId;
+
+/**
+ * The channel configuration for this service.
+ */
+@property(nonatomic, readonly) MSChannelUnitConfiguration *channelUnitConfiguration;
+
+@required
+
 /**
  * Apply the enabled state to the service.
  *
@@ -103,19 +120,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isStartedFromApplication;
 
 @optional
-
-/**
- * Service unique key for storage purpose.
- *
- * @discussion: IMPORTANT, This string is used to point to the right storage value for this service. Changing this string results in data
- * lost if previous data is not migrated.
- */
-@property(nonatomic, copy, readonly) NSString *groupId;
-
-/**
- * The channel configuration for this service.
- */
-@property(nonatomic, readonly) MSChannelUnitConfiguration *channelUnitConfiguration;
 
 /**
  * Get the unique instance.

--- a/AppCenter/AppCenter/Internals/MSServiceCommon.h
+++ b/AppCenter/AppCenter/Internals/MSServiceCommon.h
@@ -48,32 +48,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)applyEnabledState:(BOOL)isEnabled;
 
-@optional
-
-/**
- * Service unique key for storage purpose.
- *
- * @discussion: IMPORTANT, This string is used to point to the right storage value for this service. Changing this string results in data
- * lost if previous data is not migrated.
- */
-@property(nonatomic, copy, readonly) NSString *groupId;
-
-/**
- * The channel configuration for this service.
- */
-@property(nonatomic, readonly) MSChannelUnitConfiguration *channelUnitConfiguration;
-
 /**
  * The initialization priority for this service.
  */
 @property(nonatomic, readonly) MSInitializationPriority initializationPriority;
-
-/**
- * Get the unique instance.
- *
- * @return unique instance.
- */
-+ (instancetype)sharedInstance;
 
 /**
  * Check if the SDK has been properly initialized and the service can be used. Logs an error in case it wasn't.
@@ -123,6 +101,28 @@ NS_ASSUME_NONNULL_BEGIN
  * @return `YES` if the service is started from an application, `NO` otherwise.
  */
 - (BOOL)isStartedFromApplication;
+
+@optional
+
+/**
+ * Service unique key for storage purpose.
+ *
+ * @discussion: IMPORTANT, This string is used to point to the right storage value for this service. Changing this string results in data
+ * lost if previous data is not migrated.
+ */
+@property(nonatomic, copy, readonly) NSString *groupId;
+
+/**
+ * The channel configuration for this service.
+ */
+@property(nonatomic, readonly) MSChannelUnitConfiguration *channelUnitConfiguration;
+
+/**
+ * Get the unique instance.
+ *
+ * @return unique instance.
+ */
++ (instancetype)sharedInstance;
 
 @end
 

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -443,12 +443,13 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
     return;
   }
   NSObject *logObject = (NSObject *)log;
-  if ([logObject isKindOfClass:[MSEventLog class]] && [self.delegate respondsToSelector:@selector(analytics:willSendEventLog:)]) {
+  id<MSAnalyticsDelegate> delegate = self.delegate;
+  if ([logObject isKindOfClass:[MSEventLog class]] && [delegate respondsToSelector:@selector(analytics:willSendEventLog:)]) {
     MSEventLog *eventLog = (MSEventLog *)log;
-    [self.delegate analytics:self willSendEventLog:eventLog];
-  } else if ([logObject isKindOfClass:[MSPageLog class]] && [self.delegate respondsToSelector:@selector(analytics:willSendPageLog:)]) {
+    [delegate analytics:self willSendEventLog:eventLog];
+  } else if ([logObject isKindOfClass:[MSPageLog class]] && [delegate respondsToSelector:@selector(analytics:willSendPageLog:)]) {
     MSPageLog *pageLog = (MSPageLog *)log;
-    [self.delegate analytics:self willSendPageLog:pageLog];
+    [delegate analytics:self willSendPageLog:pageLog];
   }
 }
 
@@ -474,14 +475,15 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
     return;
   }
   NSObject *logObject = (NSObject *)log;
-  if ([logObject isKindOfClass:[MSEventLog class]] && [self.delegate respondsToSelector:@selector(analytics:
+  id<MSAnalyticsDelegate> delegate = self.delegate;
+  if ([logObject isKindOfClass:[MSEventLog class]] && [delegate respondsToSelector:@selector(analytics:
                                                                                             didFailSendingEventLog:withError:)]) {
     MSEventLog *eventLog = (MSEventLog *)log;
-    [self.delegate analytics:self didFailSendingEventLog:eventLog withError:error];
-  } else if ([logObject isKindOfClass:[MSPageLog class]] && [self.delegate respondsToSelector:@selector(analytics:
+    [delegate analytics:self didFailSendingEventLog:eventLog withError:error];
+  } else if ([logObject isKindOfClass:[MSPageLog class]] && [delegate respondsToSelector:@selector(analytics:
                                                                                                   didFailSendingPageLog:withError:)]) {
     MSPageLog *pageLog = (MSPageLog *)log;
-    [self.delegate analytics:self didFailSendingPageLog:pageLog withError:error];
+    [delegate analytics:self didFailSendingPageLog:pageLog withError:error];
   }
 }
 

--- a/AppCenterCrashes/AppCenterCrashes/Internals/MSCrashesPrivate.h
+++ b/AppCenterCrashes/AppCenterCrashes/Internals/MSCrashesPrivate.h
@@ -153,14 +153,6 @@ typedef struct MSCrashesCallbacks {
 - (BOOL)shouldProcessErrorReport:(MSErrorReport *)errorReport;
 
 /**
- * Determine whether delegate has an attachment callback for error report or
- * not.
- *
- * @return YES if delegate has an attachment callback, otherwise NO.
- */
-- (BOOL)delegateImplementsAttachmentCallback;
-
-/**
  * Creates log buffer to buffer logs which will be saved in an async-safe manner
  * at crash time. The buffer makes sure we don't lose any logs at crash time.
  * This method creates 20 files that will be used to buffer 20 logs.

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -515,37 +515,37 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 #pragma mark - Channel Delegate
 
 - (void)channel:(id<MSChannelProtocol>)__unused channel willSendLog:(id<MSLog>)log {
-  id<MSCrashesDelegate> strongDelegate = self.delegate;
-  if (strongDelegate && [strongDelegate respondsToSelector:@selector(crashes:willSendErrorReport:)]) {
+  id<MSCrashesDelegate> delegate = self.delegate;
+  if ([delegate respondsToSelector:@selector(crashes:willSendErrorReport:)]) {
     NSObject *logObject = static_cast<NSObject *>(log);
     if ([logObject isKindOfClass:[MSAppleErrorLog class]]) {
       MSAppleErrorLog *appleErrorLog = static_cast<MSAppleErrorLog *>(log);
       MSErrorReport *report = [MSErrorLogFormatter errorReportFromLog:appleErrorLog];
-      [strongDelegate crashes:self willSendErrorReport:report];
+      [delegate crashes:self willSendErrorReport:report];
     }
   }
 }
 
 - (void)channel:(id<MSChannelProtocol>)__unused channel didSucceedSendingLog:(id<MSLog>)log {
-  id<MSCrashesDelegate> strongDelegate = self.delegate;
-  if (strongDelegate && [strongDelegate respondsToSelector:@selector(crashes:didSucceedSendingErrorReport:)]) {
+  id<MSCrashesDelegate> delegate = self.delegate;
+  if ([delegate respondsToSelector:@selector(crashes:didSucceedSendingErrorReport:)]) {
     NSObject *logObject = static_cast<NSObject *>(log);
     if ([logObject isKindOfClass:[MSAppleErrorLog class]]) {
       MSAppleErrorLog *appleErrorLog = static_cast<MSAppleErrorLog *>(log);
       MSErrorReport *report = [MSErrorLogFormatter errorReportFromLog:appleErrorLog];
-      [strongDelegate crashes:self didSucceedSendingErrorReport:report];
+      [delegate crashes:self didSucceedSendingErrorReport:report];
     }
   }
 }
 
 - (void)channel:(id<MSChannelProtocol>)__unused channel didFailSendingLog:(id<MSLog>)log withError:(NSError *)error {
-  id<MSCrashesDelegate> strongDelegate = self.delegate;
-  if (strongDelegate && [strongDelegate respondsToSelector:@selector(crashes:didFailSendingErrorReport:withError:)]) {
+  id<MSCrashesDelegate> delegate = self.delegate;
+  if ([delegate respondsToSelector:@selector(crashes:didFailSendingErrorReport:withError:)]) {
     NSObject *logObject = static_cast<NSObject *>(log);
     if ([logObject isKindOfClass:[MSAppleErrorLog class]]) {
       MSAppleErrorLog *appleErrorLog = static_cast<MSAppleErrorLog *>(log);
       MSErrorReport *report = [MSErrorLogFormatter errorReportFromLog:appleErrorLog];
-      [strongDelegate crashes:self didFailSendingErrorReport:report withError:error];
+      [delegate crashes:self didFailSendingErrorReport:report withError:error];
     }
   }
 }
@@ -1016,14 +1016,11 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 }
 
 - (BOOL)shouldProcessErrorReport:(MSErrorReport *)errorReport {
-  id<MSCrashesDelegate> strongDelegate = self.delegate;
-  return (!strongDelegate || ![strongDelegate respondsToSelector:@selector(crashes:shouldProcessErrorReport:)] ||
-          [strongDelegate crashes:self shouldProcessErrorReport:errorReport]);
-}
-
-- (BOOL)delegateImplementsAttachmentCallback {
-  id<MSCrashesDelegate> strongDelegate = self.delegate;
-  return strongDelegate && [strongDelegate respondsToSelector:@selector(attachmentsWithCrashes:forErrorReport:)];
+  id<MSCrashesDelegate> delegate = self.delegate;
+  if ([delegate respondsToSelector:@selector(crashes:shouldProcessErrorReport:)]) {
+    return [delegate crashes:self shouldProcessErrorReport:errorReport];
+  }
+  return YES;
 }
 
 // We need to override setter, because it's default behavior creates an NSArray, and some tests fail.
@@ -1128,8 +1125,9 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
     NSURL *fileURL = self.unprocessedFilePaths[i];
 
     // Get error attachments.
-    if ([self delegateImplementsAttachmentCallback]) {
-      attachments = [self.delegate attachmentsWithCrashes:self forErrorReport:report];
+    id<MSCrashesDelegate> delegate = self.delegate;
+    if ([delegate respondsToSelector:@selector(attachmentsWithCrashes:forErrorReport:)]) {
+      attachments = [delegate attachmentsWithCrashes:self forErrorReport:report];
     } else {
       MSLogDebug([MSCrashes logTag], @"attachmentsWithCrashes is not implemented");
     }

--- a/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
@@ -204,7 +204,6 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
 
   // Then
   assertThatBool([[MSCrashes sharedInstance] shouldProcessErrorReport:nil], isTrue());
-  assertThatBool([[MSCrashes sharedInstance] delegateImplementsAttachmentCallback], isFalse());
 }
 
 - (void)testProcessCrashes {

--- a/AppCenterCrashes/AppCenterCrashesTests/MSMockCrashesDelegate.h
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSMockCrashesDelegate.h
@@ -1,5 +1,4 @@
 #import <Foundation/Foundation.h>
-
 #import "MSCrashesDelegate.h"
 
 @interface MSMockCrashesDelegate : NSObject <MSCrashesDelegate>

--- a/AppCenterCrashes/AppCenterCrashesTests/MSMockCrashesDelegate.m
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSMockCrashesDelegate.m
@@ -1,5 +1,4 @@
 #import "MSMockCrashesDelegate.h"
 
-@implementation MSMockCrashesDelegate {
-}
+@implementation MSMockCrashesDelegate
 @end

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -712,10 +712,10 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
   // Step 7. Open a dialog and ask a user to choose options for the update.
   if (!self.releaseDetails || ![self.releaseDetails isEqual:details]) {
     self.releaseDetails = details;
-    id<MSDistributeDelegate> strongDelegate = self.delegate;
-    if (strongDelegate && [strongDelegate respondsToSelector:@selector(distribute:releaseAvailableWithDetails:)]) {
+    id<MSDistributeDelegate> delegate = self.delegate;
+    if ([delegate respondsToSelector:@selector(distribute:releaseAvailableWithDetails:)]) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        BOOL customized = [strongDelegate distribute:self releaseAvailableWithDetails:details];
+        BOOL customized = [delegate distribute:self releaseAvailableWithDetails:details];
         MSLogDebug([MSDistribute logTag], @"releaseAvailableWithDetails delegate returned %@.", customized ? @"YES" : @"NO");
         if (!customized) {
           [self showConfirmationAlert:details];

--- a/AppCenterPush/AppCenterPush.xcodeproj/project.pbxproj
+++ b/AppCenterPush/AppCenterPush.xcodeproj/project.pbxproj
@@ -100,6 +100,8 @@
 		38C65D8421826CC80004FB44 /* MSUserNotificationCenterDelegateForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 38C65D8121826CC80004FB44 /* MSUserNotificationCenterDelegateForwarder.m */; };
 		38C65D8521826CC80004FB44 /* MSUserNotificationCenterDelegateForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 38C65D8121826CC80004FB44 /* MSUserNotificationCenterDelegateForwarder.m */; };
 		38D3B01F1FF3D2A900E5FAF2 /* MSAppDelegateForwarderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 38D3B01D1FF3D2A400E5FAF2 /* MSAppDelegateForwarderTests.m */; };
+		C25680CE223126A80063B3F7 /* MSMockPushDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C25680CD223126A80063B3F7 /* MSMockPushDelegate.m */; };
+		C25680CF223126A80063B3F7 /* MSMockPushDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C25680CD223126A80063B3F7 /* MSMockPushDelegate.m */; };
 		D38023C11E6DE01700466558 /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D38023C01E6DE01700466558 /* UserNotifications.framework */; };
 		D39B04E41E66FBD50048E397 /* MSPushTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D39B04E31E66FBD50048E397 /* MSPushTestUtil.m */; };
 		D3AD5EC51E5C4F6A001627AB /* libAppCenterPush.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D33A94511E5B11BB003966DB /* libAppCenterPush.a */; };
@@ -198,6 +200,8 @@
 		38C65D8021826CC80004FB44 /* MSUserNotificationCenterDelegateForwarder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MSUserNotificationCenterDelegateForwarder.h; path = DelegateForwarder/MSUserNotificationCenterDelegateForwarder.h; sourceTree = "<group>"; };
 		38C65D8121826CC80004FB44 /* MSUserNotificationCenterDelegateForwarder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MSUserNotificationCenterDelegateForwarder.m; path = DelegateForwarder/MSUserNotificationCenterDelegateForwarder.m; sourceTree = "<group>"; };
 		38D3B01D1FF3D2A400E5FAF2 /* MSAppDelegateForwarderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSAppDelegateForwarderTests.m; sourceTree = "<group>"; };
+		C25680CC223126A80063B3F7 /* MSMockPushDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSMockPushDelegate.h; sourceTree = "<group>"; };
+		C25680CD223126A80063B3F7 /* MSMockPushDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSMockPushDelegate.m; sourceTree = "<group>"; };
 		D33A94511E5B11BB003966DB /* libAppCenterPush.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAppCenterPush.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D33A94541E5B11BB003966DB /* AppCenterPush.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppCenterPush.h; sourceTree = "<group>"; };
 		D38023C01E6DE01700466558 /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
@@ -289,6 +293,8 @@
 			isa = PBXGroup;
 			children = (
 				04849D781E9E913A0093ECA6 /* MSPushLogTests.m */,
+				C25680CC223126A80063B3F7 /* MSMockPushDelegate.h */,
+				C25680CD223126A80063B3F7 /* MSMockPushDelegate.m */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -743,6 +749,7 @@
 				046964501F2A5D4F00F9D31F /* MSPushLogTests.m in Sources */,
 				046964511F2A5D8D00F9D31F /* MSPushTestUtil.m in Sources */,
 				0469644F1F2A5D4A00F9D31F /* MSPushTests.m in Sources */,
+				C25680CF223126A80063B3F7 /* MSMockPushDelegate.m in Sources */,
 				384A925E2188B94F0099BE70 /* MSUserNotificationCenterDelegateForwarderTest.m in Sources */,
 				F82E4C86217F218D00EDAB34 /* sqlite3.c in Sources */,
 				384A92672188C65C0099BE70 /* MSDelegateForwarderTestUtil.m in Sources */,
@@ -769,6 +776,7 @@
 				0496A67B1F3128CE005AE1DB /* MSPushTests.m in Sources */,
 				04849D791E9E913A0093ECA6 /* MSPushLogTests.m in Sources */,
 				D39B04E41E66FBD50048E397 /* MSPushTestUtil.m in Sources */,
+				C25680CE223126A80063B3F7 /* MSMockPushDelegate.m in Sources */,
 				384A92662188C65C0099BE70 /* MSDelegateForwarderTestUtil.m in Sources */,
 				38D3B01F1FF3D2A900E5FAF2 /* MSAppDelegateForwarderTests.m in Sources */,
 				F82E4C85217F218D00EDAB34 /* sqlite3.c in Sources */,

--- a/AppCenterPush/AppCenterPush/MSPush.m
+++ b/AppCenterPush/AppCenterPush/MSPush.m
@@ -371,9 +371,7 @@ static void *UserNotificationCenterDelegateContext = &UserNotificationCenterDele
                                                                             customData:(NSDictionary<NSString *, NSString *> *)customData];
 
       // Call push delegate and deliver notification back to the application.
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [self.delegate push:self didReceivePushNotification:pushNotification];
-      });
+      [self didReceivePushNotification:pushNotification];
 #if TARGET_OS_OSX
     } else {
       NSUserNotification *notification = [[NSUserNotification alloc] init];
@@ -387,6 +385,15 @@ static void *UserNotificationCenterDelegateContext = &UserNotificationCenterDele
     return YES;
   }
   return NO;
+}
+
+- (void)didReceivePushNotification:(MSPushNotification *)pushNotification {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    id<MSPushDelegate> delegate = self.delegate;
+    if (delegate && [delegate respondsToSelector:@selector(push:didReceivePushNotification:)]) {
+      [delegate push:self didReceivePushNotification:pushNotification];
+    }
+  });
 }
 
 @end

--- a/AppCenterPush/AppCenterPush/MSPush.m
+++ b/AppCenterPush/AppCenterPush/MSPush.m
@@ -390,7 +390,7 @@ static void *UserNotificationCenterDelegateContext = &UserNotificationCenterDele
 - (void)didReceivePushNotification:(MSPushNotification *)pushNotification {
   dispatch_async(dispatch_get_main_queue(), ^{
     id<MSPushDelegate> delegate = self.delegate;
-    if (delegate && [delegate respondsToSelector:@selector(push:didReceivePushNotification:)]) {
+    if ([delegate respondsToSelector:@selector(push:didReceivePushNotification:)]) {
       [delegate push:self didReceivePushNotification:pushNotification];
     }
   });

--- a/AppCenterPush/AppCenterPushTests/MSMockPushDelegate.h
+++ b/AppCenterPush/AppCenterPushTests/MSMockPushDelegate.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import "MSPushDelegate.h"
+
+@interface MSMockPushDelegate : NSObject <MSPushDelegate>
+
+@end

--- a/AppCenterPush/AppCenterPushTests/MSMockPushDelegate.m
+++ b/AppCenterPush/AppCenterPushTests/MSMockPushDelegate.m
@@ -1,0 +1,4 @@
+#import "MSMockPushDelegate.h"
+
+@implementation MSMockPushDelegate
+@end

--- a/AppCenterPush/AppCenterPushTests/MSPushTests.m
+++ b/AppCenterPush/AppCenterPushTests/MSPushTests.m
@@ -8,6 +8,7 @@
 
 #import "MSChannelGroupProtocol.h"
 #import "MSChannelUnitProtocol.h"
+#import "MSMockPushDelegate.h"
 #import "MSPush.h"
 #import "MSPushAppDelegate.h"
 #import "MSPushLog.h"
@@ -208,6 +209,51 @@ static NSString *const kMSTestPushToken = @"TestPushToken";
 
   // Then
   OCMVerify([pushMock didFailToRegisterForRemoteNotificationsWithError:errorMock]);
+  [pushMock stopMocking];
+}
+
+- (void)testNotificationReceivedWithoutCallback {
+
+  // If
+  XCTestExpectation *notificationReceived = [self expectationWithDescription:@"Valid notification received."];
+  id pushMock = OCMPartialMock(self.sut);
+  OCMStub([pushMock sharedInstance]).andReturn(pushMock);
+  OCMStub([pushMock canBeUsed]).andReturn(YES);
+  [MSPush resetSharedInstance];
+  [MSPush setDelegate:[MSMockPushDelegate new]];
+  __block NSString *message = @"notification message";
+  __block NSDictionary *customData = @{@"key" : @"value"};
+  NSDictionary *userInfo = @{
+    kMSPushNotificationApsKey : @{kMSPushNotificationAlertKey : message}, kMSPushNotificationCustomDataKey : customData
+  };
+#if TARGET_OS_OSX
+  id userNotificationUserInfoMock = OCMClassMock([NSUserNotification class]);
+  id notificationMock = ;OCMClassMock([NSNotification class])
+  NSDictionary *notificationUserInfo = @{NSApplicationLaunchUserNotificationKey : userNotificationUserInfoMock};
+  OCMStub([notificationMock userInfo]).andReturn(notificationUserInfo);
+  OCMStub([userNotificationUserInfoMock userInfo]).andReturn(userInfo);
+#endif
+
+  // When
+#if TARGET_OS_OSX
+  [self.sut applicationDidFinishLaunching:notificationMock];
+#else
+  BOOL result = [MSPush didReceiveRemoteNotification:userInfo];
+#endif
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [notificationReceived fulfill];
+  });
+
+  // Then
+  [self waitForExpectationsWithTimeout:1
+                               handler:^(NSError *error) {
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                               }];
+#if !TARGET_OS_OSX
+  XCTAssertTrue(result);
+#endif
   [pushMock stopMocking];
 }
 

--- a/AppCenterPush/AppCenterPushTests/MSPushTests.m
+++ b/AppCenterPush/AppCenterPushTests/MSPushTests.m
@@ -228,7 +228,7 @@ static NSString *const kMSTestPushToken = @"TestPushToken";
   };
 #if TARGET_OS_OSX
   id userNotificationUserInfoMock = OCMClassMock([NSUserNotification class]);
-  id notificationMock = ;OCMClassMock([NSNotification class])
+  id notificationMock = OCMClassMock([NSNotification class]);
   NSDictionary *notificationUserInfo = @{NSApplicationLaunchUserNotificationKey : userNotificationUserInfoMock};
   OCMStub([notificationMock userInfo]).andReturn(notificationUserInfo);
   OCMStub([userNotificationUserInfoMock userInfo]).andReturn(userInfo);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * **[Feature]** Preparation work for a future change in transmission protocol and endpoint for Analytics data on macOS. There is no impact on your current workflow when using App Center.
 
+### AppCenterPush
+
+* **[Fix]** Fix crash on invoking an optional push callback when it isn't implemented in the push delegate.
+
 ___
 
 ## Version 1.13.2


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

1. Remove `MSPushDelegate push:didReceivePushNotification:` from `AppDelegate` in test application;
2. Deploy to a device and send push notification from the portal;
3. The application crashed with `*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[AppDelegate push:didReceivePushNotification:]: unrecognized selector sent to instance 0x2815ec210'`

## Related PRs or issues

AB#57902
