### PR TITLE
Delete authToken from MSAppCenterIngestion and pass it for each batch

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -27,9 +27,7 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
     _storage = [MSLogDBStorage new];
     if (ingestion) {
       _ingestion = ingestion;
-      _ingestion.authToken = [MSAuthTokenContext sharedInstance].authToken;
     }
-    [[MSAuthTokenContext sharedInstance] addDelegate:self];
   }
   return self;
 }
@@ -234,12 +232,6 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
   dispatch_async(self.logsDispatchQueue, ^{
     [self.storage setMaxStorageSize:sizeInBytes completionHandler:completionHandler];
   });
-}
-
-- (void)authTokenContext:(__unused MSAuthTokenContext *)authTokenContext didSetNewAuthToken:(NSString *)authToken {
-  if (self.ingestion) {
-    self.ingestion.authToken = authToken;
-  }
 }
 
 @end

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class MSAppCenterIngestion;
 
-@interface MSChannelGroupDefault () <MSAuthTokenContextDelegate, MSChannelDelegate>
+@interface MSChannelGroupDefault () <MSChannelDelegate>
 
 /**
  * Initializes a new `MSChannelGroupDefault` instance.

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -3,6 +3,7 @@
 #import "MSAppCenterErrors.h"
 #import "MSAppCenterIngestion.h"
 #import "MSAppCenterInternal.h"
+#import "MSAuthTokenContext.h"
 #import "MSChannelUnitConfiguration.h"
 #import "MSChannelUnitDefaultPrivate.h"
 #import "MSDeviceTracker.h"
@@ -250,9 +251,11 @@
                                           [delegate channel:self willSendLog:aLog];
                                         }
                                       }];
+            NSString *authToken = [MSAuthTokenContext sharedInstance].authToken;
 
             // Forward logs to the ingestion.
             [self.ingestion sendAsync:container
+                            authToken:authToken
                     completionHandler:^(NSString *ingestionBatchId, NSHTTPURLResponse *response, __attribute__((unused)) NSData *data,
                                         NSError *error) {
                       dispatch_async(self.logsDispatchQueue, ^{

--- a/AppCenter/AppCenter/Internals/Ingestion/MSAppCenterIngestion.h
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSAppCenterIngestion.h
@@ -15,11 +15,6 @@ extern NSString *const kMSBearerTokenHeaderFormat;
 @property(nonatomic, copy) NSString *appSecret;
 
 /**
- * The authorization token. If unavailable, this is nil.
- */
-@property(atomic, copy, nullable) NSString *authToken;
-
-/**
  * Initialize the Ingestion.
  *
  * @param baseUrl Base url.

--- a/AppCenter/AppCenter/Internals/Ingestion/MSAppCenterIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSAppCenterIngestion.m
@@ -28,7 +28,7 @@ NSString *const kMSBearerTokenHeaderFormat = @"Bearer %@";
   return self.appSecret != nil;
 }
 
-- (void)sendAsync:(NSObject *)data completionHandler:(MSSendAsyncCompletionHandler)handler {
+- (void)sendAsync:(NSObject *)data authToken:(NSString *)authToken completionHandler:(MSSendAsyncCompletionHandler)handler {
   MSLogContainer *container = (MSLogContainer *)data;
   NSString *batchId = container.batchId;
 
@@ -46,10 +46,10 @@ NSString *const kMSBearerTokenHeaderFormat = @"Bearer %@";
     return;
   }
 
-  [super sendAsync:container eTag:nil callId:container.batchId completionHandler:handler];
+  [super sendAsync:container eTag:nil authToken:authToken callId:container.batchId completionHandler:handler];
 }
 
-- (NSURLRequest *)createRequest:(NSObject *)data eTag:(NSString *)__unused eTag {
+- (NSURLRequest *)createRequest:(NSObject *)data eTag:(NSString *)__unused eTag authToken:(nullable NSString *)authToken {
   if (!self.appSecret) {
     MSLogError([MSAppCenter logTag], @"AppCenter ingestion is used without app secret.");
     return nil;
@@ -63,11 +63,8 @@ NSString *const kMSBearerTokenHeaderFormat = @"Bearer %@";
   // Set Header params.
   request.allHTTPHeaderFields = self.httpHeaders;
   [request setValue:self.appSecret forHTTPHeaderField:kMSHeaderAppSecretKey];
-
-  // Copy self.authToken into a local variable to avoid a race condition.
-  NSString *authTokenCopy = self.authToken;
-  if ([authTokenCopy length] > 0) {
-    NSString *bearerTokenHeader = [NSString stringWithFormat:kMSBearerTokenHeaderFormat, authTokenCopy];
+  if ([authToken length] > 0) {
+    NSString *bearerTokenHeader = [NSString stringWithFormat:kMSBearerTokenHeaderFormat, authToken];
     [request setValue:bearerTokenHeader forHTTPHeaderField:kMSAuthorizationHeaderKey];
   }
 

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.h
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.h
@@ -55,16 +55,6 @@ static NSString *const kMSETagRequestHeader = @"If-None-Match";
  *
  * @param data A data instance that will be transformed to request body.
  * @param eTag HTTP entity tag.
- *
- * @return A URL request.
- */
-- (NSURLRequest *)createRequest:(NSObject *)data eTag:(nullable NSString *)eTag;
-
-/**
- * Create a request based on data. Must override this method in sub classes.
- *
- * @param data A data instance that will be transformed to request body.
- * @param eTag HTTP entity tag.
  * @param authToken auth token to send data with.
  *
  * @return A URL request.

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.h
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.h
@@ -55,6 +55,16 @@ static NSString *const kMSETagRequestHeader = @"If-None-Match";
  *
  * @param data A data instance that will be transformed to request body.
  * @param eTag HTTP entity tag.
+ *
+ * @return A URL request.
+ */
+- (NSURLRequest *)createRequest:(NSObject *)data eTag:(nullable NSString *)eTag;
+
+/**
+ * Create a request based on data. Must override this method in sub classes.
+ *
+ * @param data A data instance that will be transformed to request body.
+ * @param eTag HTTP entity tag.
  * @param authToken auth token to send data with.
  *
  * @return A URL request.

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.h
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.h
@@ -40,11 +40,13 @@ static NSString *const kMSETagRequestHeader = @"If-None-Match";
  *
  * @param data A data instance that will be transformed request body.
  * @param eTag HTTP entity tag.
+ * @param authToken Auth token to send data with
  * @param callId A unique ID that identify a request.
  * @param handler Completion handler
  */
 - (void)sendAsync:(nullable NSObject *)data
                  eTag:(nullable NSString *)eTag
+            authToken:(nullable NSString *)authToken
                callId:(NSString *)callId
     completionHandler:(MSSendAsyncCompletionHandler)handler;
 
@@ -53,10 +55,11 @@ static NSString *const kMSETagRequestHeader = @"If-None-Match";
  *
  * @param data A data instance that will be transformed to request body.
  * @param eTag HTTP entity tag.
+ * @param authToken auth token to send data with
  *
  * @return A URL request.
  */
-- (NSURLRequest *)createRequest:(NSObject *)data eTag:(nullable NSString *)eTag;
+- (NSURLRequest *)createRequest:(NSObject *)data eTag:(nullable NSString *)eTag authToken:(nullable NSString *)authToken;
 
 /**
  * Get eTag from the given response.

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.h
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.h
@@ -40,9 +40,9 @@ static NSString *const kMSETagRequestHeader = @"If-None-Match";
  *
  * @param data A data instance that will be transformed request body.
  * @param eTag HTTP entity tag.
- * @param authToken Auth token to send data with
+ * @param authToken Auth token to send data with.
  * @param callId A unique ID that identify a request.
- * @param handler Completion handler
+ * @param handler Completion handler.
  */
 - (void)sendAsync:(nullable NSObject *)data
                  eTag:(nullable NSString *)eTag
@@ -55,7 +55,7 @@ static NSString *const kMSETagRequestHeader = @"If-None-Match";
  *
  * @param data A data instance that will be transformed to request body.
  * @param eTag HTTP entity tag.
- * @param authToken auth token to send data with
+ * @param authToken auth token to send data with.
  *
  * @return A URL request.
  */

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
@@ -346,13 +346,6 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
   return nil;
 }
 
-/**
- * This is an empty method expected to be overridden in sub classes.
- */
-- (NSURLRequest *)createRequest:(NSObject *)__unused data eTag:(NSString *)__unused eTag {
-  return nil;
-}
-
 - (NSString *)obfuscateHeaderValue:(NSString *)value forKey:(NSString *)key {
   (void)key;
   return value;

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
@@ -96,12 +96,23 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
   return YES;
 }
 
+- (void)sendAsync:(NSObject *)data authToken:(nullable NSString *)authToken completionHandler:(MSSendAsyncCompletionHandler)handler {
+  [self sendAsync:data eTag:nil authToken:authToken callId:MS_UUID_STRING completionHandler:handler];
+}
+
+- (void)sendAsync:(NSObject *)data
+                 eTag:(nullable NSString *)eTag
+            authToken:(nullable NSString *)authToken
+    completionHandler:(MSSendAsyncCompletionHandler)handler {
+  [self sendAsync:data eTag:eTag authToken:authToken callId:MS_UUID_STRING completionHandler:handler];
+}
+
 - (void)sendAsync:(NSObject *)data completionHandler:(MSSendAsyncCompletionHandler)handler {
-  [self sendAsync:data eTag:nil callId:MS_UUID_STRING completionHandler:handler];
+  [self sendAsync:data eTag:nil authToken:nil callId:MS_UUID_STRING completionHandler:handler];
 }
 
 - (void)sendAsync:(NSObject *)data eTag:(nullable NSString *)eTag completionHandler:(MSSendAsyncCompletionHandler)handler {
-  [self sendAsync:data eTag:eTag callId:MS_UUID_STRING completionHandler:handler];
+  [self sendAsync:data eTag:eTag authToken:nil callId:MS_UUID_STRING completionHandler:handler];
 }
 
 - (void)addDelegate:(id<MSIngestionDelegate>)delegate {
@@ -203,7 +214,7 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
     }
 
     // Create the request.
-    NSURLRequest *request = [self createRequest:call.data eTag:call.eTag];
+    NSURLRequest *request = [self createRequest:call.data eTag:call.eTag authToken:call.authToken];
     if (!request) {
       return;
     }
@@ -331,7 +342,7 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
 /**
  * This is an empty method expected to be overridden in sub classes.
  */
-- (NSURLRequest *)createRequest:(NSObject *)__unused data eTag:(NSString *)__unused eTag {
+- (NSURLRequest *)createRequest:(NSObject *)__unused data eTag:(NSString *)__unused eTag authToken:(nullable NSString *)__unused authToken {
   return nil;
 }
 
@@ -376,6 +387,7 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
 
 - (void)sendAsync:(NSObject *)data
                  eTag:(nullable NSString *)eTag
+            authToken:(nullable NSString *)__unused authToken
                callId:(NSString *)callId
     completionHandler:(MSSendAsyncCompletionHandler)handler {
   @synchronized(self) {
@@ -386,6 +398,7 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
       call = [[MSIngestionCall alloc] initWithRetryIntervals:self.callsRetryIntervals];
       call.delegate = self;
       call.data = data;
+      call.authToken = authToken;
       call.eTag = eTag;
       call.callId = callId;
       call.completionHandler = handler;

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
@@ -387,7 +387,7 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
 
 - (void)sendAsync:(NSObject *)data
                  eTag:(nullable NSString *)eTag
-            authToken:(nullable NSString *)__unused authToken
+            authToken:(nullable NSString *)authToken
                callId:(NSString *)callId
     completionHandler:(MSSendAsyncCompletionHandler)handler {
   @synchronized(self) {

--- a/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSHttpIngestion.m
@@ -346,6 +346,13 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
   return nil;
 }
 
+/**
+ * This is an empty method expected to be overridden in sub classes.
+ */
+- (NSURLRequest *)createRequest:(NSObject *)__unused data eTag:(NSString *)__unused eTag {
+  return nil;
+}
+
 - (NSString *)obfuscateHeaderValue:(NSString *)value forKey:(NSString *)key {
   (void)key;
   return value;

--- a/AppCenter/AppCenter/Internals/Ingestion/MSIngestionCall.h
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSIngestionCall.h
@@ -24,7 +24,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Entity tag of the request.
  */
-@property(nonatomic, nullable) NSString *eTag;
+@property(nonatomic, nullable, copy) NSString *eTag;
+
+/**
+ * Auth token for the request.
+ */
+@property(nonatomic, nullable, copy) NSString *authToken;
 
 /**
  * Unique call ID.

--- a/AppCenter/AppCenter/Internals/Ingestion/MSIngestionProtocol.h
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSIngestionProtocol.h
@@ -30,9 +30,33 @@ NS_ASSUME_NONNULL_BEGIN
  * Send data.
  *
  * @param data Instance that will be transformed to request body.
+ * @param authToken Auth token to send data with.
+ * @param handler Completion handler.
+ */
+- (void)sendAsync:(nullable NSObject *)data
+            authToken:(nullable NSString *)__unused authToken
+    completionHandler:(MSSendAsyncCompletionHandler)handler;
+
+/**
+ * Send data.
+ *
+ * @param data Instance that will be transformed to request body.
  * @param handler Completion handler.
  */
 - (void)sendAsync:(nullable NSObject *)data completionHandler:(MSSendAsyncCompletionHandler)handler;
+
+/**
+ * Send data.
+ *
+ * @param data Instance that will be transformed to request body.
+ * @param eTag HTTP entity tag.
+ * @param authToken Auth token to send data with.
+ * @param handler Completion handler.
+ */
+- (void)sendAsync:(nullable NSObject *)data
+                 eTag:(nullable NSString *)eTag
+            authToken:(nullable NSString *)authToken
+    completionHandler:(MSSendAsyncCompletionHandler)handler;
 
 /**
  * Send data.

--- a/AppCenter/AppCenter/Internals/Ingestion/MSOneCollectorIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSOneCollectorIngestion.m
@@ -36,7 +36,7 @@ NSString *const kMSOneCollectorUploadTimeKey = @"Upload-Time";
   return self;
 }
 
-- (void)sendAsync:(NSObject *)data completionHandler:(MSSendAsyncCompletionHandler)handler {
+- (void)sendAsync:(NSObject *)data authToken:(nullable NSString *)authToken completionHandler:(MSSendAsyncCompletionHandler)handler {
   MSLogContainer *container = (MSLogContainer *)data;
   NSString *batchId = container.batchId;
 
@@ -54,7 +54,7 @@ NSString *const kMSOneCollectorUploadTimeKey = @"Upload-Time";
     handler(batchId, 0, nil, error);
     return;
   }
-  [super sendAsync:container eTag:nil callId:container.batchId completionHandler:handler];
+  [super sendAsync:container eTag:nil authToken:authToken callId:container.batchId completionHandler:handler];
 }
 
 - (NSURLRequest *)createRequest:(NSObject *)data eTag:(NSString *)__unused eTag {

--- a/AppCenter/AppCenter/Internals/Ingestion/MSOneCollectorIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSOneCollectorIngestion.m
@@ -57,7 +57,7 @@ NSString *const kMSOneCollectorUploadTimeKey = @"Upload-Time";
   [super sendAsync:container eTag:nil authToken:authToken callId:container.batchId completionHandler:handler];
 }
 
-- (NSURLRequest *)createRequest:(NSObject *)data eTag:(NSString *)__unused eTag {
+- (NSURLRequest *)createRequest:(NSObject *)data eTag:(NSString *)__unused eTag authToken:(NSString *)__unused authToken {
   MSLogContainer *container = (MSLogContainer *)data;
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.sendURL];
 

--- a/AppCenter/AppCenterTests/MSAppCenterIngestionTests.m
+++ b/AppCenter/AppCenterTests/MSAppCenterIngestionTests.m
@@ -342,8 +342,6 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
                                }];
 }
 
-// TODO: Create test to check flow when we miss MSAppCenterIngestion::sendAsync call and go to MSHttpIngestion::sendAsync
-
 - (void)testInvalidContainer {
 
   MSAbstractLog *log = [MSAbstractLog new];
@@ -580,22 +578,20 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   XCTAssertTrue(request.HTTPBody.length < httpBody.length);
 }
 
-// TODO: Uncomment, fix
-//- (void)testSendsAuthHeaderWhenAuthTokenIsNotNil {
-//
-//  // If
-//  NSString *expectedToken = @"auth token";
-//  MSLogContainer *logContainer = [[MSLogContainer alloc] initWithBatchId:@"whatever" andLogs:(NSArray<id<MSLog>> *)@ [[MSMockLog new]]];
-//  self.sut.authToken = expectedToken;
-//
-//  // When
-//  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil authToken:nil];
-//
-//  // Then
-//  NSString *expectedHeader = [NSString stringWithFormat:kMSBearerTokenHeaderFormat, expectedToken];
-//  NSString *actualHeader = request.allHTTPHeaderFields[kMSAuthorizationHeaderKey];
-//  XCTAssertEqualObjects(expectedHeader, actualHeader);
-//}
+- (void)testSendsAuthHeaderWhenAuthTokenIsNotNil {
+
+  // If
+  NSString *token = @"auth token";
+  MSLogContainer *logContainer = [[MSLogContainer alloc] initWithBatchId:@"whatever" andLogs:(NSArray<id<MSLog>> *)@ [[MSMockLog new]]];
+
+  // When
+  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil authToken:token];
+
+  // Then
+  NSString *expectedHeader = [NSString stringWithFormat:kMSBearerTokenHeaderFormat, token];
+  NSString *actualHeader = request.allHTTPHeaderFields[kMSAuthorizationHeaderKey];
+  XCTAssertEqualObjects(expectedHeader, actualHeader);
+}
 
 - (void)testDoesNotSendAuthHeaderWithNilAuthToken {
 
@@ -609,19 +605,17 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   XCTAssertNil([request.allHTTPHeaderFields valueForKey:kMSAuthorizationHeaderKey]);
 }
 
-// TODO: Uncomment, fix
-//- (void)testDoesNotSendAuthHeaderWithEmptyAuthToken {
-//
-//  // If
-//  MSLogContainer *logContainer = [[MSLogContainer alloc] initWithBatchId:@"whatever" andLogs:(NSArray<id<MSLog>> *)@ [[MSMockLog new]]];
-//  self.sut.authToken = @"";
-//
-//  // When
-//  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil authToken:nil];
-//
-//  // Then
-//  XCTAssertNil([request.allHTTPHeaderFields valueForKey:kMSAuthorizationHeaderKey]);
-//}
+- (void)testDoesNotSendAuthHeaderWithEmptyAuthToken {
+
+  // If
+  MSLogContainer *logContainer = [[MSLogContainer alloc] initWithBatchId:@"whatever" andLogs:(NSArray<id<MSLog>> *)@ [[MSMockLog new]]];
+
+  // When
+  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil authToken:nil];
+
+  // Then
+  XCTAssertNil([request.allHTTPHeaderFields valueForKey:kMSAuthorizationHeaderKey]);
+}
 
 - (void)testObfuscateHeaderValue {
 

--- a/AppCenter/AppCenterTests/MSAppCenterIngestionTests.m
+++ b/AppCenter/AppCenterTests/MSAppCenterIngestionTests.m
@@ -74,6 +74,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   MSLogContainer *container = [self createLogContainerWithId:containerId];
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"HTTP Response 200"];
   [self.sut sendAsync:container
+              authToken:nil
       completionHandler:^(NSString *batchId, NSHTTPURLResponse *response, __unused NSData *data, NSError *error) {
         XCTAssertNil(error);
         XCTAssertEqual(containerId, batchId);
@@ -103,6 +104,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
 
   // When
   [self.sut sendAsync:container
+              authToken:nil
       completionHandler:^(NSString *batchId, NSHTTPURLResponse *response, __unused NSData *data, NSError *error) {
         // Then
         XCTAssertEqual(containerId, batchId);
@@ -340,6 +342,8 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
                                }];
 }
 
+// TODO: Create test to check flow when we miss MSAppCenterIngestion::sendAsync call and go to MSHttpIngestion::sendAsync
+
 - (void)testInvalidContainer {
 
   MSAbstractLog *log = [MSAbstractLog new];
@@ -350,6 +354,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   MSLogContainer *container = [[MSLogContainer alloc] initWithBatchId:@"1" andLogs:(NSArray<id<MSLog>> *)@[ log ]];
 
   [self.sut sendAsync:container
+              authToken:nil
       completionHandler:^(__unused NSString *batchId, __unused NSHTTPURLResponse *response, __unused NSData *data, NSError *error) {
         XCTAssertEqual(error.domain, kMSACErrorDomain);
         XCTAssertEqual(error.code, kMSACLogInvalidContainerErrorCode);
@@ -364,6 +369,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
 
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"HTTP Network Down"];
   [self.sut sendAsync:container
+              authToken:nil
       completionHandler:^(__unused NSString *batchId, __unused NSHTTPURLResponse *response, __unused NSData *data, NSError *error) {
         XCTAssertNotNil(error);
         [expectation fulfill];
@@ -554,7 +560,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   NSData *httpBody = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
 
   // When
-  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil];
+  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil authToken:nil];
 
   // Then
   XCTAssertEqualObjects(request.HTTPBody, httpBody);
@@ -568,27 +574,28 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   httpBody = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
 
   // When
-  request = [self.sut createRequest:logContainer eTag:nil];
+  request = [self.sut createRequest:logContainer eTag:nil authToken:nil];
 
   // Then
   XCTAssertTrue(request.HTTPBody.length < httpBody.length);
 }
 
-- (void)testSendsAuthHeaderWhenAuthTokenIsNotNil {
-
-  // If
-  NSString *expectedToken = @"auth token";
-  MSLogContainer *logContainer = [[MSLogContainer alloc] initWithBatchId:@"whatever" andLogs:(NSArray<id<MSLog>> *)@ [[MSMockLog new]]];
-  self.sut.authToken = expectedToken;
-
-  // When
-  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil];
-
-  // Then
-  NSString *expectedHeader = [NSString stringWithFormat:kMSBearerTokenHeaderFormat, expectedToken];
-  NSString *actualHeader = request.allHTTPHeaderFields[kMSAuthorizationHeaderKey];
-  XCTAssertEqualObjects(expectedHeader, actualHeader);
-}
+// TODO: Uncomment, fix
+//- (void)testSendsAuthHeaderWhenAuthTokenIsNotNil {
+//
+//  // If
+//  NSString *expectedToken = @"auth token";
+//  MSLogContainer *logContainer = [[MSLogContainer alloc] initWithBatchId:@"whatever" andLogs:(NSArray<id<MSLog>> *)@ [[MSMockLog new]]];
+//  self.sut.authToken = expectedToken;
+//
+//  // When
+//  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil authToken:nil];
+//
+//  // Then
+//  NSString *expectedHeader = [NSString stringWithFormat:kMSBearerTokenHeaderFormat, expectedToken];
+//  NSString *actualHeader = request.allHTTPHeaderFields[kMSAuthorizationHeaderKey];
+//  XCTAssertEqualObjects(expectedHeader, actualHeader);
+//}
 
 - (void)testDoesNotSendAuthHeaderWithNilAuthToken {
 
@@ -596,24 +603,25 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   MSLogContainer *logContainer = [[MSLogContainer alloc] initWithBatchId:@"whatever" andLogs:(NSArray<id<MSLog>> *)@ [[MSMockLog new]]];
 
   // When
-  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil];
+  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil authToken:nil];
 
   // Then
   XCTAssertNil([request.allHTTPHeaderFields valueForKey:kMSAuthorizationHeaderKey]);
 }
 
-- (void)testDoesNotSendAuthHeaderWithEmptyAuthToken {
-
-  // If
-  MSLogContainer *logContainer = [[MSLogContainer alloc] initWithBatchId:@"whatever" andLogs:(NSArray<id<MSLog>> *)@ [[MSMockLog new]]];
-  self.sut.authToken = @"";
-
-  // When
-  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil];
-
-  // Then
-  XCTAssertNil([request.allHTTPHeaderFields valueForKey:kMSAuthorizationHeaderKey]);
-}
+// TODO: Uncomment, fix
+//- (void)testDoesNotSendAuthHeaderWithEmptyAuthToken {
+//
+//  // If
+//  MSLogContainer *logContainer = [[MSLogContainer alloc] initWithBatchId:@"whatever" andLogs:(NSArray<id<MSLog>> *)@ [[MSMockLog new]]];
+//  self.sut.authToken = @"";
+//
+//  // When
+//  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil authToken:nil];
+//
+//  // Then
+//  XCTAssertNil([request.allHTTPHeaderFields valueForKey:kMSAuthorizationHeaderKey]);
+//}
 
 - (void)testObfuscateHeaderValue {
 

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -478,32 +478,4 @@
   [channelUnitMock stopMocking];
 }
 
-- (void)testUpdatesIngestionAuthTokenWhenAuthTokenIsReceived {
-
-  // If
-  MSAppCenterIngestion *ingestionMock = [[MSAppCenterIngestion alloc] initWithBaseUrl:@"baseurl" installId:@"5"];
-  __unused MSChannelGroupDefault *sut = [[MSChannelGroupDefault alloc] initWithIngestion:ingestionMock];
-  NSString *expectedAuthToken = @"auth token";
-
-  // When
-  [[MSAuthTokenContext sharedInstance] setAuthToken:expectedAuthToken withAccountId:@"any"];
-
-  // Then
-  XCTAssertEqualObjects(expectedAuthToken, ingestionMock.authToken);
-}
-
-- (void)testInitUpdatesIngestionAuthTokenWhenAuthTokenAlreadyExists {
-
-  // If
-  MSAppCenterIngestion *ingestionMock = [[MSAppCenterIngestion alloc] initWithBaseUrl:@"baseurl" installId:@"5"];
-  NSString *expectedAuthToken = @"auth token";
-  [[MSAuthTokenContext sharedInstance] setAuthToken:expectedAuthToken withAccountId:@"any"];
-
-  // When
-  (void)[[MSChannelGroupDefault alloc] initWithIngestion:ingestionMock];
-
-  // Then
-  XCTAssertEqualObjects(expectedAuthToken, ingestionMock.authToken);
-}
-
 @end

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -96,7 +96,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   OCMStub([ingestionMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     // Get ingestion block for later call.
     [invocation retainArguments];
-    [invocation getArgument:&ingestionBlock atIndex:3];
+    [invocation getArgument:&ingestionBlock atIndex:4];
     [invocation getArgument:&logContainer atIndex:2];
   });
   __block id responseMock = [MSHttpTestUtil createMockResponseForStatusCode:200 headers:nil];
@@ -189,7 +189,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   OCMStub([ingestionMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     // Get ingestion block for later call.
     [invocation retainArguments];
-    [invocation getArgument:&ingestionBlock atIndex:3];
+    [invocation getArgument:&ingestionBlock atIndex:4];
     [invocation getArgument:&logContainer atIndex:2];
   });
   __block id responseMock = [MSHttpTestUtil createMockResponseForStatusCode:300 headers:nil];
@@ -499,10 +499,10 @@ static NSString *const kMSTestGroupId = @"GroupId";
   // Init mocks.
   id ingestionMock = OCMProtocolMock(@protocol(MSIngestionProtocol));
   OCMStub([ingestionMock isReadyToSend]).andReturn(YES);
-  OCMStub([ingestionMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+  OCMStub([ingestionMock sendAsync:OCMOCK_ANY authToken:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     // Get ingestion block for later call.
     [invocation retainArguments];
-    [invocation getArgument:&ingestionBlock atIndex:3];
+    [invocation getArgument:&ingestionBlock atIndex:4];
     [invocation getArgument:&lastBatchLogContainer atIndex:2];
   });
   __block id responseMock = [MSHttpTestUtil createMockResponseForStatusCode:200 headers:nil];

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -93,7 +93,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   id<MSLog> enqueuedLog = [self getValidMockLog];
   id ingestionMock = OCMProtocolMock(@protocol(MSIngestionProtocol));
   OCMStub([ingestionMock isReadyToSend]).andReturn(YES);
-  OCMStub([ingestionMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+  OCMStub([ingestionMock sendAsync:OCMOCK_ANY authToken:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     // Get ingestion block for later call.
     [invocation retainArguments];
     [invocation getArgument:&ingestionBlock atIndex:4];
@@ -186,7 +186,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   id<MSLog> enqueuedLog = [self getValidMockLog];
   id ingestionMock = OCMProtocolMock(@protocol(MSIngestionProtocol));
   OCMStub([ingestionMock isReadyToSend]).andReturn(YES);
-  OCMStub([ingestionMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+  OCMStub([ingestionMock sendAsync:OCMOCK_ANY authToken:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     // Get ingestion block for later call.
     [invocation retainArguments];
     [invocation getArgument:&ingestionBlock atIndex:4];
@@ -438,7 +438,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   // Set up mock and stubs.
   id ingestionMock = OCMProtocolMock(@protocol(MSIngestionProtocol));
   OCMStub([ingestionMock isReadyToSend]).andReturn(YES);
-  OCMStub([ingestionMock sendAsync:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+  OCMStub([ingestionMock sendAsync:OCMOCK_ANY authToken:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     MSLogContainer *container;
     [invocation getArgument:&container atIndex:2];
     if (container) {

--- a/AppCenter/AppCenterTests/MSOneCollectorIngestionTests.m
+++ b/AppCenter/AppCenterTests/MSOneCollectorIngestionTests.m
@@ -63,7 +63,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   // When
   NSString *containerId = @"1";
   MSLogContainer *container = [self createLogContainerWithId:containerId];
-  NSURLRequest *request = [self.sut createRequest:container eTag:nil];
+  NSURLRequest *request = [self.sut createRequest:container eTag:nil authToken:nil];
   NSArray *keys = [request.allHTTPHeaderFields allKeys];
 
   // Then
@@ -136,7 +136,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   MSLogContainer *logContainer = [[MSLogContainer alloc] initWithBatchId:containerId andLogs:(NSArray<id<MSLog>> *)@[ log1, log2 ]];
 
   // When
-  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil];
+  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil authToken:nil];
 
   // Then
   XCTAssertNotNil(request);
@@ -156,6 +156,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   MSLogContainer *container = [self createLogContainerWithId:containerId];
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"HTTP Response 200"];
   [self.sut sendAsync:container
+              authToken:nil
       completionHandler:^(NSString *batchId, NSHTTPURLResponse *response, __attribute__((unused)) NSData *data, NSError *error) {
         XCTAssertNil(error);
         XCTAssertEqual(containerId, batchId);
@@ -184,6 +185,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
   // When
   [self.sut sendAsync:container
+              authToken:nil
       completionHandler:^(__attribute__((unused)) NSString *batchId, __attribute__((unused)) NSHTTPURLResponse *response,
                           __attribute__((unused)) NSData *data, NSError *error) {
         // Then
@@ -203,6 +205,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   // When
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"HTTP Network Down"];
   [self.sut sendAsync:container
+              authToken:nil
       completionHandler:^(__attribute__((unused)) NSString *batchId, __attribute__((unused)) NSHTTPURLResponse *response,
                           __attribute__((unused)) NSData *data, NSError *error) {
         // Then
@@ -270,7 +273,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   NSData *httpBody = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
 
   // When
-  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil];
+  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil authToken:nil];
 
   // Then
   XCTAssertNil(request.allHTTPHeaderFields[kMSHeaderContentEncodingKey]);
@@ -285,11 +288,12 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   OCMStub([deviceMock isValid]).andReturn(YES);
   MSMockCommonSchemaLog *log1 = [[MSMockCommonSchemaLog alloc] init];
   log1.sid = @"";
+  log1.name = @"";
   log1.timestamp = [NSDate date];
   log1.ext = [MSModelTestsUtililty extensionsWithDummyValues:[MSModelTestsUtililty extensionDummies]];
   NSMutableString *jsonString = [NSMutableString new];
   log1.sid = [log1.sid stringByPaddingToLength:kMSHTTPMinGZipLength withString:@"." startingAtIndex:0];
-  log1.name = [log1.sid stringByPaddingToLength:kMSHTTPMinGZipLength withString:@"abcd" startingAtIndex:0];
+  log1.name = [log1.name stringByPaddingToLength:kMSHTTPMinGZipLength withString:@"abcd" startingAtIndex:0];
   MSLogContainer *logContainer = [[MSLogContainer alloc] initWithBatchId:@"whatever" andLogs:(NSArray<id<MSLog>> *)@[ log1 ]];
   for (id<MSLog> log in logContainer.logs) {
     MSCommonSchemaLog *abstractLog = (MSCommonSchemaLog *)log;
@@ -299,7 +303,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
   NSData *httpBody = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
 
   // When
-  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil];
+  NSURLRequest *request = [self.sut createRequest:logContainer eTag:nil authToken:nil];
 
   // Then
   XCTAssertEqual(request.allHTTPHeaderFields[kMSHeaderContentEncodingKey], kMSHeaderContentEncoding);

--- a/AppCenterDistribute/AppCenterDistribute/Internals/Ingestion/MSDistributeIngestion.m
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/Ingestion/MSDistributeIngestion.m
@@ -36,7 +36,7 @@ static NSString *const kMSLatestPublicReleaseApiPathFormat = @"/public/sdk/apps/
   return self;
 }
 
-- (NSURLRequest *)createRequest:(NSObject *)__unused data eTag:(NSString *)__unused eTag {
+- (NSURLRequest *)createRequest:(NSObject *)__unused data eTag:(NSString *)__unused eTag authToken:(nullable NSString *)__unused authToken {
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.sendURL];
 
   // Set method.

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeIngestionTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeIngestionTests.m
@@ -26,7 +26,7 @@
                                                                      retryIntervals:@[]];
 
   // When
-  NSURLRequest *request = [ingestion createRequest:[NSData new] eTag:nil];
+  NSURLRequest *request = [ingestion createRequest:[NSData new] eTag:nil authToken:nil];
 
   // Then
   assertThat(request.HTTPMethod, equalTo(@"GET"));
@@ -51,7 +51,7 @@
                                                                         queryStrings:@{}];
 
   // When
-  NSURLRequest *request1 = [ingestion1 createRequest:[NSData new] eTag:nil];
+  NSURLRequest *request1 = [ingestion1 createRequest:[NSData new] eTag:nil authToken:nil];
 
   // Then
   assertThat(request1.HTTPMethod, equalTo(@"GET"));

--- a/AppCenterIdentity/AppCenterIdentity/Internals/Ingestion/MSIdentityConfigIngestion.m
+++ b/AppCenterIdentity/AppCenterIdentity/Internals/Ingestion/MSIdentityConfigIngestion.m
@@ -21,7 +21,7 @@
   return self;
 }
 
-- (NSURLRequest *)createRequest:(NSObject *)__unused data eTag:(NSString *)eTag {
+- (NSURLRequest *)createRequest:(NSObject *)__unused data eTag:(NSString *)eTag authToken:(nullable NSString *)__unused authToken {
 
   // Ignoring local cache data to receive 304 when configuration hasn't changed since last download.
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.sendURL

--- a/AppCenterIdentity/AppCenterIdentityTests/MSIdentityConfigIngestionTests.m
+++ b/AppCenterIdentity/AppCenterIdentityTests/MSIdentityConfigIngestionTests.m
@@ -21,7 +21,7 @@
   MSIdentityConfigIngestion *ingestion = [[MSIdentityConfigIngestion alloc] initWithBaseURL:baseUrl appSecret:appSecret];
 
   // When
-  NSURLRequest *request = [ingestion createRequest:[NSData new] eTag:eTag];
+  NSURLRequest *request = [ingestion createRequest:[NSData new] eTag:eTag authToken:nil];
 
   // Then
   assertThat(request.HTTPMethod, equalTo(@"GET"));
@@ -40,7 +40,7 @@
   MSIdentityConfigIngestion *ingestion = [[MSIdentityConfigIngestion alloc] initWithBaseURL:baseUrl appSecret:appSecret];
 
   // When
-  NSURLRequest *request = [ingestion createRequest:[NSData new] eTag:nil];
+  NSURLRequest *request = [ingestion createRequest:[NSData new] eTag:nil authToken:nil];
 
   // Then
   assertThat(request.HTTPMethod, equalTo(@"GET"));
@@ -54,7 +54,7 @@
   MSIdentityConfigIngestion *ingestion1 = [[MSIdentityConfigIngestion alloc] initWithBaseURL:baseUrl appSecret:appSecret];
 
   // When
-  NSURLRequest *request1 = [ingestion1 createRequest:[NSData new] eTag:nil];
+  NSURLRequest *request1 = [ingestion1 createRequest:[NSData new] eTag:nil authToken:nil];
 
   // Then
   assertThat(request1.HTTPMethod, equalTo(@"GET"));


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR deletes `authToken` from `MSAppCenterIngestion` and passes it for each batch to avoid sending incorrect token when token is changed.