### PR TITLE
Fix unit test [MSChannelUnitDefaultTests testResumeWhenOnlyPausedObjectIsDeallocated] intermittently fails in CI

### DIFF
--- a/AppCenter/AppCenter.xcodeproj/project.pbxproj
+++ b/AppCenter/AppCenter.xcodeproj/project.pbxproj
@@ -546,7 +546,7 @@
 		6E3E2CC11D3596AE00B1EE50 /* MSDeviceLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E3E2CC01D3596AE00B1EE50 /* MSDeviceLogTests.m */; };
 		6E48A5A41D3831FE006E8B5F /* MSChannelUnitConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E48A5A31D3831FE006E8B5F /* MSChannelUnitConfigurationTests.m */; };
 		6E48A5A71D383893006E8B5F /* MSChannelGroupDefaultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E48A5A61D383893006E8B5F /* MSChannelGroupDefaultTests.m */; };
-		6EB1F40E1D2443B7005F9F99 /* MSChannelUnitDefaultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EB1F40D1D2443B7005F9F99 /* MSChannelUnitDefaultTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		6EB1F40E1D2443B7005F9F99 /* MSChannelUnitDefaultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EB1F40D1D2443B7005F9F99 /* MSChannelUnitDefaultTests.m */; };
 		6EF628F41D371B1600CAFF64 /* MSChannelUnitConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EF628F21D371B1600CAFF64 /* MSChannelUnitConfiguration.h */; };
 		6EF628F51D371B1600CAFF64 /* MSChannelUnitConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EF628F31D371B1600CAFF64 /* MSChannelUnitConfiguration.m */; };
 		7FB7054B222E595F00D93258 /* MSMockReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FB70548222E58FB00D93258 /* MSMockReachability.m */; };

--- a/AppCenter/AppCenter.xcodeproj/project.pbxproj
+++ b/AppCenter/AppCenter.xcodeproj/project.pbxproj
@@ -546,7 +546,7 @@
 		6E3E2CC11D3596AE00B1EE50 /* MSDeviceLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E3E2CC01D3596AE00B1EE50 /* MSDeviceLogTests.m */; };
 		6E48A5A41D3831FE006E8B5F /* MSChannelUnitConfigurationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E48A5A31D3831FE006E8B5F /* MSChannelUnitConfigurationTests.m */; };
 		6E48A5A71D383893006E8B5F /* MSChannelGroupDefaultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E48A5A61D383893006E8B5F /* MSChannelGroupDefaultTests.m */; };
-		6EB1F40E1D2443B7005F9F99 /* MSChannelUnitDefaultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EB1F40D1D2443B7005F9F99 /* MSChannelUnitDefaultTests.m */; };
+		6EB1F40E1D2443B7005F9F99 /* MSChannelUnitDefaultTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EB1F40D1D2443B7005F9F99 /* MSChannelUnitDefaultTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		6EF628F41D371B1600CAFF64 /* MSChannelUnitConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 6EF628F21D371B1600CAFF64 /* MSChannelUnitConfiguration.h */; };
 		6EF628F51D371B1600CAFF64 /* MSChannelUnitConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 6EF628F31D371B1600CAFF64 /* MSChannelUnitConfiguration.m */; };
 		7FB7054B222E595F00D93258 /* MSMockReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FB70548222E58FB00D93258 /* MSMockReachability.m */; };

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -1098,8 +1098,12 @@ static NSString *const kMSTestGroupId = @"GroupId";
   NSObject *object = [NSObject new];
   [self.sut pauseWithIdentifyingObjectSync:object];
 
+  // Then
+  XCTAssertTrue([self.sut paused]);
+
   // When
-  [[self.sut pausedIdentifyingObjects] removeObject:object];
+  // To use `dealloc`, `-fno-objc-arc` flag should be enabled for this class in Build Phases > Compile Sources.
+  [object dealloc];
   [self.sut resumeWithIdentifyingObjectSync:[NSObject new]];
 
   // Then

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -1099,7 +1099,8 @@ static NSString *const kMSTestGroupId = @"GroupId";
   [self.sut pauseWithIdentifyingObjectSync:object];
 
   // When
-  [self.sut resumeWithIdentifyingObjectSync:object];
+  [[self.sut pausedIdentifyingObjects] removeObject:object];
+  [self.sut resumeWithIdentifyingObjectSync:[NSObject new]];
 
   // Then
   XCTAssertFalse([self.sut paused]);

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -1095,10 +1095,11 @@ static NSString *const kMSTestGroupId = @"GroupId";
 - (void)testResumeWhenOnlyPausedObjectIsDeallocated {
 
   // If
-  [self.sut pauseWithIdentifyingObjectSync:[NSObject new]];
+  NSObject *object = [NSObject new];
+  [self.sut pauseWithIdentifyingObjectSync:object];
 
   // When
-  [self.sut resumeWithIdentifyingObjectSync:[NSObject new]];
+  [self.sut resumeWithIdentifyingObjectSync:object];
 
   // Then
   XCTAssertFalse([self.sut paused]);


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
Fix unit test [MSChannelUnitDefaultTests testResumeWhenOnlyPausedObjectIsDeallocated] intermittently fails.
Before:
It's because given parameters both are new object when call `pauseWithIdentifyingObjectSync` and   `resumeWithIdentifyingObjectSync` method in `testResumeWhenOnlyPausedObjectIsDeallocated` test.
In`pauseWithIdentifyingObjectSync` method, add the income parameter for `pausedIdentifyingObjects` .
In`resumeWithIdentifyingObjectSync` method, remove the income parameter for `pausedIdentifyingObjects`. 
So the removed object is sometimes different from the added object. It cause the added object can't be removed for `pausedIdentifyingObjects` and the test finally failed. 
After:
  Make sure given a same parameter when call `pauseWithIdentifyingObjectSync` and `resumeWithIdentifyingObjectSync` method, so added object will always be removed for `pausedIdentifyingObjects`.


## Related PRs or issues
[58813](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/58813/?triage=true)

