### PR TITLE
Skip test and import validation on lint

### DIFF
--- a/vsts/publish-podspec.sh
+++ b/vsts/publish-podspec.sh
@@ -123,7 +123,7 @@ if [ "$mode" == "internal" ] || [ "$mode" == "test" ]; then
 else
 
   ## 1. Run lint to validate podspec.
-  resp="$(pod spec lint $PODSPEC_FILENAME)"
+  resp="$(pod spec lint --verbose --skip-tests --skip-import-validation $PODSPEC_FILENAME)"
   echo $resp
 
   # Check error from the response


### PR DESCRIPTION
Skip test and import validation on pod lint temporarily. CocoaPods is broken when it runs with Xcode 10.1.