### PR TITLE
Disable in-app updates when in guided access mode

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -736,9 +736,12 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
   // Check if we are not in AppStore or TestFlight environments.
   BOOL environmentOkay = [MSUtility currentAppEnvironment] == MSEnvironmentOther;
 
+  // Check if we are currently in guided access mode
+  BOOL noGuidedAccessMode = !UIAccessibilityIsGuidedAccessEnabled();
+    
   // Check if a debugger is attached.
   BOOL noDebuggerAttached = ![MSAppCenter isDebuggerAttached];
-  return environmentOkay && noDebuggerAttached;
+  return environmentOkay && noDebuggerAttached && noGuidedAccessMode;
 }
 
 - (BOOL)isNewerVersion:(MSReleaseDetails *)details {


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Addresses feedback from @florianbuerger referenced in [this issue](https://github.com/Microsoft/appcenter/issues/46) on the planning repository. Confirmed this issue does occur when an app is in guided access mode on my iPhone XS.

## Related PRs or issues
[#46](https://github.com/Microsoft/appcenter/issues/46)

## Misc

Tested on my personal iPhone XS device.