### PR TITLE
Use class instead of self to get rid of warnings

### DIFF
--- a/AppCenter/AppCenter/Internals/DelegateForwarder/MSAppDelegateForwarder.m
+++ b/AppCenter/AppCenter/Internals/DelegateForwarder/MSAppDelegateForwarder.m
@@ -23,7 +23,7 @@ static dispatch_once_t swizzlingOnceToken;
    * never be called even if added later via swizzling. This is why the application delegate swizzling should happen at the time it is set
    * to the application object.
    */
-  [[self sharedInstance] setEnabledFromPlistForKey:kMSAppDelegateForwarderEnabledKey];
+  [[MSAppDelegateForwarder sharedInstance] setEnabledFromPlistForKey:kMSAppDelegateForwarderEnabledKey];
 }
 
 - (instancetype)init {

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -195,10 +195,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 }
 
 + (void)setUserConfirmationHandler:(_Nullable MSUserConfirmationHandler)userConfirmationHandler {
-
-  // FIXME: Type cast is required at the moment. Need to fix the root cause.
-  MSCrashes *crashes = static_cast<MSCrashes *>([self sharedInstance]);
-  crashes.userConfirmationHandler = userConfirmationHandler;
+  [[MSCrashes sharedInstance] setUserConfirmationHandler:userConfirmationHandler];
 }
 
 + (void)notifyWithUserConfirmation:(MSUserConfirmation)userConfirmation {

--- a/AppCenterPush/AppCenterPush/Internal/DelegateForwarder/MSUserNotificationCenterDelegateForwarder.m
+++ b/AppCenterPush/AppCenterPush/Internal/DelegateForwarder/MSUserNotificationCenterDelegateForwarder.m
@@ -17,7 +17,8 @@ static MSUserNotificationCenterDelegateForwarder *sharedInstance = nil;
 @implementation MSUserNotificationCenterDelegateForwarder
 
 + (void)load {
-  [[MSUserNotificationCenterDelegateForwarder sharedInstance] setEnabledFromPlistForKey:kMSUserNotificationCenterDelegateForwarderEnabledKey];
+  [[MSUserNotificationCenterDelegateForwarder sharedInstance]
+      setEnabledFromPlistForKey:kMSUserNotificationCenterDelegateForwarderEnabledKey];
 
   // TODO test the forwarder on macOS.
   // Register selectors to swizzle (iOS 10+).

--- a/AppCenterPush/AppCenterPush/Internal/DelegateForwarder/MSUserNotificationCenterDelegateForwarder.m
+++ b/AppCenterPush/AppCenterPush/Internal/DelegateForwarder/MSUserNotificationCenterDelegateForwarder.m
@@ -17,7 +17,7 @@ static MSUserNotificationCenterDelegateForwarder *sharedInstance = nil;
 @implementation MSUserNotificationCenterDelegateForwarder
 
 + (void)load {
-  [[self sharedInstance] setEnabledFromPlistForKey:kMSUserNotificationCenterDelegateForwarderEnabledKey];
+  [[MSUserNotificationCenterDelegateForwarder sharedInstance] setEnabledFromPlistForKey:kMSUserNotificationCenterDelegateForwarderEnabledKey];
 
   // TODO test the forwarder on macOS.
   // Register selectors to swizzle (iOS 10+).


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Use class instead of self to get rid of warnings in Xcode 10

## Related PRs or issues

[59035](https://dev.azure.com/msmobilecenter/Mobile-Center/_queries/edit/59035/?triage=true)

## Misc
Also find some using of `[self sharedInstance]` in \AppCenter-SDK-Apple\AppCenter\AppCenter\MSServiceAbstract.m with `#pragma clang diagnostic ignored "-Wobjc-messaging-id` is before the class to ignore the warning. So I don't changed them.

