### PR TITLE
Handle duplicate item error in [MSKeychainUtil storeString]

### DIFF
--- a/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
+++ b/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
@@ -21,6 +21,12 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
   NSMutableDictionary *attributes = [MSKeychainUtil generateItem:key withServiceName:serviceName];
   attributes[(__bridge id)kSecValueData] = [string dataUsingEncoding:NSUTF8StringEncoding];
   OSStatus status = [self addSecItem:attributes];
+
+  // Delete item if already exists.
+  if (status == errSecDuplicateItem) {
+    [self deleteSecItem:attributes];
+    status = [self addSecItem:attributes];
+  }
   return status == noErr;
 }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Calling `[MSKeychainUtil storeString]` fails with -25299 (`errSecDuplicateItem`) error when data under the same key was already written.

This PR fixes `[MSKeychainUtil storeString]` method and adds handling of duplicate item errors.

---

[AB#59293](https://msmobilecenter.visualstudio.com/web/wi.aspx?pcguid=27bf89de-9697-418a-accf-1aa125b22914&id=59293)