### PR TITLE
fix flaky unit tests by no mock distribute

### DIFF
--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -638,10 +638,6 @@ static NSURL *sfURL;
                                                  appName, details.shortVersion, details.version];
 #pragma clang diagnostic pop
 
-  // Mock MSDistribute isNewerVersion to return YES.
-  id distributeMock = OCMPartialMock(self.sut);
-  OCMStub([distributeMock isNewerVersion:OCMOCK_ANY]).andReturn(YES);
-
   // Mock reachability.
   id reachabilityMock = OCMClassMock([MS_Reachability class]);
   OCMStub([reachabilityMock reachabilityForInternetConnection]).andReturn(reachabilityMock);
@@ -654,7 +650,7 @@ static NSURL *sfURL;
   [MS_USER_DEFAULTS setObject:[details serializeToDictionary] forKey:kMSMandatoryReleaseKey];
 
   // When
-  [distributeMock checkLatestRelease:@"whateverToken" distributionGroupId:@"whateverGroupId" releaseHash:@"whateverReleaseHash"];
+  [self.sut checkLatestRelease:@"whateverToken" distributionGroupId:@"whateverGroupId" releaseHash:@"whateverReleaseHash"];
   dispatch_async(dispatch_get_main_queue(), ^{
     [expectation fulfill];
   });
@@ -677,7 +673,7 @@ static NSURL *sfURL;
   expectation = [self expectationWithDescription:@"Confirmation alert for public distribution has been displayed"];
 
   // When
-  [distributeMock checkLatestRelease:nil distributionGroupId:@"whateverGroupId" releaseHash:@"whateverReleaseHash"];
+  [self.sut checkLatestRelease:nil distributionGroupId:@"whateverGroupId" releaseHash:@"whateverReleaseHash"];
   dispatch_async(dispatch_get_main_queue(), ^{
     [expectation fulfill];
   });
@@ -696,7 +692,6 @@ static NSURL *sfURL;
                                  OCMVerifyAll(self.alertControllerMock);
                                }];
 
-  [distributeMock stopMocking];
   [reachabilityMock stopMocking];
 }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
Looks `stubResponseWithCode` in `MSHttpTestUtil` doesn't stub response properly, so that the distribute tests got unexpected data (expected nil, but got NSZeroData) then lead to crash;

Fixed by stop mock distribution in the test.

## Related PRs or issues
http://github.com/Microsoft/AppCenter-SDK-Apple/pull/1416

