### PR TITLE
Fix issue: fail to second sign-in after first sign-in failed

### DIFF
--- a/AppCenterIdentity/AppCenterIdentity/MSIdentity.m
+++ b/AppCenterIdentity/AppCenterIdentity/MSIdentity.m
@@ -225,6 +225,7 @@ static dispatch_once_t onceToken;
                                               code:errorCode
                                           userInfo:@{NSLocalizedDescriptionKey : errorMessage}];
   self.signInCompletionHandler(nil, error);
+  self.signInCompletionHandler = nil;
 }
 
 - (void)signOut {

--- a/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
+++ b/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
@@ -593,7 +593,6 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
     self.signInUserInformation = userInformation;
     self.signInError = error;
   };
-
   [MSIdentity signInWithCompletionHandler:handler2];
 
   // When we complete second call
@@ -606,7 +605,6 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   XCTAssertNotNil(self.signInUserInformation);
   XCTAssertEqualObjects(accountId, self.signInUserInformation.accountId);
   XCTAssertNil(self.signInError);
-
   [identityMock stopMocking];
 }
 

--- a/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
+++ b/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
@@ -551,6 +551,65 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   [identityMock stopMocking];
 }
 
+- (void)testSecondSignInSuccessAfterFirstSignInFails {
+
+  // If
+  NSString *idToken = @"idToken";
+  NSString *accountId = @"94c82516-cbee-44aa-8a6a-19f8d20322be";
+  id msalResultMock = OCMPartialMock([MSALResult new]);
+  OCMStub([msalResultMock idToken]).andReturn(idToken);
+  OCMStub([msalResultMock uniqueId]).andReturn(accountId);
+  self.sut.clientApplication = self.clientApplicationMock;
+  id identityMock = OCMPartialMock(self.sut);
+  OCMStub([identityMock sharedInstance]).andReturn(identityMock);
+  OCMStub([identityMock canBeUsed]).andReturn(YES);
+
+  // When
+  MSSignInCompletionHandler handler1 = ^(MSUserInformation *_Nullable userInformation, NSError *_Nullable error) {
+    self.signInUserInformation = userInformation;
+    self.signInError = error;
+  };
+  [MSIdentity signInWithCompletionHandler:handler1];
+
+  // Then
+  XCTAssertNil(self.signInUserInformation);
+  XCTAssertNotNil(self.signInError);
+  XCTAssertEqualObjects(kMSACIdentityErrorDomain, self.signInError.domain);
+  XCTAssertEqual(MSACIdentityErrorSignInBackgroundOrNotConfigured, self.signInError.code);
+  XCTAssertNotNil(self.signInError.userInfo[NSLocalizedDescriptionKey]);
+
+  // If
+  id configMock = OCMPartialMock([MSIdentityConfig new]);
+  OCMStub([configMock identityScope]).andReturn(@"fake");
+  OCMStub([identityMock identityConfig]).andReturn(configMock);
+  OCMStub([self.clientApplicationMock acquireTokenForScopes:OCMOCK_ANY completionBlock:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+    __block MSALCompletionBlock completionBlock;
+    [invocation getArgument:&completionBlock atIndex:3];
+    self.msalCompletionBlock = completionBlock;
+  });
+
+  // When
+  MSSignInCompletionHandler handler2 = ^(MSUserInformation *_Nullable userInformation, NSError *_Nullable error) {
+    self.signInUserInformation = userInformation;
+    self.signInError = error;
+  };
+
+  [MSIdentity signInWithCompletionHandler:handler2];
+
+  // When we complete second call
+  self.msalCompletionBlock(msalResultMock, nil);
+
+  // Then
+  OCMVerify([self.clientApplicationMock acquireTokenForScopes:OCMOCK_ANY completionBlock:OCMOCK_ANY]);
+  XCTAssertEqualObjects(idToken, [MSAuthTokenContext sharedInstance].authToken);
+  XCTAssertEqualObjects(idToken, [MSMockKeychainUtil stringForKey:kMSIdentityAuthTokenKey]);
+  XCTAssertNotNil(self.signInUserInformation);
+  XCTAssertEqualObjects(accountId, self.signInUserInformation.accountId);
+  XCTAssertNil(self.signInError);
+
+  [identityMock stopMocking];
+}
+
 - (void)testSilentSignInSavesAuthTokenAndHomeAccountId {
 
   // If

--- a/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
+++ b/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
@@ -599,11 +599,12 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
 
   // When we complete second call
   self.msalCompletionBlock(msalResultMock, nil);
+  MSAuthTokenInfo *actualAuthTokenInfo = [[MSMockKeychainUtil arrayForKey:kMSAuthTokenHistoryKey] lastObject];
 
   // Then
   OCMVerify([self.clientApplicationMock acquireTokenForScopes:OCMOCK_ANY completionBlock:OCMOCK_ANY]);
   XCTAssertEqualObjects(idToken, [MSAuthTokenContext sharedInstance].authToken);
-  XCTAssertEqualObjects(idToken, [MSMockKeychainUtil stringForKey:kMSIdentityAuthTokenKey]);
+  XCTAssertEqualObjects(idToken, actualAuthTokenInfo.authToken);
   XCTAssertNotNil(self.signInUserInformation);
   XCTAssertEqualObjects(accountId, self.signInUserInformation.accountId);
   XCTAssertNil(self.signInError);

--- a/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
+++ b/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
@@ -565,6 +565,8 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   OCMStub([identityMock canBeUsed]).andReturn(YES);
 
   // When
+
+  // We expect the call would fail and the handler will be called with an error because identityConfig isn't mocked and configured.
   MSSignInCompletionHandler handler1 = ^(MSUserInformation *_Nullable userInformation, NSError *_Nullable error) {
     self.signInUserInformation = userInformation;
     self.signInError = error;


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

1. Fix the issue: fail to second sign-in after first sign-in failed with config file failure or MSAL initialization failure
2. Add the unit test to verify.
