### PR TITLE
Fix validating 1ds properties

### DIFF
--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -294,14 +294,13 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
         MSLogError([MSAnalytics logTag], @"This transmission target is disabled.");
         return;
       }
+    } else {
+      properties = [self validateAppCenterEventProperties:properties];
     }
 
     // Set properties of the event log.
     log.name = eventName;
     log.eventId = MS_UUID_STRING;
-    if (!self.defaultTransmissionTarget) {
-      properties = [self validateAppCenterEventProperties:properties];
-    }
     log.typedProperties = [properties isEmpty] ? nil : properties;
 
     // Send log to channel.


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The AppCenter rules of validation event properties are applied to 1ds logs.
