### PR TITLE
Clear token on error and cancel actions

### DIFF
--- a/AppCenterIdentity/AppCenterIdentity/MSIdentity.m
+++ b/AppCenterIdentity/AppCenterIdentity/MSIdentity.m
@@ -372,6 +372,7 @@ static dispatch_once_t onceToken;
                                 completionBlock:^(MSALResult *result, NSError *e) {
                                   typeof(self) strongSelf = weakSelf;
                                   if (e) {
+                                    [[MSAuthTokenContext sharedInstance] setAuthToken:nil withAccountId:nil expiresOn:nil];
                                     if (e.code == MSALErrorUserCanceled) {
                                       MSLogWarning([MSIdentity logTag], @"User canceled sign-in.");
                                     } else {

--- a/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
+++ b/AppCenterIdentity/AppCenterIdentityTests/MSIdentityTests.m
@@ -740,6 +740,8 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
 - (void)testSignInError {
 
   // If
+  id authTokenContextMock = OCMPartialMock([MSAuthTokenContext sharedInstance]);
+  OCMStub([authTokenContextMock sharedInstance]).andReturn(authTokenContextMock);
   NSError *signInError = [[NSError alloc] initWithDomain:MSALErrorDomain
                                                     code:MSALErrorAuthorizationFailed
                                                 userInfo:@{MSALErrorDescriptionKey : @"failed"}];
@@ -764,17 +766,21 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
 
   // Then
   OCMVerify([self.clientApplicationMock acquireTokenForScopes:OCMOCK_ANY completionBlock:OCMOCK_ANY]);
+  OCMVerify([authTokenContextMock setAuthToken:nil withAccountId:nil expiresOn:nil]);
   XCTAssertNil(self.signInUserInformation);
   XCTAssertNotNil(self.signInError);
   XCTAssertEqualObjects(MSALErrorDomain, self.signInError.domain);
   XCTAssertEqual(MSALErrorAuthorizationFailed, self.signInError.code);
   XCTAssertNotNil(self.signInError.userInfo[MSALErrorDescriptionKey]);
   [identityMock stopMocking];
+  [authTokenContextMock stopMocking];
 }
 
 - (void)testSignInCancelled {
 
   // If
+  id authTokenContextMock = OCMPartialMock([MSAuthTokenContext sharedInstance]);
+  OCMStub([authTokenContextMock sharedInstance]).andReturn(authTokenContextMock);
   NSError *signInError = [[NSError alloc] initWithDomain:MSALErrorDomain
                                                     code:MSALErrorUserCanceled
                                                 userInfo:@{MSALErrorDescriptionKey : @"cancelled"}];
@@ -799,12 +805,14 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
 
   // Then
   OCMVerify([self.clientApplicationMock acquireTokenForScopes:OCMOCK_ANY completionBlock:OCMOCK_ANY]);
+  OCMVerify([authTokenContextMock setAuthToken:nil withAccountId:nil expiresOn:nil]);
   XCTAssertNil(self.signInUserInformation);
   XCTAssertNotNil(self.signInError);
   XCTAssertEqualObjects(MSALErrorDomain, self.signInError.domain);
   XCTAssertEqual(MSALErrorUserCanceled, self.signInError.code);
   XCTAssertNotNil(self.signInError.userInfo[MSALErrorDescriptionKey]);
   [identityMock stopMocking];
+  [authTokenContextMock stopMocking];
 }
 
 - (void)testSignInFailsAfterDisablingEvenIfBrowserWasOpenedAndSignInSucceeds {
@@ -1080,14 +1088,16 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   OCMStub([identityMock retrieveAccountWithAccountId:fakeAccountId]).andReturn(nil);
   OCMStub([identityMock acquireTokenSilentlyWithMSALAccount:OCMOCK_ANY]);
   OCMReject([identityMock acquireTokenSilentlyWithMSALAccount:OCMOCK_ANY]);
-  id contextMock = OCMPartialMock([MSAuthTokenContext sharedInstance]);
+  id authTokenContextMock = OCMPartialMock([MSAuthTokenContext sharedInstance]);
+  OCMStub([authTokenContextMock sharedInstance]).andReturn(authTokenContextMock);
 
   // When
   [[MSAuthTokenContext sharedInstance] checkIfTokenNeedsToBeRefreshed:fakeValidityInfo];
 
   // Then
-  OCMVerify([contextMock setAuthToken:nil withAccountId:nil expiresOn:nil]);
+  OCMVerify([authTokenContextMock setAuthToken:nil withAccountId:nil expiresOn:nil]);
   [identityMock stopMocking];
+  [authTokenContextMock stopMocking];
 }
 
 @end


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Wait token to expire (can modify expiration in code to avoid waiting 1 hour)
Track event and cause sign in refresh to fail or cancel (can simulate failure by modifying code as it will likely succeed most of the time).
=> Channel blocked.

Expected behavior: unblock channel sending and send logs anonymously.
