### PR TITLE
Change account Id verification for unit test: testSetAuthTokenDoesTriggerNewUserOnNewAccount

### DIFF
--- a/AppCenter/AppCenterTests/MSAuthTokenContextTests.m
+++ b/AppCenter/AppCenterTests/MSAuthTokenContextTests.m
@@ -121,7 +121,7 @@
   // Then
   OCMVerify([delegateMock authTokenContext:self.sut
                   didUpdateUserInformation:[OCMArg checkWithBlock:^BOOL(id obj) {
-                    return [((MSUserInformation *)obj).accountId isEqualToString:expectedAccountId];
+                    return [((MSUserInformation *)obj).accountId isEqualToString:expectedAccountId2];
                   }]]);
 }
 


### PR DESCRIPTION
Change the account Id verification for second setting authtoken with new user account