### PR TITLE
Extract accountId from homeAccountId before calling delegate

### DIFF
--- a/AppCenter/AppCenter/Internals/Context/AuthToken/MSAuthTokenContext.m
+++ b/AppCenter/AppCenter/Internals/Context/AuthToken/MSAuthTokenContext.m
@@ -12,6 +12,11 @@
 static MSAuthTokenContext *sharedInstance;
 static dispatch_once_t onceToken;
 
+/*
+ * Length of accountId in home accountId.
+ */
+static NSUInteger const kMSAccountIdLengthInHomeAccount = 36;
+
 @interface MSAuthTokenContext ()
 
 /**
@@ -119,6 +124,9 @@ static dispatch_once_t onceToken;
     if (isNewUser && [delegate respondsToSelector:@selector(authTokenContext:didUpdateUserInformation:)]) {
       MSUserInformation *userInfo = nil;
       if (accountId) {
+        if ([accountId length] > kMSAccountIdLengthInHomeAccount) {
+          accountId = [accountId substringToIndex:kMSAccountIdLengthInHomeAccount];
+        }
         userInfo = [[MSUserInformation alloc] initWithAccountId:(NSString *)accountId];
       }
       [delegate authTokenContext:self didUpdateUserInformation:userInfo];
@@ -249,11 +257,11 @@ static dispatch_once_t onceToken;
 }
 
 - (void)finishInitialize {
-    if (!self.resetAuthTokenRequired) {
-      return;
-    }
-    self.resetAuthTokenRequired = NO;
-    [self setAuthToken:nil withAccountId:nil expiresOn:nil];
+  if (!self.resetAuthTokenRequired) {
+    return;
+  }
+  self.resetAuthTokenRequired = NO;
+  [self setAuthToken:nil withAccountId:nil expiresOn:nil];
 }
 
 - (void)preventResetAuthTokenAfterStart {

--- a/AppCenter/AppCenterTests/MSAuthTokenContextTests.m
+++ b/AppCenter/AppCenterTests/MSAuthTokenContextTests.m
@@ -60,16 +60,17 @@
 
   // If
   NSString *expectedAuthToken = @"authToken1";
-  NSString *expectedAccountId = @"account1";
+  NSString *expectedAccountId = @"0d619014-65f6-485d-add1-73a3fb772cdc";
+  NSString *expectedHomeAccountId = [expectedAccountId stringByAppendingString:@"-b2c_some_other_information"];
   id<MSAuthTokenContextDelegate> delegateMock = OCMProtocolMock(@protocol(MSAuthTokenContextDelegate));
   [self.sut addDelegate:delegateMock];
 
   // When
-  [self.sut setAuthToken:expectedAuthToken withAccountId:expectedAccountId expiresOn:nil];
+  [self.sut setAuthToken:expectedAuthToken withAccountId:expectedHomeAccountId expiresOn:nil];
 
   // Then
   XCTAssertEqualObjects([self.sut authToken], expectedAuthToken);
-  XCTAssertEqualObjects([self.sut accountId], expectedAccountId);
+  XCTAssertEqualObjects([self.sut accountId], expectedHomeAccountId);
   OCMVerify([delegateMock authTokenContext:self.sut
                   didUpdateUserInformation:[OCMArg checkWithBlock:^BOOL(id obj) {
                     return [((MSUserInformation *)obj).accountId isEqualToString:expectedAccountId];
@@ -400,8 +401,10 @@
   id<MSAuthTokenContextDelegate> delegateMock = OCMProtocolMock(@protocol(MSAuthTokenContextDelegate));
   [self.sut addDelegate:delegateMock];
   OCMReject([delegateMock authTokenContext:OCMOCK_ANY refreshAuthTokenForAccountId:OCMOCK_ANY]);
-  
-  NSArray<MSAuthTokenValidityInfo *> *mockArray = @[[[MSAuthTokenValidityInfo alloc] initWithAuthToken:expectedAuthToken startTime:nil endTime:nil]];
+
+  NSArray<MSAuthTokenValidityInfo *> *mockArray = @[ [[MSAuthTokenValidityInfo alloc] initWithAuthToken:expectedAuthToken
+                                                                                              startTime:nil
+                                                                                                endTime:nil] ];
   OCMStub([MSMockKeychainUtil arrayForKey:kMSAuthTokenHistoryKey]).andReturn(mockArray);
   MSAuthTokenValidityInfo *authToken = [[MSAuthTokenValidityInfo alloc] initWithAuthToken:expectedAuthToken
                                                                                 startTime:startDate
@@ -492,20 +495,20 @@
 }
 
 - (void)testFinishResetsTokenIfNotPreventedOnlyOnce {
-  
+
   // If
   id mockedSut = OCMPartialMock(self.sut);
   __block int callCount = 0;
   OCMStub([mockedSut setAuthToken:nil withAccountId:nil expiresOn:nil]).andDo(^(__unused NSInvocation *invocation) {
     ++callCount;
   });
-  
+
   // When
   [mockedSut finishInitialize];
-  
+
   // Another module starts.
   [mockedSut finishInitialize];
-  
+
   // Then
   XCTAssertEqual(callCount, 1);
 }


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Pass accountId instead of homeAccountId.
