### PR TITLE
Use integer timestamps instead of ISO

### DIFF
--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
@@ -77,11 +77,11 @@ static const NSUInteger kMSSchemaVersion = 1;
   NSString *tableName = [MSDBDocumentStore tableNameForPartition:token.partition];
   NSString *insertQuery = [NSString
       stringWithFormat:@"REPLACE INTO \"%@\" (\"%@\", \"%@\", \"%@\", \"%@\", \"%@\", \"%@\", \"%@\", \"%@\") "
-                           @"VALUES ('%@', '%@', '%@', '%@', %ld, '%ld', '%ld', '%@')",
+                       @"VALUES ('%@', '%@', '%@', '%@', %ld, '%ld', '%ld', '%@')",
                        tableName, kMSPartitionColumnName, kMSDocumentIdColumnName, kMSDocumentColumnName, kMSETagColumnName,
                        kMSExpirationTimeColumnName, kMSDownloadTimeColumnName, kMSOperationTimeColumnName, kMSPendingOperationColumnName,
                        token.partition, documentWrapper.documentId, documentWrapper.jsonValue, documentWrapper.eTag, (long)expirationTime,
-                      (long)[documentWrapper.lastUpdatedDate timeIntervalSince1970], (long)now, operation];
+                       (long)[documentWrapper.lastUpdatedDate timeIntervalSince1970], (long)now, operation];
   int result = [self.dbStorage executeNonSelectionQuery:insertQuery];
   if (result != SQLITE_OK) {
     MSLogError([MSDataStore logTag], @"Unable to update or replace stored document, SQLite error code: %ld", (long)result);
@@ -133,7 +133,7 @@ static const NSUInteger kMSSchemaVersion = 1;
     NSDate *currentDate = [NSDate date];
     if (expirationDate && [expirationDate laterDate:currentDate] == currentDate) {
       NSString *errorMessage = [NSString stringWithFormat:@"Local document with partition key '%@' and document ID '%@' expired at %@",
-                                token.partition, documentId, expirationDate];
+                                                          token.partition, documentId, expirationDate];
       MSLogWarning([MSDataStore logTag], @"%@", errorMessage);
       NSError *error = [[NSError alloc] initWithDomain:kMSACDataStoreErrorDomain
                                                   code:MSACDataStoreErrorLocalDocumentExpired

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
@@ -410,9 +410,9 @@
             pendingOperation:(NSString *)pendingOperation
               expirationTime:(long)expirationTime {
   sqlite3 *db = [self openDatabase:kMSDBDocumentFileName];
-  NSString *operationTimeString = [MSUtility dateToISO8601:[NSDate date]];
+  long operationTimeString = NSTimeIntervalSince1970;
   NSString *insertQuery = [NSString stringWithFormat:@"INSERT INTO \"%@\" (\"%@\", \"%@\", \"%@\", \"%@\", \"%@\", \"%@\", \"%@\", \"%@\") "
-                           @"VALUES ('%@', '%@', '%@', '%@', '%@', %ld, '%@', '%@')",
+                           @"VALUES ('%@', '%@', '%@', '%@', '%@', %ld, '%ld', '%@')",
                                                      kMSAppDocumentTableName, kMSIdColumnName, kMSPartitionColumnName, kMSETagColumnName,
                                                      kMSDocumentColumnName, kMSDocumentIdColumnName, kMSExpirationTimeColumnName,
                                                      kMSOperationTimeColumnName, kMSPendingOperationColumnName, @0, partition, eTag,

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
@@ -273,15 +273,15 @@
   // If
   int ttl = 1;
   MSDocumentWrapper *expectedDocumentWrapper = [MSDocumentUtils documentWrapperFromData:[self jsonFixture:@"validTestDocument"]
-                                                                   documentType:[MSDictionaryDocument class]];
+                                                                           documentType:[MSDictionaryDocument class]];
   MSReadOptions *readOptions = [[MSReadOptions alloc] initWithDeviceTimeToLive:ttl];
 
   // When
   BOOL result = [self.sut upsertWithToken:self.appToken documentWrapper:expectedDocumentWrapper operation:@"CREATE" options:readOptions];
   MSDocumentWrapper *documentWrapper = [self.sut readWithToken:self.appToken
-                                                            documentId:expectedDocumentWrapper.documentId
-                                                          documentType:[MSDictionaryDocument class]
-                                                           readOptions:nil];
+                                                    documentId:expectedDocumentWrapper.documentId
+                                                  documentType:[MSDictionaryDocument class]
+                                                   readOptions:nil];
 
   // Then
   XCTAssertTrue(result);
@@ -291,7 +291,6 @@
   XCTAssertEqualObjects(documentWrapper.documentId, expectedDocumentWrapper.documentId);
   XCTAssertEqualObjects(documentWrapper.partition, expectedDocumentWrapper.partition);
   XCTAssertEqualObjects(documentWrapper.eTag, expectedDocumentWrapper.eTag);
-
 }
 
 - (void)testUpsertAppDocumentWithNoTTL {
@@ -412,7 +411,7 @@
   sqlite3 *db = [self openDatabase:kMSDBDocumentFileName];
   long operationTimeString = NSTimeIntervalSince1970;
   NSString *insertQuery = [NSString stringWithFormat:@"INSERT INTO \"%@\" (\"%@\", \"%@\", \"%@\", \"%@\", \"%@\", \"%@\", \"%@\", \"%@\") "
-                           @"VALUES ('%@', '%@', '%@', '%@', '%@', %ld, '%ld', '%@')",
+                                                     @"VALUES ('%@', '%@', '%@', '%@', '%@', %ld, '%ld', '%@')",
                                                      kMSAppDocumentTableName, kMSIdColumnName, kMSPartitionColumnName, kMSETagColumnName,
                                                      kMSDocumentColumnName, kMSDocumentIdColumnName, kMSExpirationTimeColumnName,
                                                      kMSOperationTimeColumnName, kMSPendingOperationColumnName, @0, partition, eTag,


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The dates in local cache were being stored as strings in ISO format, but they should have been as integer timestamps (in seconds since 1970), as per the spec.
