### PR TITLE
Fix issue where readonly partition lacked unique columns constraint

### DIFF
--- a/AppCenter/AppCenter/Internals/Storage/MSDBStorage.h
+++ b/AppCenter/AppCenter/Internals/Storage/MSDBStorage.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 typedef NSArray<NSDictionary<NSString *, NSArray<NSString *> *> *> MSDBColumnsSchema;
 typedef NSDictionary<NSString *, MSDBColumnsSchema *> MSDBSchema;
+typedef NSDictionary<NSString *, NSArray<NSString *> *> MSDBUniqueColumnConstraints;
 
 // SQLite types
 static NSString *const kMSSQLiteTypeText = @"TEXT";
@@ -43,6 +44,16 @@ static NSString *const kMSSQLiteConstraintAutoincrement = @"AUTOINCREMENT";
  * @return An instance of a database.
  */
 - (instancetype)initWithSchema:(MSDBSchema *)schema version:(NSUInteger)version filename:(NSString *)filename;
+
+/**
+ * Initialize this database with a version and a filename for its creation.
+ *
+ * @param version Version of the database.
+ * @param filename Database filename in the file system.
+ *
+ * @return An instance of a database.
+ */
+- (instancetype)initWithVersion:(NSUInteger)version filename:(NSString *)filename;
 
 /**
  * Count entries on a given table using the given SQLite "WHERE" clause's condition.

--- a/AppCenter/AppCenter/Internals/Storage/MSDBStorage.h
+++ b/AppCenter/AppCenter/Internals/Storage/MSDBStorage.h
@@ -21,7 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 typedef NSArray<NSDictionary<NSString *, NSArray<NSString *> *> *> MSDBColumnsSchema;
 typedef NSDictionary<NSString *, MSDBColumnsSchema *> MSDBSchema;
-typedef NSDictionary<NSString *, NSArray<NSString *> *> MSDBUniqueColumnConstraints;
 
 // SQLite types
 static NSString *const kMSSQLiteTypeText = @"TEXT";

--- a/AppCenter/AppCenter/Internals/Storage/MSDBStorage.m
+++ b/AppCenter/AppCenter/Internals/Storage/MSDBStorage.m
@@ -29,7 +29,7 @@
         MSLogInfo([MSAppCenter logTag], @"Created \"%@\" database with %lu version.", filename, (unsigned long)version);
         [self customizeDatabase:db];
       } else if (databaseVersion < version) {
-        MSLogInfo([MSAppCenter logTag], @"Migrate \"%@\" database from %lu to %lu version.", filename, (unsigned long)databaseVersion,
+        MSLogInfo([MSAppCenter logTag], @"Migrating \"%@\" database from version %lu to %lu.", filename, (unsigned long)databaseVersion,
                   (unsigned long)version);
         [self migrateDatabase:db fromVersion:databaseVersion];
       }

--- a/AppCenter/AppCenterTests/MSLogDBStorageTests.m
+++ b/AppCenter/AppCenterTests/MSLogDBStorageTests.m
@@ -1061,9 +1061,6 @@ static NSString *const kMSLatestSchema = @"CREATE TABLE \"logs\" ("
 
 - (void)testCreateFromLatestSchema {
 
-  // If
-  [self.storageTestUtil deleteDatabase];
-
   // When
   self.sut = [MSLogDBStorage new];
 

--- a/AppCenter/AppCenterTests/MSLogDBStorageTests.m
+++ b/AppCenter/AppCenterTests/MSLogDBStorageTests.m
@@ -1071,10 +1071,6 @@ static NSString *const kMSLatestSchema = @"CREATE TABLE \"logs\" ("
   NSString *currentTable =
       [self.sut executeSelectionQuery:[NSString stringWithFormat:@"SELECT sql FROM sqlite_master WHERE name='%@'", kMSLogTableName]][0][0];
   assertThat(currentTable, is(kMSLatestSchema));
-//  NSArray *result =
-//  [self.sut executeSelectionQuery:[NSString stringWithFormat:@"SELECT * FROM sqlite_master", kMSLogTableName,
-//                                   kMSPriorityColumnName]];
-//
   NSString *priorityIndex =
       [self.sut executeSelectionQuery:[NSString stringWithFormat:@"SELECT sql FROM sqlite_master WHERE name='ix_%@_%@'", kMSLogTableName,
                                                                  kMSPriorityColumnName]][0][0];

--- a/AppCenter/AppCenterTests/MSLogDBStorageTests.m
+++ b/AppCenter/AppCenterTests/MSLogDBStorageTests.m
@@ -1061,6 +1061,9 @@ static NSString *const kMSLatestSchema = @"CREATE TABLE \"logs\" ("
 
 - (void)testCreateFromLatestSchema {
 
+  // If
+  [self.storageTestUtil deleteDatabase];
+
   // When
   self.sut = [MSLogDBStorage new];
 
@@ -1068,6 +1071,10 @@ static NSString *const kMSLatestSchema = @"CREATE TABLE \"logs\" ("
   NSString *currentTable =
       [self.sut executeSelectionQuery:[NSString stringWithFormat:@"SELECT sql FROM sqlite_master WHERE name='%@'", kMSLogTableName]][0][0];
   assertThat(currentTable, is(kMSLatestSchema));
+//  NSArray *result =
+//  [self.sut executeSelectionQuery:[NSString stringWithFormat:@"SELECT * FROM sqlite_master", kMSLogTableName,
+//                                   kMSPriorityColumnName]];
+//
   NSString *priorityIndex =
       [self.sut executeSelectionQuery:[NSString stringWithFormat:@"SELECT sql FROM sqlite_master WHERE name='ix_%@_%@'", kMSLogTableName,
                                                                  kMSPriorityColumnName]][0][0];

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.h
@@ -16,18 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
  * Create an instance of document store.
  *
  * @param dbStorage Database storage clinet.
- * @param schema Database schema.
  *
  * @return An intance of document store.
  */
-- (instancetype)initWithDbStorage:(MSDBStorage *)dbStorage schema:(MSDBSchema *)schema;
-
-/**
- * Get document table schema.
- *
- * @return Document table schema.
- */
-+ (MSDBSchema *)documentTableSchema;
+- (instancetype)initWithDbStorage:(MSDBStorage *)dbStorage;
 
 /**
  * Get column schema.

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
@@ -25,9 +25,10 @@ static const NSUInteger kMSSchemaVersion = 1;
 
 #pragma mark - Initialization
 
-- (instancetype)initWithDbStorage:(MSDBStorage *)dbStorage schema:(MSDBSchema *)schema {
+- (instancetype)initWithDbStorage:(MSDBStorage *)dbStorage {
   if ((self = [super init])) {
     _dbStorage = dbStorage;
+    MSDBSchema *schema = @{kMSAppDocumentTableName: MSDBDocumentStore.columnsSchema };
     NSDictionary *columnIndexes = [MSDBStorage columnsIndexes:schema];
     _idColumnIndex = ((NSNumber *)columnIndexes[kMSAppDocumentTableName][kMSIdColumnName]).unsignedIntegerValue;
     _partitionColumnIndex = ((NSNumber *)columnIndexes[kMSAppDocumentTableName][kMSPartitionColumnName]).unsignedIntegerValue;
@@ -38,6 +39,7 @@ static const NSUInteger kMSSchemaVersion = 1;
     _downloadTimeColumnIndex = ((NSNumber *)columnIndexes[kMSAppDocumentTableName][kMSDownloadTimeColumnName]).unsignedIntegerValue;
     _operationTimeColumnIndex = ((NSNumber *)columnIndexes[kMSAppDocumentTableName][kMSOperationTimeColumnName]).unsignedIntegerValue;
     _pendingOperationColumnIndex = ((NSNumber *)columnIndexes[kMSAppDocumentTableName][kMSPendingOperationColumnName]).unsignedIntegerValue;
+    [self createTableWithTableName:kMSAppDocumentTableName];
   }
   return self;
 }
@@ -47,17 +49,21 @@ static const NSUInteger kMSSchemaVersion = 1;
   /*
    * DO NOT modify schema without a migration plan and bumping database version.
    */
-  MSDBSchema *schema = [MSDBDocumentStore documentTableSchema];
-  MSDBStorage *dbStorage = [[MSDBStorage alloc] initWithSchema:schema version:kMSSchemaVersion filename:kMSDBDocumentFileName];
-  return [self initWithDbStorage:dbStorage schema:schema];
+  MSDBStorage *dbStorage = [[MSDBStorage alloc] initWithVersion:kMSSchemaVersion filename:kMSDBDocumentFileName];
+  return [self initWithDbStorage:dbStorage];
 }
 
 #pragma mark - Table Management
 
 - (BOOL)createUserStorageWithAccountId:(NSString *)accountId {
+  NSString *tableName = [NSString stringWithFormat:kMSUserDocumentTableNameFormat, accountId];
+  return [self createTableWithTableName:tableName];
+}
+
+- (BOOL)createTableWithTableName:(NSString *)tableName {
 
   // Create table based on the schema.
-  return [self.dbStorage createTable:[NSString stringWithFormat:kMSUserDocumentTableNameFormat, accountId]
+  return [self.dbStorage createTable:tableName
                        columnsSchema:[MSDBDocumentStore columnsSchema]
              uniqueColumnsConstraint:@[ kMSPartitionColumnName, kMSDocumentIdColumnName ]];
 }
@@ -160,10 +166,6 @@ static const NSUInteger kMSSchemaVersion = 1;
 - (void)deleteAllTables {
   // Delete all the tables.
   [self.dbStorage dropAllTables];
-}
-
-+ (MSDBSchema *)documentTableSchema {
-  return @{kMSAppDocumentTableName : [MSDBDocumentStore columnsSchema]};
 }
 
 + (MSDBColumnsSchema *)columnsSchema {

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
@@ -28,7 +28,7 @@ static const NSUInteger kMSSchemaVersion = 1;
 - (instancetype)initWithDbStorage:(MSDBStorage *)dbStorage {
   if ((self = [super init])) {
     _dbStorage = dbStorage;
-    MSDBSchema *schema = @{kMSAppDocumentTableName: MSDBDocumentStore.columnsSchema };
+    MSDBSchema *schema = @{kMSAppDocumentTableName : MSDBDocumentStore.columnsSchema};
     NSDictionary *columnIndexes = [MSDBStorage columnsIndexes:schema];
     _idColumnIndex = ((NSNumber *)columnIndexes[kMSAppDocumentTableName][kMSIdColumnName]).unsignedIntegerValue;
     _partitionColumnIndex = ((NSNumber *)columnIndexes[kMSAppDocumentTableName][kMSPartitionColumnName]).unsignedIntegerValue;

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
@@ -217,10 +217,11 @@
   // Ensure that there is exactly one entry in the cache with the given document ID and partition name.
   NSString *tableName = [MSDBDocumentStore tableNameForPartition:self.appToken.partition];
   NSArray<NSArray *> *result = [self.dbStorage
-                                executeSelectionQuery:[NSString stringWithFormat:@"SELECT * FROM \"%@\" WHERE \"%@\" = \"%@\" AND \"%@\" = \"%@\"", tableName, kMSDocumentIdColumnName, expectedDocumentWrapper.documentId, kMSPartitionColumnName, self.appToken.partition]];
+      executeSelectionQuery:[NSString stringWithFormat:@"SELECT * FROM \"%@\" WHERE \"%@\" = \"%@\" AND \"%@\" = \"%@\"", tableName,
+                                                       kMSDocumentIdColumnName, expectedDocumentWrapper.documentId, kMSPartitionColumnName,
+                                                       self.appToken.partition]];
   XCTAssertEqual(result.count, 1);
 }
-
 
 - (void)testCreationOfApplicationLevelTable {
 

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
@@ -25,7 +25,6 @@
 
 @property(nonatomic, strong) MSDBStorage *dbStorage;
 @property(nonatomic, strong) MSDBDocumentStore *sut;
-@property(nonnull, strong) MSDBSchema *schema;
 @property(nonnull, strong) MSTokenResult *appToken;
 @property(nonnull, strong) MSTokenResult *userToken;
 
@@ -40,9 +39,8 @@
   [MSUtility deleteItemForPathComponent:kMSDBDocumentFileName];
 
   // Init storage.
-  self.schema = [MSDBDocumentStore documentTableSchema];
-  self.dbStorage = [[MSDBStorage alloc] initWithSchema:self.schema version:0 filename:kMSDBDocumentFileName];
-  self.sut = [[MSDBDocumentStore alloc] initWithDbStorage:self.dbStorage schema:self.schema];
+  self.dbStorage = [[MSDBStorage alloc] initWithVersion:0 filename:kMSDBDocumentFileName];
+  self.sut = [[MSDBDocumentStore alloc] initWithDbStorage:self.dbStorage];
 
   // Init tokens.
   self.appToken = [[MSTokenResult alloc] initWithPartition:MSDataStoreAppDocumentsPartition
@@ -201,6 +199,28 @@
   XCTAssertEqual(documentWrapper.error.error.code, MSACDataStoreErrorDocumentNotFound);
   XCTAssertEqualObjects(documentWrapper.documentId, documentId);
 }
+
+- (void)testUpsertReplacesCorrectlyInAppStorage {
+
+  // If
+  MSDocumentWrapper *expectedDocumentWrapper = [MSDocumentUtils documentWrapperFromData:[self jsonFixture:@"validTestDocument"]
+                                                                           documentType:[MSDictionaryDocument class]];
+  MSWriteOptions *writeOptions = [[MSWriteOptions alloc] initWithDeviceTimeToLive:MSDataStoreTimeToLiveInfinite];
+
+  // When
+  // Upsert twice to ensure that replacement is correct.
+  [self.sut upsertWithToken:self.appToken documentWrapper:expectedDocumentWrapper operation:@"REPLACE" options:writeOptions];
+  [self.sut upsertWithToken:self.appToken documentWrapper:expectedDocumentWrapper operation:@"REPLACE" options:writeOptions];
+
+  // Then
+
+  // Ensure that there is exactly one entry in the cache with the given document ID and partition name.
+  NSString *tableName = [MSDBDocumentStore tableNameForPartition:self.appToken.partition];
+  NSArray<NSArray *> *result = [self.dbStorage
+                                executeSelectionQuery:[NSString stringWithFormat:@"SELECT * FROM \"%@\" WHERE \"%@\" = \"%@\" AND \"%@\" = \"%@\"", tableName, kMSDocumentIdColumnName, expectedDocumentWrapper.documentId, kMSPartitionColumnName, self.appToken.partition]];
+  XCTAssertEqual(result.count, 1);
+}
+
 
 - (void)testCreationOfApplicationLevelTable {
 

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
@@ -210,10 +210,17 @@
   // When
   // Upsert twice to ensure that replacement is correct.
   [self.sut upsertWithToken:self.appToken documentWrapper:expectedDocumentWrapper operation:@"REPLACE" options:writeOptions];
+
+  // If
+  // Mock the document wrapper to appear to have a different eTag now.
+  MSDocumentWrapper *mockDocumentWrapper = OCMPartialMock(expectedDocumentWrapper);
+  NSString *expectedEtag = @"the new etag";
+  OCMStub(mockDocumentWrapper.eTag).andReturn(expectedEtag);
+
+  // When
   [self.sut upsertWithToken:self.appToken documentWrapper:expectedDocumentWrapper operation:@"REPLACE" options:writeOptions];
 
   // Then
-
   // Ensure that there is exactly one entry in the cache with the given document ID and partition name.
   NSString *tableName = [MSDBDocumentStore tableNameForPartition:self.appToken.partition];
   NSArray<NSArray *> *result = [self.dbStorage
@@ -221,6 +228,7 @@
                                                        kMSDocumentIdColumnName, expectedDocumentWrapper.documentId, kMSPartitionColumnName,
                                                        self.appToken.partition]];
   XCTAssertEqual(result.count, 1);
+  XCTAssertEqualObjects(expectedEtag, result[0][self.sut.eTagColumnIndex]);
 }
 
 - (void)testCreationOfApplicationLevelTable {


### PR DESCRIPTION

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
The readonly storage table was not being created with the unique columns constraint that all tables require. As a result, when a document in the readonly table was replaced (usually to update TTL), it was actually duplicated instead of replaced.
