### PR TITLE
Change default device time-to-live from 1 hour to 1 day

### DIFF
--- a/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.h
@@ -35,7 +35,7 @@ static NSString *const MSDataStoreUserDocumentsPartition = @"user";
 static NSString *const MSDataStoreAppDocumentsPartition = @"readonly";
 
 /**
- * Cache does not expire.
+ * No expiration on cache.
  */
 static int const MSDataStoreTimeToLiveInfinite = -1;
 
@@ -45,7 +45,7 @@ static int const MSDataStoreTimeToLiveInfinite = -1;
 static int const MSDataStoreTimeToLiveNoCache = 0;
 
 /**
- * Default cahcing value of one day.
+ * Default expiration on cache.
  */
 static int const MSDataStoreTimeToLiveDefault = 60 * 60 * 24;
 

--- a/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.h
@@ -35,11 +35,19 @@ static NSString *const MSDataStoreUserDocumentsPartition = @"user";
 static NSString *const MSDataStoreAppDocumentsPartition = @"readonly";
 
 /**
- * Time to live constants
+ * Cache does not expire.
  */
 static int const MSDataStoreTimeToLiveInfinite = -1;
+
+/**
+ * Do not cache.
+ */
 static int const MSDataStoreTimeToLiveNoCache = 0;
-static int const MSDataStoreTimeToLiveDefault = 60 * 60;
+
+/**
+ * Default cahcing value of one day.
+ */
+static int const MSDataStoreTimeToLiveDefault = 60 * 60 * 24;
 
 @interface MSDataStore<T : id <MSSerializableDocument>> : MSServiceAbstract
 

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSBaseOptionsTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSBaseOptionsTests.m
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #import "MSBaseOptions.h"
+#import "MSDataStore.h"
 #import "MSTestFrameworks.h"
 
 @interface MSBaseOptionsTests : XCTestCase
@@ -24,14 +25,11 @@
 
 - (void)testInitWithCorrectDeviceTtlByDefault {
 
-  // If
-  NSInteger expectedTimeToLive = 3600;
-
   // When
   MSBaseOptions *baseOptions = [[MSBaseOptions alloc] init];
 
   // Then
-  XCTAssertEqual(baseOptions.deviceTimeToLive, expectedTimeToLive);
+  XCTAssertEqual(baseOptions.deviceTimeToLive, MSDataStoreTimeToLiveDefault);
 }
 
 @end


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The default device time-to-live is 1 hour which is not too short. We're going to use 1 day as the default value.

