### PR TITLE
Code clean - prefix constant variables with `k` following our convention

### DIFF
--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSTokenExchange.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSTokenExchange.m
@@ -188,7 +188,7 @@ static NSString *const kMSGetTokenPath = @"/data/tokens";
  *       User partition : MSStorageUserDbToken
  */
 + (NSString *)tokenKeyNameForPartition:(NSString *)partitionName {
-  if ([partitionName isEqualToString:MSDataStoreAppDocumentsPartition]) {
+  if ([partitionName isEqualToString:kMSDataStoreAppDocumentsPartition]) {
     return kMSStorageReadOnlyDbTokenKey;
   }
 

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
@@ -80,7 +80,7 @@ static const NSUInteger kMSSchemaVersion = 1;
    */
   NSTimeInterval now = NSDate.timeIntervalSinceReferenceDate + NSTimeIntervalSince1970;
   NSTimeInterval expirationTime = -1;
-  if (options.deviceTimeToLive != MSDataStoreTimeToLiveInfinite) {
+  if (options.deviceTimeToLive != kMSDataStoreTimeToLiveInfinite) {
     expirationTime = now + options.deviceTimeToLive;
   }
   NSString *tableName = [MSDBDocumentStore tableNameForPartition:token.partition];
@@ -137,7 +137,7 @@ static const NSUInteger kMSSchemaVersion = 1;
 
   // If the document is expired, return an error and delete it.
   long expirationTime = [(NSNumber *)(result[0][self.expirationTimeColumnIndex]) longValue];
-  if (expirationTime != MSDataStoreTimeToLiveInfinite) {
+  if (expirationTime != kMSDataStoreTimeToLiveInfinite) {
     NSDate *expirationDate = [NSDate dateWithTimeIntervalSince1970:expirationTime];
     NSDate *currentDate = [NSDate date];
     if (expirationDate && [expirationDate laterDate:currentDate] == currentDate) {
@@ -166,7 +166,7 @@ static const NSUInteger kMSSchemaVersion = 1;
                                             documentId:documentId
                                       pendingOperation:pendingOperation];
   if (readOptions) {
-    if (readOptions.deviceTimeToLive == MSDataStoreTimeToLiveNoCache) {
+    if (readOptions.deviceTimeToLive == kMSDataStoreTimeToLiveNoCache) {
 
       // If no cache, delete whatever is already in the cache.
       [self deleteWithToken:token documentId:documentId];

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
@@ -185,7 +185,7 @@ static const NSUInteger kMSSchemaVersion = 1;
 }
 
 + (NSString *)tableNameForPartition:(NSString *)partition {
-  if ([partition isEqualToString:MSDataStoreAppDocumentsPartition]) {
+  if ([partition isEqualToString:kMSDataStoreAppDocumentsPartition]) {
     return kMSAppDocumentTableName;
   } else if ([partition rangeOfString:kMSDataStoreAppDocumentsUserPartitionPrefix options:NSAnchoredSearch].location == 0) {
     return [NSString

--- a/AppCenterDataStorage/AppCenterDataStorage/MSBaseOptions.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSBaseOptions.h
@@ -6,7 +6,7 @@
 @interface MSBaseOptions : NSObject
 
 /**
- * Device document time-to-live in seconds. Default is one hour.
+ * Device document time-to-live in seconds. Default is one day.
  */
 @property long deviceTimeToLive;
 

--- a/AppCenterDataStorage/AppCenterDataStorage/MSBaseOptions.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSBaseOptions.m
@@ -19,7 +19,7 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _deviceTimeToLive = MSDataStoreTimeToLiveDefault;
+    _deviceTimeToLive = kMSDataStoreTimeToLiveDefault;
   }
   return self;
 }

--- a/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.h
@@ -37,17 +37,17 @@ static NSString *const kMSDataStoreAppDocumentsPartition = @"readonly";
 /**
  * No expiration on cache.
  */
-static int const MSDataStoreTimeToLiveInfinite = -1;
+static int const kMSDataStoreTimeToLiveInfinite = -1;
 
 /**
  * Do not cache.
  */
-static int const MSDataStoreTimeToLiveNoCache = 0;
+static int const kMSDataStoreTimeToLiveNoCache = 0;
 
 /**
  * Default expiration on cache.
  */
-static int const MSDataStoreTimeToLiveDefault = 60 * 60 * 24;
+static int const kMSDataStoreTimeToLiveDefault = 60 * 60 * 24;
 
 @interface MSDataStore<T : id <MSSerializableDocument>> : MSServiceAbstract
 

--- a/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.h
@@ -25,14 +25,14 @@ static NSString *const kMSDataStorageErrorDomain = @"MSDataStorageErrorDomain";
  * User partition.
  * An authenticated user can read/write documents in this partition.
  */
-static NSString *const MSDataStoreUserDocumentsPartition = @"user";
+static NSString *const kMSDataStoreUserDocumentsPartition = @"user";
 
 /**
  * Application partition.
  * Everyone can read documents in this partition.
  * Writes not allowed via the SDK.
  */
-static NSString *const MSDataStoreAppDocumentsPartition = @"readonly";
+static NSString *const kMSDataStoreAppDocumentsPartition = @"readonly";
 
 /**
  * Time to live constants

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSBaseOptionsTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSBaseOptionsTests.m
@@ -29,7 +29,7 @@
   MSBaseOptions *baseOptions = [[MSBaseOptions alloc] init];
 
   // Then
-  XCTAssertEqual(baseOptions.deviceTimeToLive, MSDataStoreTimeToLiveDefault);
+  XCTAssertEqual(baseOptions.deviceTimeToLive, kMSDataStoreTimeToLiveDefault);
 }
 
 @end

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
@@ -43,7 +43,7 @@
   self.sut = [[MSDBDocumentStore alloc] initWithDbStorage:self.dbStorage];
 
   // Init tokens.
-  self.appToken = [[MSTokenResult alloc] initWithPartition:MSDataStoreAppDocumentsPartition
+  self.appToken = [[MSTokenResult alloc] initWithPartition:kMSDataStoreAppDocumentsPartition
                                                  dbAccount:@"account"
                                                     dbName:@"dbname"
                                           dbCollectionName:@"collection"

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
@@ -134,7 +134,7 @@
                    partition:self.appToken.partition
                   documentId:documentId
             pendingOperation:@""
-              expirationTime:MSDataStoreTimeToLiveInfinite];
+              expirationTime:kMSDataStoreTimeToLiveInfinite];
 
   // When
   MSDocumentWrapper *documentWrapper = [self.sut readWithToken:self.appToken
@@ -213,7 +213,7 @@
                   documentId:documentId
             pendingOperation:pendingOperation
               expirationTime:(long)[[NSDate dateWithTimeIntervalSinceNow:1000000] timeIntervalSince1970]];
-  MSReadOptions *readOptions = [[MSReadOptions alloc] initWithDeviceTimeToLive:MSDataStoreTimeToLiveNoCache];
+  MSReadOptions *readOptions = [[MSReadOptions alloc] initWithDeviceTimeToLive:kMSDataStoreTimeToLiveNoCache];
 
   // When
 
@@ -237,7 +237,7 @@
                   documentId:documentId
             pendingOperation:pendingOperation
               expirationTime:(long)[[NSDate dateWithTimeIntervalSinceNow:1000000] timeIntervalSince1970]];
-  MSReadOptions *readOptions = [[MSReadOptions alloc] initWithDeviceTimeToLive:MSDataStoreTimeToLiveInfinite];
+  MSReadOptions *readOptions = [[MSReadOptions alloc] initWithDeviceTimeToLive:kMSDataStoreTimeToLiveInfinite];
 
   // When
 
@@ -246,7 +246,7 @@
 
   // Then
   long expirationTime = [self expirationTimeWithToken:self.appToken documentId:documentId];
-  XCTAssertEqual(expirationTime, MSDataStoreTimeToLiveInfinite);
+  XCTAssertEqual(expirationTime, kMSDataStoreTimeToLiveInfinite);
 }
 
 - (void)testReadFromLocalDatabaseCorrectlyUpdatesTTL {
@@ -285,7 +285,7 @@
   // If
   MSDocumentWrapper *expectedDocumentWrapper = [MSDocumentUtils documentWrapperFromData:[self jsonFixture:@"validTestDocument"]
                                                                            documentType:[MSDictionaryDocument class]];
-  MSWriteOptions *writeOptions = [[MSWriteOptions alloc] initWithDeviceTimeToLive:MSDataStoreTimeToLiveInfinite];
+  MSWriteOptions *writeOptions = [[MSWriteOptions alloc] initWithDeviceTimeToLive:kMSDataStoreTimeToLiveInfinite];
 
   // When
   // Upsert twice to ensure that replacement is correct.
@@ -414,7 +414,7 @@
   // If
   MSDocumentWrapper *documentWrapper = [MSDocumentUtils documentWrapperFromData:[self jsonFixture:@"validTestDocument"]
                                                                    documentType:[MSDictionaryDocument class]];
-  MSReadOptions *readOptions = [[MSReadOptions alloc] initWithDeviceTimeToLive:MSDataStoreTimeToLiveInfinite];
+  MSReadOptions *readOptions = [[MSReadOptions alloc] initWithDeviceTimeToLive:kMSDataStoreTimeToLiveInfinite];
 
   // When
   BOOL result = [self.sut upsertWithToken:self.appToken documentWrapper:documentWrapper operation:@"CREATE" options:readOptions];
@@ -432,7 +432,7 @@
   XCTAssertEqualObjects(expectedDocumentWrapper.partition, documentWrapper.partition);
   XCTAssertEqualObjects(expectedDocumentWrapper.eTag, documentWrapper.eTag);
   long expirationTime = [self expirationTimeWithToken:self.appToken documentId:expectedDocumentWrapper.documentId];
-  XCTAssertEqual(expirationTime, MSDataStoreTimeToLiveInfinite);
+  XCTAssertEqual(expirationTime, kMSDataStoreTimeToLiveInfinite);
 }
 
 - (void)testDeleteAppDocumentForNonExistentDocument {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Prefix constant variables with `k` following our convention.

(Addressing https://github.com/Microsoft/AppCenter-SDK-Apple/pull/1503#discussion_r275027389)

Please don't merge before #1500, otherwise it may slow things down.