### PR TITLE
Fix no userConfirmationHandler provided

### DIFF
--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -1121,7 +1121,13 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
      */
     [MS_USER_DEFAULTS setObject:[[NSNumber alloc] initWithBool:YES] forKey:kMSUserConfirmationKey];
   }
-
+  
+  // Check if there is no handler set and unprocessedReports are not initialized as NSMutableArray (Init occurs in correct call sequence).
+  if ([MSCrashes sharedInstance].userConfirmationHandler==nil && !self.unprocessedReports) {
+    MSLogWarning(MSCrashes.logTag, @"Incorrect implementation of notifyWithUserConfirmation: should only be called from userConfirmationHandler. See https://docs.microsoft.com/en-us/appcenter/sdk/crashes/xamarin#ask-for-the-users-consent-to-send-a-crash-log");
+    return;
+  }
+  
   // Process crashes logs.
   for (NSUInteger i = 0; i < [self.unprocessedReports count]; i++) {
     MSAppleErrorLog *log = self.unprocessedLogs[i];


### PR DESCRIPTION
AB#59984

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

There was an issue on iOS and Xamarin iOS when setUserId didn't work.
It occured when there is a call to Crashes.NotifyUserConfirmation(AlwaysSend) or MSCrashes.notify(with: .always) without ShouldAwaitUserConfirmation callback or dialog implementation. This is a case of misconfiguration, this is a fix to catch that situation.
## Related PRs or issues

List related PRs and other issues.

## Misc

