### PR TITLE
Fix flashing logs after reaching maximum of parallel batches

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -250,6 +250,9 @@
                                               [delegate channel:self didSucceedSendingLog:aLog];
                                             }
                                           }];
+
+                // Remove the logs from storage.
+                [self.storage deleteLogsWithBatchId:ingestionBatchId groupId:self.configuration.groupId];
               }
 
               // Failure.
@@ -266,9 +269,8 @@
                                           }];
               }
 
-              // Remove from pending batches and storage.
+              // Remove from pending batches.
               [self.pendingBatchIds removeObject:ingestionBatchId];
-              [self.storage deleteLogsWithBatchId:ingestionBatchId groupId:self.configuration.groupId];
 
               // Update pending batch queue state.
               if (self.pendingBatchQueueFull && self.pendingBatchIds.count < self.configuration.pendingBatchesLimit) {

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -238,8 +238,6 @@
                 return;
               }
               BOOL succeeded = response.statusCode == MSHTTPCodesNo200OK;
-
-              // Success.
               if (succeeded) {
                 MSLogDebug([MSAppCenter logTag], @"Log(s) sent with success, batch Id:%@.", ingestionBatchId);
 

--- a/AppCenter/AppCenter/Internals/Context/AuthToken/MSAuthTokenContext.h
+++ b/AppCenter/AppCenter/Internals/Context/AuthToken/MSAuthTokenContext.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return Array of MSAuthTokenValidityInfo.
  */
-- (NSMutableArray<MSAuthTokenValidityInfo *> *)authTokenValidityArray;
+- (NSArray<MSAuthTokenValidityInfo *> *)authTokenValidityArray;
 
 /**
  * Removes the token from history. Please note that only oldest token is

--- a/AppCenter/AppCenter/Internals/Context/AuthToken/MSAuthTokenContext.m
+++ b/AppCenter/AppCenter/Internals/Context/AuthToken/MSAuthTokenContext.m
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 #import "MSAuthTokenContext.h"
+#import "MSAppCenterInternal.h"
 #import "MSAuthTokenContextDelegate.h"
 #import "MSAuthTokenContextPrivate.h"
 #import "MSAuthTokenInfo.h"
 #import "MSAuthTokenValidityInfo.h"
-#import "MSAppCenterInternal.h"
 #import "MSConstants+Internal.h"
 #import "MSEncrypter.h"
 #import "MSUserInformation.h"
@@ -169,7 +169,7 @@ static NSUInteger const kMSAccountIdLengthInHomeAccount = 36;
   return latestAuthTokenInfo.accountId;
 }
 
-- (NSMutableArray<MSAuthTokenValidityInfo *> *)authTokenValidityArray {
+- (NSArray<MSAuthTokenValidityInfo *> *)authTokenValidityArray {
   NSArray<MSAuthTokenInfo *> *authTokenHistory = [self authTokenHistory];
   NSMutableArray<MSAuthTokenValidityInfo *> *resultArray = [NSMutableArray<MSAuthTokenValidityInfo *> new];
   if (authTokenHistory.count == 0) {
@@ -223,7 +223,7 @@ static NSUInteger const kMSAccountIdLengthInHomeAccount = 36;
   }
   NSData *encryptedData = [MS_USER_DEFAULTS objectForKey:kMSAuthTokenHistoryKey];
   NSData *decryptedData = encryptedData ? [self.encrypter decryptData:encryptedData] : nil;
-  NSArray<MSAuthTokenInfo *> * history = decryptedData ? [NSKeyedUnarchiver unarchiveObjectWithData:decryptedData] : nil;
+  NSArray<MSAuthTokenInfo *> *history = decryptedData ? [NSKeyedUnarchiver unarchiveObjectWithData:decryptedData] : nil;
   if (history) {
     MSLogDebug([MSAppCenter logTag], @"Retrieved history state.");
   } else {

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -30,8 +30,8 @@ static NSString *const kMSTestGroupId = @"GroupId";
 @interface MSChannelUnitDefault (Test)
 
 - (void)sendLogContainer:(MSLogContainer *__nonnull)container
-  withAuthTokenFromArray:(NSArray<MSAuthTokenValidityInfo *> *__nonnull)tokenArray
-                 atIndex:(NSUInteger)tokenIndex;
+    withAuthTokenFromArray:(NSArray<MSAuthTokenValidityInfo *> *__nonnull)tokenArray
+                   atIndex:(NSUInteger)tokenIndex;
 
 - (void)flushQueueForTokenArray:(NSArray<MSAuthTokenValidityInfo *> *)tokenArray withTokenIndex:(NSUInteger)tokenIndex;
 

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -29,10 +29,9 @@ static NSString *const kMSTestGroupId = @"GroupId";
 
 @interface MSChannelUnitDefault (Test)
 
-- (void)sendLogArray:(NSArray<id<MSLog>> *__nonnull)logArray
-              withBatchId:(NSString *)batchId
-    andAuthTokenFromArray:(NSArray<MSAuthTokenValidityInfo *> *)tokenArray
-                  atIndex:(NSUInteger)tokenIndex;
+- (void)sendLogContainer:(MSLogContainer *__nonnull)container
+  withAuthTokenFromArray:(NSArray<MSAuthTokenValidityInfo *> *__nonnull)tokenArray
+                 atIndex:(NSUInteger)tokenIndex;
 
 - (void)flushQueueForTokenArray:(NSArray<MSAuthTokenValidityInfo *> *)tokenArray withTokenIndex:(NSUInteger)tokenIndex;
 
@@ -1299,8 +1298,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
 
   // Stub sendLogArray part - we don't need this in this test.
   id sutMock = OCMPartialMock(self.sut);
-  OCMStub([[sutMock ignoringNonObjectArgs] sendLogArray:OCMOCK_ANY withBatchId:OCMOCK_ANY andAuthTokenFromArray:OCMOCK_ANY atIndex:0])
-      .andDo(nil);
+  OCMStub([[sutMock ignoringNonObjectArgs] sendLogContainer:OCMOCK_ANY withAuthTokenFromArray:OCMOCK_ANY atIndex:0]).andDo(nil);
   OCMStub([self.storageMock loadLogsWithGroupId:self.sut.configuration.groupId
                                           limit:self.sut.configuration.batchSizeLimit
                              excludedTargetKeys:OCMOCK_ANY
@@ -1329,7 +1327,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   [sutMock flushQueueForTokenArray:tokenValidityArray withTokenIndex:0];
 
   // Then
-  OCMVerify([sutMock sendLogArray:logsForToken3 withBatchId:OCMOCK_ANY andAuthTokenFromArray:tokenValidityArray atIndex:2]);
+  OCMVerify([sutMock sendLogContainer:OCMOCK_ANY withAuthTokenFromArray:tokenValidityArray atIndex:2]);
   [sutMock stopMocking];
 }
 


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This is 1-line fix + some cleanup.

The problematic line is
https://github.com/Microsoft/AppCenter-SDK-Apple/blob/95b1d74f3bb7b22f6fa23323ac8bff230f59e9b5/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m#L259
It is trying to resend already sent logs instead of reading new batch from DB. It wasn't covered by unit tests (fixed).

## Misc

# :exclamation: REVIEW WITH HIDDEN WHITESPACE CHANGES


