### PR TITLE
Do not block the UI thread by using a dispatch queue

### DIFF
--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
@@ -821,6 +821,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
   // If we change the default token URL.
   NSString *expectedUrl = @"https://another.domain.com";
   [MSDataStore setTokenExchangeUrl:expectedUrl];
+  __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Make any API call"];
   __block NSURL *actualUrl;
   OCMStub([self.tokenExchangeMock performDbTokenAsyncOperationWithHttpClient:OCMOCK_ANY
                                                             tokenExchangeUrl:OCMOCK_ANY
@@ -830,6 +831,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                                            completionHandler:OCMOCK_ANY])
       .andDo(^(NSInvocation *invocation) {
         [invocation getArgument:&actualUrl atIndex:3];
+        [expectation fulfill];
       });
 
   // When doing any API call, it will request a token.
@@ -839,8 +841,15 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                  }];
 
   // Then that call uses the base URL we specified.
-  XCTAssertEqualObjects([actualUrl scheme], @"https");
-  XCTAssertEqualObjects([actualUrl host], @"another.domain.com");
+  [self waitForExpectationsWithTimeout:1
+                               handler:^(NSError *_Nullable error) {
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 } else {
+                                   XCTAssertEqualObjects([actualUrl scheme], @"https");
+                                   XCTAssertEqualObjects([actualUrl host], @"another.domain.com");
+                                 }
+                               }];
 }
 
 - (void)testListSingleDocument {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Bring back dispatch queue calls. Note that some HTTP calls are also "forked" from the dispatch queue, but that should be fine.

The operation proxy is now executed on the dispatch queue.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
