### PR TITLE
Pass an error when Cosmos DB returns error response

### DIFF
--- a/AppCenter/AppCenter/Internals/HttpClient/Util/MSHttpUtil.h
+++ b/AppCenter/AppCenter/Internals/HttpClient/Util/MSHttpUtil.h
@@ -13,9 +13,18 @@ static NSString *const kMSHidingStringForAppSecret = @"*";
  *
  * @param statusCode Http status code.
  *
- * @return is recoverable.
+ * @return YES if it is recoverable.
  */
 + (BOOL)isRecoverableError:(NSInteger)statusCode;
+
+/**
+ * Indicate if the http response is a success response.
+ *
+ * @param statusCode Http status code.
+ *
+ * @return YES if it is a success code.
+ */
++ (BOOL)isSuccessStatusCode:(NSInteger)statusCode;
 
 /**
  * Indicate if error is due to no internet connection.

--- a/AppCenter/AppCenter/Internals/HttpClient/Util/MSHttpUtil.m
+++ b/AppCenter/AppCenter/Internals/HttpClient/Util/MSHttpUtil.m
@@ -11,6 +11,10 @@
   return statusCode >= 500 || statusCode == 408 || statusCode == 429 || statusCode == 0;
 }
 
++ (BOOL)isSuccessStatusCode:(NSInteger)statusCode {
+  return statusCode >= 200 && statusCode < 300;
+}
+
 + (BOOL)isNoInternetConnectionError:(NSError *)error {
   return ([error.domain isEqualToString:NSURLErrorDomain] &&
           ((error.code == NSURLErrorNotConnectedToInternet) || (error.code == NSURLErrorNetworkConnectionLost)));

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)performCosmosDbAsyncOperationWithHttpClient:(id<MSHttpClientProtocol>)httpClient
                                         tokenResult:(MSTokenResult *)tokenResult
-                                         documentId:(NSString *)documentId
+                                         documentId:(NSString *_Nullable)documentId
                                          httpMethod:(NSString *)httpMethod
                                                body:(NSData *_Nullable)body
                                   additionalHeaders:(NSDictionary *_Nullable)additionalHeaders

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
@@ -115,14 +115,14 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
 
 + (NSString *)documentBaseUrlWithDatabaseName:(NSString *)databaseName
                                collectionName:(NSString *)collectionName
-                                   documentId:(NSString *)documentId {
+                                   documentId:(NSString *_Nullable)documentId {
   NSString *dbUrlSuffix = [NSString stringWithFormat:kMSDocumentDbDatabaseUrlSuffix, databaseName];
   NSString *dbCollectionUrlSuffix = [NSString stringWithFormat:kMSDocumentDbCollectionUrlSuffix, collectionName];
   NSString *dbDocumentId = documentId ? [NSString stringWithFormat:@"/%@", documentId] : @"";
   return [NSString stringWithFormat:@"%@/%@/%@%@", dbUrlSuffix, dbCollectionUrlSuffix, kMSDocumentDbDocumentUrlPrefix, dbDocumentId];
 }
 
-+ (NSString *)documentUrlWithTokenResult:(MSTokenResult *)tokenResult documentId:(NSString *)documentId {
++ (NSString *)documentUrlWithTokenResult:(MSTokenResult *)tokenResult documentId:(NSString *_Nullable)documentId {
   NSString *documentResourceIdPrefix = [MSCosmosDb documentBaseUrlWithDatabaseName:tokenResult.dbName
                                                                     collectionName:tokenResult.dbCollectionName
                                                                         documentId:documentId];
@@ -131,7 +131,7 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
 
 + (void)performCosmosDbAsyncOperationWithHttpClient:(id<MSHttpClientProtocol>)httpClient
                                         tokenResult:(MSTokenResult *)tokenResult
-                                         documentId:(NSString *)documentId
+                                         documentId:(NSString *_Nullable)documentId
                                          httpMethod:(NSString *)httpMethod
                                                body:(NSData *_Nullable)body
                                   additionalHeaders:(NSDictionary *_Nullable)additionalHeaders

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/MSDataStorePrivate.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/MSDataStorePrivate.h
@@ -39,6 +39,23 @@ static NSString *const kMSDefaultApiUrl = @"https://api.appcenter.ms/v0.1";
         continuationToken:(NSString *_Nullable)continuationToken
         completionHandler:(MSPaginatedDocumentsCompletionHandler)completionHandler;
 
+/**
+ * Perform Cosmos DB operation.
+ *
+ * @param partition The CosmosDB partition key.
+ * @param documentId The identifier of a document.
+ * @param httpMethod Http method.
+ * @param body Http body.
+ * @param additionalHeaders Additional http headers.
+ * @param completionHandler Completion handler callback.
+ */
+- (void)performCosmosDbOperationWithPartition:(NSString *)partition
+                                   documentId:(NSString *_Nullable)documentId
+                                   httpMethod:(NSString *)httpMethod
+                                         body:(NSData *_Nullable)body
+                            additionalHeaders:(NSDictionary *_Nullable)additionalHeaders
+                            completionHandler:(MSHttpRequestCompletionHandler)completionHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Util/MSDataStorageConstants.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Util/MSDataStorageConstants.h
@@ -18,3 +18,8 @@ static NSString *const kMSPendingOperationCreate = @"CREATE";
 static NSString *const kMSPendingOperationReplace = @"REPLACE";
 static NSString *const kMSPendingOperationDelete = @"DELETE";
 static NSString *const kMSPendingOperationRead = nil;
+
+/**
+ * CosmosDb Http code key.
+ */
+static NSString *const kMSCosmosDbHttpCodeKey = @"MSHttpCodeKey";

--- a/AppCenterDataStorage/AppCenterDataStorage/MSDataSourceError.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDataSourceError.m
@@ -2,12 +2,8 @@
 // Licensed under the MIT License.
 
 #import "MSDataSourceError.h"
+#import "MSDataStorageConstants.h"
 #import "MSDataStoreErrors.h"
-
-/**
- * CosmosDb Http code key.
- */
-static NSString *const kMSCosmosDbHttpCodeKey = @"com.Microsoft.AppCenter.HttpCodeKey";
 
 @implementation MSDataSourceError
 

--- a/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.m
@@ -11,6 +11,7 @@
 #import "MSCosmosDb.h"
 #import "MSDBDocumentStore.h"
 #import "MSDataSourceError.h"
+#import "MSDataStorageConstants.h"
 #import "MSDataStoreErrors.h"
 #import "MSDataStoreInternal.h"
 #import "MSDataStorePrivate.h"
@@ -18,6 +19,7 @@
 #import "MSDocumentUtils.h"
 #import "MSDocumentWrapperInternal.h"
 #import "MSHttpClient.h"
+#import "MSHttpUtil.h"
 #import "MSPaginatedDocuments.h"
 #import "MSReadOptions.h"
 #import "MSServiceAbstractProtected.h"
@@ -439,10 +441,10 @@ static dispatch_once_t onceToken;
 #pragma mark - CosmosDB operation implementations
 
 - (void)performCosmosDbOperationWithPartition:(NSString *)partition
-                                   documentId:(NSString *)documentId
+                                   documentId:(NSString *_Nullable)documentId
                                    httpMethod:(NSString *)httpMethod
                                          body:(NSData *_Nullable)body
-                            additionalHeaders:(NSDictionary *)additionalHeaders
+                            additionalHeaders:(NSDictionary *_Nullable)additionalHeaders
                             completionHandler:(MSHttpRequestCompletionHandler)completionHandler {
   [MSTokenExchange
       performDbTokenAsyncOperationWithHttpClient:(id<MSHttpClientProtocol>)self.httpClient
@@ -461,7 +463,22 @@ static dispatch_once_t onceToken;
                                                                               httpMethod:httpMethod
                                                                                     body:body
                                                                        additionalHeaders:additionalHeaders
-                                                                       completionHandler:completionHandler];
+                                                                       completionHandler:^(NSData *_Nullable data,
+                                                                                           NSHTTPURLResponse *_Nullable response,
+                                                                                           NSError *_Nullable cosmosDbError) {
+                                                                         if (!cosmosDbError &&
+                                                                             ![MSHttpUtil isSuccessStatusCode:response.statusCode]) {
+                                                                           cosmosDbError = [[NSError alloc]
+                                                                               initWithDomain:kMSDataStorageErrorDomain
+                                                                                         code:MSACDataStoreErrorHTTPError
+                                                                                     userInfo:@{
+                                                                                       NSLocalizedDescriptionKey :
+                                                                                           kMSACDataStoreCosmosDbErrorResponseDesc,
+                                                                                       kMSCosmosDbHttpCodeKey : @(response.statusCode)
+                                                                                     }];
+                                                                         }
+                                                                         completionHandler(data, response, cosmosDbError);
+                                                                       }];
                                }];
 }
 

--- a/AppCenterDataStorage/AppCenterDataStorage/MSDataStoreErrors.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDataStoreErrors.h
@@ -46,5 +46,6 @@ NS_ENUM(NSInteger){MSACDataStoreErrorJSONSerializationFailed = -620000,
 // Error descriptions.
 static NSString const *kMSACDataStoreInvalidClassDesc =
     @"Provided class does not conform to serialization protocol (MSSerializableDocument).";
+static NSString const *kMSACDataStoreCosmosDbErrorResponseDesc = @"Cosmos DB returned error response.";
 
 NS_ASSUME_NONNULL_END

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDataSourceErrorTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDataSourceErrorTests.m
@@ -16,7 +16,7 @@
 
   // If
   NSInteger expectedErrorCode = MSACDocumentInternalServerErrorErrorCode;
-  NSDictionary *userInfo = @{@"com.Microsoft.AppCenter.HttpCodeKey" : @(expectedErrorCode)};
+  NSDictionary *userInfo = @{@"MSHttpCodeKey" : @(expectedErrorCode)};
   NSError *error = [NSError errorWithDomain:kMSACErrorDomain code:0 userInfo:userInfo];
   id dataSourceErrorMock = OCMClassMock([MSDataSourceError class]);
 
@@ -46,7 +46,7 @@
 
   // If
   NSInteger expectedErrorCode = MSACDocumentInternalServerErrorErrorCode;
-  NSDictionary *userInfo = @{@"com.Microsoft.AppCenter.HttpCodeKey" : @(expectedErrorCode)};
+  NSDictionary *userInfo = @{@"MSHttpCodeKey" : @(expectedErrorCode)};
   NSError *error = [NSError errorWithDomain:kMSACErrorDomain code:0 userInfo:userInfo];
 
   // When

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
@@ -538,12 +538,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
       .andDo(^(NSInvocation *invocation) {
         MSHttpRequestCompletionHandler cosmosdbOperationCallback;
         [invocation getArgument:&cosmosdbOperationCallback atIndex:8];
-        cosmosdbOperationCallback(nil,
-                                  [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://contoso.com"]
-                                                              statusCode:MSHTTPCodesNo400BadRequest
-                                                             HTTPVersion:nil
-                                                            headerFields:nil],
-                                  nil);
+        cosmosdbOperationCallback(nil, [self generateResponseWithStatusCode:MSHTTPCodesNo400BadRequest], nil);
       });
 
   // When
@@ -594,7 +589,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
       .andDo(^(NSInvocation *invocation) {
         MSHttpRequestCompletionHandler cosmosdbOperationCallback;
         [invocation getArgument:&cosmosdbOperationCallback atIndex:8];
-        cosmosdbOperationCallback(testCosmosDbResponse, nil, nil);
+        cosmosdbOperationCallback(testCosmosDbResponse, [self generateResponseWithStatusCode:MSHTTPCodesNo200OK], nil);
       });
 
   // When
@@ -724,7 +719,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
       .andDo(^(NSInvocation *invocation) {
         MSHttpRequestCompletionHandler cosmosdbOperationCallback;
         [invocation getArgument:&cosmosdbOperationCallback atIndex:8];
-        cosmosdbOperationCallback(brokenCosmosDbResponse, nil, nil);
+        cosmosdbOperationCallback(brokenCosmosDbResponse, [self generateResponseWithStatusCode:MSHTTPCodesNo200OK], nil);
       });
 
   // When
@@ -769,7 +764,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
       .andDo(^(NSInvocation *invocation) {
         MSHttpRequestCompletionHandler cosmosdbOperationCallback;
         [invocation getArgument:&cosmosdbOperationCallback atIndex:8];
-        cosmosdbOperationCallback(nil, nil, nil);
+        cosmosdbOperationCallback(nil, [self generateResponseWithStatusCode:MSHTTPCodesNo200OK], nil);
       });
 
   // When
@@ -1329,7 +1324,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
       .andDo(^(NSInvocation *invocation) {
         MSHttpRequestCompletionHandler cosmosdbOperationCallback;
         [invocation getArgument:&cosmosdbOperationCallback atIndex:8];
-        cosmosdbOperationCallback(testCosmosDbResponse, nil, nil);
+        cosmosdbOperationCallback(testCosmosDbResponse, [self generateResponseWithStatusCode:MSHTTPCodesNo200OK], nil);
       });
   MSDocumentWrapper *expectedDocumentWrapper = [MSDocumentUtils documentWrapperFromData:testCosmosDbResponse
                                                                            documentType:[MSDictionaryDocument class]];
@@ -1393,7 +1388,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
       .andDo(^(NSInvocation *invocation) {
         MSHttpRequestCompletionHandler cosmosdbOperationCallback;
         [invocation getArgument:&cosmosdbOperationCallback atIndex:8];
-        cosmosdbOperationCallback(jsonFixture, nil, nil);
+        cosmosdbOperationCallback(jsonFixture, [self generateResponseWithStatusCode:MSHTTPCodesNo200OK], nil);
       });
 
   // When
@@ -1492,4 +1487,10 @@ static NSString *const kMSDocumentIdTest = @"documentId";
   return testToken;
 }
 
+- (NSHTTPURLResponse *)generateResponseWithStatusCode:(NSInteger)statusCode {
+  return [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"https://contoso.com"]
+                                     statusCode:statusCode
+                                    HTTPVersion:nil
+                                   headerFields:nil];
+}
 @end

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
@@ -556,7 +556,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                 }];
 
   // Then
-  [self waitForExpectationsWithTimeout:100
+  [self waitForExpectationsWithTimeout:1
                                handler:^(NSError *error) {
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you add unit tests?
* [X] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

HTTP request to Cosmos DB returns an error code without an error object which causes unexpected process in Data module. Add code to instantiate an error object with details in this case.
