### PR TITLE
Adding uriEncoding for CosmosDB calls.

### DIFF
--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
@@ -44,7 +44,7 @@ static NSString *const kMSDocumentDbAuthorizationHeaderFormat = @"type=master&ve
 /**
  * Url character set to skip(utf8 encoding).
  */
-static NSString *const kMSUrlCharactersToEscape = @"!*'();:@&=+$,/?%#[]";
+static NSString *const kMSUrlCharactersToEscape = @"!*'();:@&=+$,/?%#[] ";
 
 /**
  * RFC1123 locale.

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
@@ -116,9 +116,9 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
 + (NSString *)documentBaseUrlWithDatabaseName:(NSString *)databaseName
                                collectionName:(NSString *)collectionName
                                    documentId:(NSString *)documentId {
-  NSString *dbUrlSuffix = [NSString stringWithFormat:kMSDocumentDbDatabaseUrlSuffix, databaseName];
-  NSString *dbCollectionUrlSuffix = [NSString stringWithFormat:kMSDocumentDbCollectionUrlSuffix, collectionName];
-  NSString *dbDocumentId = documentId ? [NSString stringWithFormat:@"/%@", documentId] : @"";
+  NSString *dbUrlSuffix = [NSString stringWithFormat:kMSDocumentDbDatabaseUrlSuffix, encodeUrl:databaseName];
+  NSString *dbCollectionUrlSuffix = [NSString stringWithFormat:kMSDocumentDbCollectionUrlSuffix, encodeUrl:collectionName];
+  NSString *dbDocumentId = documentId ? [NSString stringWithFormat:@"/%@", encodeUrl:documentId] : @"";
   return [NSString stringWithFormat:@"%@/%@/%@%@", dbUrlSuffix, dbCollectionUrlSuffix, kMSDocumentDbDocumentUrlPrefix, dbDocumentId];
 }
 

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
@@ -116,9 +116,9 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
 + (NSString *)documentBaseUrlWithDatabaseName:(NSString *)databaseName
                                collectionName:(NSString *)collectionName
                                    documentId:(NSString *)documentId {
-  NSString *dbUrlSuffix = [NSString stringWithFormat:kMSDocumentDbDatabaseUrlSuffix, encodeUrl:databaseName];
-  NSString *dbCollectionUrlSuffix = [NSString stringWithFormat:kMSDocumentDbCollectionUrlSuffix, encodeUrl:collectionName];
-  NSString *dbDocumentId = documentId ? [NSString stringWithFormat:@"/%@", encodeUrl:documentId] : @"";
+  NSString *dbUrlSuffix = [NSString stringWithFormat:kMSDocumentDbDatabaseUrlSuffix, [MSCosmosDb encodeUrl:databaseName]];
+  NSString *dbCollectionUrlSuffix = [NSString stringWithFormat:kMSDocumentDbCollectionUrlSuffix, [MSCosmosDb encodeUrl:collectionName]];
+  NSString *dbDocumentId = documentId ? [NSString stringWithFormat:@"/%@", [MSCosmosDb encodeUrl:documentId]] : @"";
   return [NSString stringWithFormat:@"%@/%@/%@%@", dbUrlSuffix, dbCollectionUrlSuffix, kMSDocumentDbDocumentUrlPrefix, dbDocumentId];
 }
 

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
@@ -71,7 +71,7 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
 
 @implementation MSCosmosDb : NSObject
 
-+ (NSString *)encodeUrl:(NSString *_Nullable)string {
++ (NSString *)encodeUrl:(NSString *)string {
   NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:kMSUrlCharactersToEscape] invertedSet];
   return (NSString *)[string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }
@@ -118,7 +118,7 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
                                    documentId:(NSString *_Nullable)documentId {
   NSString *dbUrlSuffix = [NSString stringWithFormat:kMSDocumentDbDatabaseUrlSuffix, [MSCosmosDb encodeUrl:databaseName]];
   NSString *dbCollectionUrlSuffix = [NSString stringWithFormat:kMSDocumentDbCollectionUrlSuffix, [MSCosmosDb encodeUrl:collectionName]];
-  NSString *dbDocumentId = documentId ? [NSString stringWithFormat:@"/%@", [MSCosmosDb encodeUrl:documentId]] : @"";
+  NSString *dbDocumentId = documentId ? [NSString stringWithFormat:@"/%@", [MSCosmosDb encodeUrl:(NSString *)documentId]] : @"";
   return [NSString stringWithFormat:@"%@/%@/%@%@", dbUrlSuffix, dbCollectionUrlSuffix, kMSDocumentDbDocumentUrlPrefix, dbDocumentId];
 }
 

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSCosmosDb.m
@@ -71,7 +71,7 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
 
 @implementation MSCosmosDb : NSObject
 
-+ (NSString *)encodeUrl:(NSString *)string {
++ (NSString *)encodeUrl:(NSString *_Nullable)string {
   NSCharacterSet *allowedCharacters = [[NSCharacterSet characterSetWithCharactersInString:kMSUrlCharactersToEscape] invertedSet];
   return (NSString *)[string stringByAddingPercentEncodingWithAllowedCharacters:allowedCharacters];
 }

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
@@ -437,6 +437,22 @@ static NSString *const kMSDocumentIdTest = @"documentId";
   XCTAssertTrue([testResult containsString:kMSDbCollectionNameTest]);
 }
 
+- (void)testDocumentUrlWithUnecnodedDocumentId {
+
+  // If
+  MSTokenResult *tokenResult = [[MSTokenResult alloc] initWithDictionary:[self prepareMutableDictionary]];
+
+  // When
+  NSString *testDocumentUnencoded = @"Test Document";
+  NSString *testDocumentEncoded = @"Test%20Document";
+  NSString *testResult = [MSCosmosDb documentUrlWithTokenResult:tokenResult documentId:testDocumentUnencoded];
+
+  // Then
+  XCTAssertNotNil(testResult);
+  XCTAssertFalse([testResult containsString:testDocumentUnencoded]);
+  XCTAssertTrue([testResult containsString:testDocumentEncoded]);
+}
+
 - (void)testPerformCosmosDbAsyncOperationWithHttpClientWithAdditionalParams {
 
   // If


### PR DESCRIPTION
Following scenario test fails:
1. Create a document with document id that contains spaces (e.g. "Test Document").
2. Retrieve all documents (Storage.list) - make sure the new document is present and its id is "Test Document"
3. Call Storage.read with that document id results in 400 error.

The issue is that we construct DocumentDB Uri without escaping strings that can contain unencoded URI values (e.g. spaces or slashes). 


Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

A few sentences describing the overall goals of the pull request.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
