### PR TITLE
Fix unit tests for MSCrashesTests under Xcode 10.2

### DIFF
--- a/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTestUtil.m
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTestUtil.m
@@ -24,13 +24,15 @@
 + (BOOL)copyFixtureCrashReportWithFileName:(NSString *)filename {
   NSFileManager *fm = [[NSFileManager alloc] init];
 
-  // the bundle identifier when running with unit tests is "otest"
-  const char *progName = getprogname();
-  if (progName == NULL) {
-    return NO;
+  NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+  if (!bundleIdentifier) {
+    const char *progname = getprogname();
+    if (progname == NULL) {
+      return NO;
+    }
+    bundleIdentifier = [NSString stringWithUTF8String: progname];
   }
 
-  NSString *bundleIdentifierPathString = [NSString stringWithUTF8String:progName];
   NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
 
   // create the PLCR cache dir
@@ -38,7 +40,7 @@
   if (![MSCrashesTestUtil createTempDirectory:plcrRootCrashesDir])
     return NO;
 
-  NSString *plcrCrashesDir = [plcrRootCrashesDir stringByAppendingPathComponent:bundleIdentifierPathString];
+  NSString *plcrCrashesDir = [plcrRootCrashesDir stringByAppendingPathComponent:bundleIdentifier];
   if (![MSCrashesTestUtil createTempDirectory:plcrCrashesDir])
     return NO;
 


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

It looks like the main bundle id isn't empty anymore here.

## Related PRs or issues

[AB#60103](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/60103)