### PR TITLE
Don't store a document with pending operation after a remote call

### DIFF
--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSDataOperationProxy.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSDataOperationProxy.m
@@ -76,7 +76,8 @@
               currentCachedDocument:cachedDocument
                   newCachedDocument:remoteDocument
                    deviceTimeToLive:deviceTimeToLive
-                          operation:operation];
+                          // For online scenarios, the intended pending operation in the local store is nil.
+                          operation:nil];
         }
         completionHandler(remoteDocument);
       });

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDataOperationProxyTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDataOperationProxyTests.m
@@ -122,7 +122,7 @@
   __block MSTokensResponse *tokensResponse = [[MSTokensResponse alloc] initWithTokens:@[ token ]];
 
   // When
-  [self.sut performOperation:kMSPendingOperationRead
+  [self.sut performOperation:kMSPendingOperationDelete
       documentId:@"documentId"
       documentType:[NSString class]
       document:nil
@@ -147,7 +147,7 @@
                                  XCTAssertEqual(wrapper, remoteDocumentWrapper);
                                  OCMVerify([self.documentStoreMock upsertWithToken:token
                                                                    documentWrapper:remoteDocumentWrapper
-                                                                         operation:kMSPendingOperationRead
+                                                                         operation:nil
                                                                   deviceTimeToLive:kMSDataStoreTimeToLiveDefault]);
                                }];
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

After a remote call, we were updating the local store with a document with a pending operation (for non-read operations).

This was an incorrect behavior, that was preventing consecutive remote calls to happen.

Fixed the behavior and a unit test that should have caught the issue (but was not because it was performing a read).

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
