### PR TITLE
Fix infinite recursion in Storage.replace call

### DIFF
--- a/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.m
@@ -158,7 +158,7 @@ static dispatch_once_t onceToken;
                     document:(id<MSSerializableDocument>)document
                 writeOptions:(MSWriteOptions *_Nullable)writeOptions
            completionHandler:(MSDocumentWrapperCompletionHandler)completionHandler {
-  [self replaceWithPartition:partition
+  [[MSDataStore sharedInstance] replaceWithPartition:partition
                   documentId:documentId
                     document:document
                 writeOptions:writeOptions

--- a/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.m
@@ -159,10 +159,10 @@ static dispatch_once_t onceToken;
                 writeOptions:(MSWriteOptions *_Nullable)writeOptions
            completionHandler:(MSDocumentWrapperCompletionHandler)completionHandler {
   [[MSDataStore sharedInstance] replaceWithPartition:partition
-                  documentId:documentId
-                    document:document
-                writeOptions:writeOptions
-           completionHandler:completionHandler];
+                                          documentId:documentId
+                                            document:document
+                                        writeOptions:writeOptions
+                                   completionHandler:completionHandler];
 }
 
 + (void)deleteWithPartition:(NSString *)partition

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
@@ -300,7 +300,6 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                }];
 }
 
-
 - (void)testReplaceWhenDataModuleDisabled {
 
   // If

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDataStoreTests.m
@@ -243,6 +243,64 @@ static NSString *const kMSDocumentIdTest = @"documentId";
   XCTAssertEqualObjects(actualDocumentWrapper.documentId, kMSDocumentIdTest);
 }
 
+- (void)testReplaceWithPartitionGoldenPath {
+  
+  // If
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Replace with partition completed"];
+  id<MSSerializableDocument> mockSerializableDocument = [MSFakeSerializableDocument new];
+  __block BOOL completionHandlerCalled = NO;
+  __block MSDocumentWrapper *actualDocumentWrapper;
+  MSTokenResult *testToken = [self mockTokenFetchingWithError:nil];
+  
+  // Mock CosmosDB requests.
+  NSData *testCosmosDbResponse = [self jsonFixture:@"validTestDocument"];
+  OCMStub([self.cosmosDbMock performCosmosDbAsyncOperationWithHttpClient:OCMOCK_ANY
+                                                             tokenResult:testToken
+                                                              documentId:kMSDocumentIdTest
+                                                              httpMethod:kMSHttpMethodPost
+                                                                document:mockSerializableDocument
+                                                       additionalHeaders:OCMOCK_ANY
+                                                       additionalUrlPath:OCMOCK_ANY
+                                                       completionHandler:OCMOCK_ANY])
+      .andDo(^(NSInvocation *invocation) {
+        MSHttpRequestCompletionHandler cosmosdbOperationCallback;
+        [invocation getArgument:&cosmosdbOperationCallback atIndex:9];
+        cosmosdbOperationCallback(testCosmosDbResponse, [self generateResponseWithStatusCode:MSHTTPCodesNo200OK], nil);
+      });
+
+  // When
+  [MSDataStore createWithPartition:kMSPartitionTest
+                        documentId:kMSDocumentIdTest
+                          document:mockSerializableDocument
+                 completionHandler:^(MSDocumentWrapper *data) {
+                   completionHandlerCalled = YES;
+                   actualDocumentWrapper = data;
+                   [expectation fulfill];
+                 }];
+  id<MSSerializableDocument> replaceMockSerializableDocument = [MSFakeSerializableDocument new];
+  [MSDataStore replaceWithPartition:kMSPartitionTest
+                         documentId:kMSDocumentIdTest
+                           document:replaceMockSerializableDocument
+                  completionHandler:^(MSDocumentWrapper *data) {
+                    completionHandlerCalled = YES;
+                    actualDocumentWrapper = data;
+                    [expectation fulfill];
+                  }];
+
+  // Then
+  [self waitForExpectationsWithTimeout:1
+                               handler:^(NSError *error) {
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                                 XCTAssertTrue(completionHandlerCalled);
+                                 XCTAssertNotNil(actualDocumentWrapper.deserializedValue);
+                                 XCTAssertTrue([[actualDocumentWrapper documentId] isEqualToString:@"standalonedocument1"]);
+                                 XCTAssertTrue([[actualDocumentWrapper partition] isEqualToString:@"readonly"]);
+                               }];
+}
+
+
 - (void)testReplaceWhenDataModuleDisabled {
 
   // If


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [X] Did you check UI tests on the sample app? They are not executed on CI.
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

One picture is worth a thousand words...
![image](https://user-images.githubusercontent.com/34677812/56419546-4185f480-62a3-11e9-8ee7-ff792990ec56.png)
