### PR TITLE
Implement fromDeviceCache flag

### DIFF
--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSDataOperationProxy.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Client/MSDataOperationProxy.m
@@ -128,7 +128,8 @@
                                                                                              eTag:cachedDocument.eTag
                                                                                   lastUpdatedDate:cachedDocument.lastUpdatedDate
                                                                                  pendingOperation:operation
-                                                                                            error:nil];
+                                                                                            error:nil
+                                                                                  fromDeviceCache:YES];
 
         // Update local store and return document.
         [self updateLocalStore:token
@@ -167,7 +168,8 @@
                                                                                                       eTag:cachedDocument.eTag
                                                                                            lastUpdatedDate:cachedDocument.lastUpdatedDate
                                                                                           pendingOperation:operation
-                                                                                                     error:nil];
+                                                                                                     error:nil
+                                                                                           fromDeviceCache:YES];
 
         // Update local store and return document.
         [self updateLocalStore:token

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/LocalStore/MSDBDocumentStore.m
@@ -161,7 +161,8 @@ static const NSUInteger kMSSchemaVersion = 1;
                                           lastUpdatedDate:[NSDate dateWithTimeIntervalSince1970:lastUpdatedDate]
                                                 partition:token.partition
                                                documentId:documentId
-                                         pendingOperation:pendingOperation];
+                                         pendingOperation:pendingOperation
+                                          fromDeviceCache:YES];
 }
 
 - (void)deleteAllTables {

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/MSDocumentWrapperInternal.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/MSDocumentWrapperInternal.h
@@ -16,6 +16,7 @@
  * @param lastUpdatedDate Last updated date of the document.
  * @param pendingOperation The name of the pending operation, or nil.
  * @param error An error.
+ * @param fromDeviceCache Flag indicating if the document wrapper was retrieved remotely or not.
  *
  * @return A new `MSDocumentWrapper` instance.
  */
@@ -26,7 +27,8 @@
                                      eTag:(NSString *)eTag
                           lastUpdatedDate:(NSDate *)lastUpdatedDate
                          pendingOperation:(NSString *)pendingOperation
-                                    error:(MSDataSourceError *)error;
+                                    error:(MSDataSourceError *)error
+                          fromDeviceCache:(BOOL)fromDeviceCache;
 
 /**
  * Initialize a `MSDocumentWrapper` instance.

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Util/MSDocumentUtils.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Util/MSDocumentUtils.h
@@ -21,34 +21,33 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSDictionary *)documentPayloadWithDocumentId:(NSString *)documentId partition:(NSString *)partition document:(NSDictionary *)document;
 
 /**
- * Test if a reference is a dictionary that has a key of a given type.
- *
- * @param reference The reference to test.
- * @param key The key to look for in the dictionary reference.
- * @param keyType The expected key type.
- */
-+ (BOOL)isReferenceDictionaryWithKey:(nullable id)reference key:(NSString *)key keyType:(Class)keyType;
-
-/**
  * Deserialize a CosmosDB document from data and return a document wrapper (valid or in an error state).
  *
  * @param data Data from which to create the document wrapper.
  * @param documentType The type of document to instantiate.
+ * @param fromDeviceCache Flag indicating if the document wrapper was retrieved remotely or not.
+ *
  * @return Document wrapper (valid or in an error state).
  */
-+ (MSDocumentWrapper *)documentWrapperFromData:(nullable NSData *)data documentType:(Class)documentType;
++ (MSDocumentWrapper *)documentWrapperFromData:(nullable NSData *)data
+                                  documentType:(Class)documentType
+                               fromDeviceCache:(BOOL)fromDeviceCache;
 
 /**
  * Deserialize a CosmosDB document from a dictionary and return a document wrapper (valid or in an error state).
  *
  * @param object Dictionary (expected) from which to create the document wrapper.
  * @param documentType The type of document to instantiate.
+ * @param fromDeviceCache Flag indicating if the document wrapper was retrieved remotely or not.
+ *
  * @return Document wrapper (valid or in an error state).
  */
-+ (MSDocumentWrapper *)documentWrapperFromDictionary:(NSObject *)object documentType:(Class)documentType;
++ (MSDocumentWrapper *)documentWrapperFromDictionary:(NSObject *)object
+                                        documentType:(Class)documentType
+                                     fromDeviceCache:(BOOL)fromDeviceCache;
 
 /**
- * Deserialize a serializable document from json document data.
+ * Deserialize a document from a byte array representing a JSON object.
  *
  * @param data Data from which to create the document wrapper.
  * @param documentType The type of document to instantiate.
@@ -57,6 +56,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @param partition The partition of the document.
  * @param documentId The DocumentId.
  * @param pendingOperation The pending operation, or nil.
+ * @param fromDeviceCache Flag indicating if the document wrapper was retrieved remotely or not.
+ *
  * @return Document wrapper (valid or in an error state).
  */
 + (MSDocumentWrapper *)documentWrapperFromDocumentData:(nullable NSData *)data
@@ -65,7 +66,8 @@ NS_ASSUME_NONNULL_BEGIN
                                        lastUpdatedDate:(NSDate *)lastUpdatedDate
                                              partition:(NSString *)partition
                                             documentId:(NSString *)documentId
-                                      pendingOperation:(nullable NSString *)pendingOperation;
+                                      pendingOperation:(nullable NSString *)pendingOperation
+                                       fromDeviceCache:(BOOL)fromDeviceCache;
 
 /**
  * Check if a given class type implements the `MSSerializableDocument` protocol.
@@ -75,6 +77,17 @@ NS_ASSUME_NONNULL_BEGIN
  * @return YES if the class type implements `MSSerializableDocument`; NO otherwise.
  */
 + (BOOL)isSerializableDocument:(Class)classType;
+
+/**
+ * Test if a reference is a dictionary that has a key of a given type.
+ *
+ * @param reference The reference to test.
+ * @param key The key to look for in the dictionary reference.
+ * @param keyType The expected key type.
+ *
+ * @return YES if the reference is a dictionary with a key of the given type; NO otherwise.
+ */
++ (BOOL)isReferenceDictionaryWithKey:(nullable id)reference key:(NSString *)key keyType:(Class)keyType;
 
 @end
 

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Util/MSDocumentUtils.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Util/MSDocumentUtils.m
@@ -38,28 +38,15 @@ static NSString *const kMSDocumentKey = @"document";
 
 @implementation MSDocumentUtils
 
+#pragma mark Interface
+
 + (NSDictionary *)documentPayloadWithDocumentId:(NSString *)documentId partition:(NSString *)partition document:(NSDictionary *)document {
   return @{kMSDocument : document, kMSPartitionKey : partition, kMSIdKey : documentId};
 }
 
-+ (BOOL)isReferenceDictionaryWithKey:(nullable id)reference key:(NSString *)key keyType:(Class)keyType {
-
-  // Validate the reference is a dictionary.
-  if (!reference || ![(NSObject *)reference isKindOfClass:[NSDictionary class]]) {
-    return false;
-  }
-
-  // Validate the reference has the expected key.
-  NSObject *keyObject = [(NSDictionary *)reference objectForKey:key];
-  if (!keyObject) {
-    return false;
-  }
-
-  // Validate the key object is of the expected type.
-  return [keyObject isKindOfClass:keyType];
-}
-
-+ (MSDocumentWrapper *)documentWrapperFromData:(nullable NSData *)data documentType:(Class)documentType {
++ (MSDocumentWrapper *)documentWrapperFromData:(nullable NSData *)data
+                                  documentType:(Class)documentType
+                               fromDeviceCache:(BOOL)fromDeviceCache {
 
   // Deserialize data.
   NSError *error;
@@ -80,7 +67,9 @@ static NSString *const kMSDocumentKey = @"document";
   }
 
   // Proceed from the dictionary.
-  return [MSDocumentUtils documentWrapperFromDictionary:(NSDictionary *)dictionary documentType:documentType];
+  return [MSDocumentUtils documentWrapperFromDictionary:(NSDictionary *)dictionary
+                                           documentType:documentType
+                                        fromDeviceCache:fromDeviceCache];
 }
 
 + (MSDocumentWrapper *)documentWrapperFromDocumentData:(nullable NSData *)data
@@ -89,7 +78,8 @@ static NSString *const kMSDocumentKey = @"document";
                                        lastUpdatedDate:(NSDate *)lastUpdatedDate
                                              partition:(NSString *)partition
                                             documentId:(NSString *)documentId
-                                      pendingOperation:(nullable NSString *)pendingOperation {
+                                      pendingOperation:(nullable NSString *)pendingOperation
+                                       fromDeviceCache:(BOOL)fromDeviceCache {
   // Deserialize data.
   NSError *error;
   NSObject *dictionary;
@@ -115,10 +105,13 @@ static NSString *const kMSDocumentKey = @"document";
                              lastUpdatedDate:lastUpdatedDate
                                    partition:partition
                                   documentId:documentId
-                            pendingOperation:pendingOperation];
+                            pendingOperation:pendingOperation
+                             fromDeviceCache:fromDeviceCache];
 }
 
-+ (MSDocumentWrapper *)documentWrapperFromDictionary:(NSObject *)object documentType:(Class)documentType {
++ (MSDocumentWrapper *)documentWrapperFromDictionary:(NSObject *)object
+                                        documentType:(Class)documentType
+                                     fromDeviceCache:(BOOL)fromDeviceCache {
 
   // Extract CosmosDB metadata information (id, date, etag) and partition key.
   if (![MSDocumentUtils isReferenceDictionaryWithKey:object key:kMSDocumentIdKey keyType:[NSString class]] ||
@@ -139,23 +132,47 @@ static NSString *const kMSDocumentKey = @"document";
   NSDate *lastUpdatedDate = [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)dictionary[kMSDocumentTimestampKey] doubleValue]];
   NSString *eTag = dictionary[kMSDocumentEtagKey];
   NSString *partition = dictionary[kMSPartitionKey];
-  return [self documentWrapperFromDictionary:object
+  return [self documentWrapperFromDictionary:dictionary
                                 documentType:documentType
                                         eTag:eTag
                              lastUpdatedDate:lastUpdatedDate
                                    partition:partition
                                   documentId:documentId
-                            pendingOperation:nil];
+                            pendingOperation:nil
+                             fromDeviceCache:fromDeviceCache];
 }
 
-+ (MSDocumentWrapper *)documentWrapperFromDictionary:(NSObject *)object
++ (BOOL)isSerializableDocument:(Class)classType {
+  return class_conformsToProtocol(classType, @protocol(MSSerializableDocument));
+}
+
++ (BOOL)isReferenceDictionaryWithKey:(nullable id)reference key:(NSString *)key keyType:(Class)keyType {
+
+  // Validate the reference is a dictionary.
+  if (!reference || ![(NSObject *)reference isKindOfClass:[NSDictionary class]]) {
+    return false;
+  }
+
+  // Validate the reference has the expected key.
+  NSObject *keyObject = [(NSDictionary *)reference objectForKey:key];
+  if (!keyObject) {
+    return false;
+  }
+
+  // Validate the key object is of the expected type.
+  return [keyObject isKindOfClass:keyType];
+}
+
+#pragma mark Private
+
++ (MSDocumentWrapper *)documentWrapperFromDictionary:(NSDictionary *)dictionary
                                         documentType:(Class)documentType
                                                 eTag:(NSString *)eTag
                                      lastUpdatedDate:(NSDate *)lastUpdatedDate
                                            partition:(NSString *)partition
                                           documentId:(NSString *)documentId
-                                    pendingOperation:(nullable NSString *)pendingOperation {
-  NSDictionary *dictionary = (NSDictionary *)object;
+                                    pendingOperation:(nullable NSString *)pendingOperation
+                                     fromDeviceCache:(BOOL)fromDeviceCache {
 
   // Extract json value.
   NSString *jsonValue;
@@ -191,11 +208,8 @@ static NSString *const kMSDocumentKey = @"document";
                                                          eTag:eTag
                                               lastUpdatedDate:lastUpdatedDate
                                              pendingOperation:pendingOperation
-                                                        error:dataSourceError];
-}
-
-+ (BOOL)isSerializableDocument:(Class)classType {
-  return class_conformsToProtocol(classType, @protocol(MSSerializableDocument));
+                                                        error:dataSourceError
+                                              fromDeviceCache:fromDeviceCache];
 }
 
 @end

--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/Util/MSDocumentUtils.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/Util/MSDocumentUtils.m
@@ -150,13 +150,13 @@ static NSString *const kMSDocumentKey = @"document";
 
   // Validate the reference is a dictionary.
   if (!reference || ![(NSObject *)reference isKindOfClass:[NSDictionary class]]) {
-    return false;
+    return NO;
   }
 
   // Validate the reference has the expected key.
   NSObject *keyObject = [(NSDictionary *)reference objectForKey:key];
   if (!keyObject) {
-    return false;
+    return NO;
   }
 
   // Validate the key object is of the expected type.

--- a/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDataStore.m
@@ -424,7 +424,9 @@ static dispatch_once_t onceToken;
                                   for (id document in jsonPayload[kMSDocumentsKey]) {
 
                                     // Deserialize document.
-                                    [items addObject:[MSDocumentUtils documentWrapperFromDictionary:document documentType:documentType]];
+                                    [items addObject:[MSDocumentUtils documentWrapperFromDictionary:document
+                                                                                       documentType:documentType
+                                                                                    fromDeviceCache:NO]];
                                   }
 
                                   // Instantiate the first page and return it.
@@ -498,7 +500,9 @@ static dispatch_once_t onceToken;
 
                               // (Try to) deserialize the incoming document.
                               else {
-                                completionHandler([MSDocumentUtils documentWrapperFromData:data documentType:documentType]);
+                                completionHandler([MSDocumentUtils documentWrapperFromData:data
+                                                                              documentType:documentType
+                                                                           fromDeviceCache:NO]);
                               }
                             }];
 }
@@ -538,7 +542,9 @@ static dispatch_once_t onceToken;
                               // (Try to) deserialize saved document.
                               else {
                                 MSLogDebug([MSDataStore logTag], @"Document created/replaced with ID: %@", documentId);
-                                completionHandler([MSDocumentUtils documentWrapperFromData:data documentType:[document class]]);
+                                completionHandler([MSDocumentUtils documentWrapperFromData:data
+                                                                              documentType:[document class]
+                                                                           fromDeviceCache:NO]);
                               }
                             }];
 }
@@ -572,7 +578,8 @@ static dispatch_once_t onceToken;
                                                                                                   eTag:nil
                                                                                        lastUpdatedDate:nil
                                                                                       pendingOperation:nil
-                                                                                                 error:nil]);
+                                                                                                 error:nil
+                                                                                       fromDeviceCache:NO]);
                               }
                             }];
 }

--- a/AppCenterDataStorage/AppCenterDataStorage/MSDocumentWrapper.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDocumentWrapper.h
@@ -43,11 +43,8 @@
 @property(nonatomic, strong, readonly) MSDataSourceError *error;
 
 /**
- * Check if the document is from the device cache.
- *
- * @return Flag indicating if the document was retrieved
- * from the device cache instead of from CosmosDB.
+ * Flag indicating if a document was obtained from the local device store/cache (as opposed to remotely by talking to CosmosDB).
  */
-- (BOOL)fromDeviceCache;
+@property(nonatomic, readonly) BOOL fromDeviceCache;
 
 @end

--- a/AppCenterDataStorage/AppCenterDataStorage/MSDocumentWrapper.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDocumentWrapper.h
@@ -43,7 +43,10 @@
 @property(nonatomic, strong, readonly) MSDataSourceError *error;
 
 /**
- * Flag indicating if a document was obtained from the local device store/cache (as opposed to remotely by talking to CosmosDB).
+ * Flag indicating if a document was obtained from the local device store/cache
+ * (as opposed to remotely by talking to CosmosDB).
+ *
+ * Note: The flag is always set to NO if the document is in an error state.
  */
 @property(nonatomic, readonly) BOOL fromDeviceCache;
 

--- a/AppCenterDataStorage/AppCenterDataStorage/MSDocumentWrapper.m
+++ b/AppCenterDataStorage/AppCenterDataStorage/MSDocumentWrapper.m
@@ -11,14 +11,6 @@
 
 @implementation MSDocumentWrapper
 
-@synthesize deserializedValue = _deserializedValue;
-@synthesize jsonValue = _jsonValue;
-@synthesize partition = _partition;
-@synthesize documentId = _documentId;
-@synthesize eTag = _eTag;
-@synthesize lastUpdatedDate = _lastUpdatedDate;
-@synthesize error = _error;
-
 - (instancetype)initWithDeserializedValue:(id<MSSerializableDocument>)deserializedValue
                                 jsonValue:(NSString *)jsonValue
                                 partition:(NSString *)partition
@@ -26,7 +18,8 @@
                                      eTag:(NSString *)eTag
                           lastUpdatedDate:(NSDate *)lastUpdatedDate
                          pendingOperation:(nullable NSString *)pendingOperation
-                                    error:(MSDataSourceError *)error {
+                                    error:(MSDataSourceError *)error
+                          fromDeviceCache:(BOOL)fromDeviceCache {
   if ((self = [super init])) {
     _deserializedValue = deserializedValue;
     _jsonValue = jsonValue;
@@ -36,6 +29,7 @@
     _lastUpdatedDate = lastUpdatedDate;
     _error = error;
     _pendingOperation = pendingOperation;
+    _fromDeviceCache = fromDeviceCache;
   }
   return self;
 }
@@ -53,11 +47,6 @@
                                                         code:errorCode
                                                     userInfo:@{NSLocalizedDescriptionKey : errorMessage}]
                   documentId:documentId];
-}
-
-- (BOOL)fromDeviceCache {
-  // @todo
-  return false;
 }
 
 @end

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDBDocumentStoreTests.m
@@ -116,7 +116,7 @@
   // Then
   XCTAssertNotNil(documentWrapper);
   XCTAssertNotNil(documentWrapper.error);
-  XCTAssertTrue(documentWrapper.fromDeviceCache);
+  XCTAssertFalse(documentWrapper.fromDeviceCache);
   XCTAssertEqualObjects(documentWrapper.documentId, documentId);
 }
 
@@ -417,7 +417,7 @@
   // Then
   XCTAssertTrue(result);
   XCTAssertNotNil(expectedDocumentWrapper.error);
-  XCTAssertFalse(documentWrapper.fromDeviceCache);
+  XCTAssertFalse(expectedDocumentWrapper.fromDeviceCache);
 }
 
 - (void)testDeletionOfAllTables {

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDataOperationProxyTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDataOperationProxyTests.m
@@ -250,7 +250,8 @@
                                                                                                      eTag:nil
                                                                                           lastUpdatedDate:nil
                                                                                          pendingOperation:kMSPendingOperationCreate
-                                                                                                    error:nil];
+                                                                                                    error:nil
+                                                                                          fromDeviceCache:YES];
   __block MSDocumentWrapper *wrapper;
   OCMStub([self.documentStoreMock readWithToken:OCMOCK_ANY documentId:OCMOCK_ANY documentType:OCMOCK_ANY]).andReturn(cachedDocumentWrapper);
   OCMReject([[self.documentStoreMock ignoringNonObjectArgs] upsertWithToken:OCMOCK_ANY
@@ -285,6 +286,8 @@
                                  XCTAssertNotEqual(wrapper, cachedDocumentWrapper);
                                  XCTAssertEqual(wrapper.documentId, cachedDocumentWrapper.documentId);
                                  XCTAssertEqual(wrapper.pendingOperation, kMSPendingOperationDelete);
+                                 XCTAssertTrue(wrapper.fromDeviceCache);
+                                 XCTAssertTrue(wrapper.fromDeviceCache);
                                  OCMVerify([self.documentStoreMock deleteWithToken:token documentId:@"documentId"]);
                                }];
 }
@@ -300,7 +303,8 @@
                                                                                                      eTag:nil
                                                                                           lastUpdatedDate:nil
                                                                                          pendingOperation:kMSPendingOperationReplace
-                                                                                                    error:nil];
+                                                                                                    error:nil
+                                                                                          fromDeviceCache:YES];
   __block MSDocumentWrapper *wrapper;
   OCMStub([self.documentStoreMock readWithToken:OCMOCK_ANY documentId:OCMOCK_ANY documentType:OCMOCK_ANY]).andReturn(cachedDocumentWrapper);
   OCMReject([[self.documentStoreMock ignoringNonObjectArgs] upsertWithToken:OCMOCK_ANY
@@ -335,6 +339,7 @@
                                  XCTAssertNotEqual(wrapper, cachedDocumentWrapper);
                                  XCTAssertEqual(wrapper.documentId, cachedDocumentWrapper.documentId);
                                  XCTAssertEqual(wrapper.pendingOperation, kMSPendingOperationDelete);
+                                 XCTAssertTrue(wrapper.fromDeviceCache);
                                  OCMVerify([self.documentStoreMock deleteWithToken:token documentId:@"documentId"]);
                                }];
 }
@@ -350,7 +355,8 @@
                                                                                                      eTag:@""
                                                                                           lastUpdatedDate:nil
                                                                                          pendingOperation:kMSPendingOperationDelete
-                                                                                                    error:nil];
+                                                                                                    error:nil
+                                                                                          fromDeviceCache:YES];
   __block MSDocumentWrapper *wrapper;
   OCMStub([self.documentStoreMock readWithToken:OCMOCK_ANY documentId:OCMOCK_ANY documentType:OCMOCK_ANY]).andReturn(cachedDocumentWrapper);
   OCMReject([[self.documentStoreMock ignoringNonObjectArgs] upsertWithToken:OCMOCK_ANY
@@ -383,6 +389,7 @@
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }
                                  XCTAssertNotNil(wrapper.error);
+                                 XCTAssertFalse(wrapper.fromDeviceCache); // Error state should not have from device cache set to YES.
                                  XCTAssertEqual(wrapper.error.error.code, MSACDataStoreErrorDocumentNotFound);
                                }];
 }
@@ -398,7 +405,8 @@
                                                                                                      eTag:@""
                                                                                           lastUpdatedDate:nil
                                                                                          pendingOperation:kMSPendingOperationRead
-                                                                                                    error:nil];
+                                                                                                    error:nil
+                                                                                          fromDeviceCache:YES];
   __block MSDocumentWrapper *wrapper;
   OCMStub([self.documentStoreMock readWithToken:OCMOCK_ANY documentId:OCMOCK_ANY documentType:OCMOCK_ANY]).andReturn(cachedDocumentWrapper);
   MSTokenResult *token = [MSTokenResult alloc];
@@ -432,6 +440,7 @@
                                  XCTAssertNotEqual(wrapper, cachedDocumentWrapper);
                                  XCTAssertEqual(wrapper.documentId, cachedDocumentWrapper.documentId);
                                  XCTAssertEqual(wrapper.pendingOperation, kMSPendingOperationDelete);
+                                 XCTAssertTrue(wrapper.fromDeviceCache);
                                  OCMVerify([self.documentStoreMock upsertWithToken:token
                                                                    documentWrapper:wrapper
                                                                          operation:kMSPendingOperationDelete
@@ -450,7 +459,8 @@
                                                                                                      eTag:@""
                                                                                           lastUpdatedDate:nil
                                                                                          pendingOperation:kMSPendingOperationRead
-                                                                                                    error:nil];
+                                                                                                    error:nil
+                                                                                          fromDeviceCache:YES];
   __block MSDocumentWrapper *wrapper;
   OCMStub([self.documentStoreMock readWithToken:OCMOCK_ANY documentId:OCMOCK_ANY documentType:OCMOCK_ANY]).andReturn(cachedDocumentWrapper);
   MSTokenResult *token = [MSTokenResult alloc];
@@ -486,6 +496,7 @@
                                  XCTAssertNotEqual(wrapper, cachedDocumentWrapper);
                                  XCTAssertEqual(wrapper.documentId, cachedDocumentWrapper.documentId);
                                  XCTAssertEqual(wrapper.pendingOperation, kMSPendingOperationCreate);
+                                 XCTAssertTrue(wrapper.fromDeviceCache);
                                  NSDictionary *actualDict = [wrapper.deserializedValue serializeToDictionary];
                                  XCTAssertEqual(actualDict[@"key"], @"value");
                                  OCMVerify([self.documentStoreMock upsertWithToken:token
@@ -506,7 +517,8 @@
                                                                                                      eTag:@""
                                                                                           lastUpdatedDate:nil
                                                                                          pendingOperation:kMSPendingOperationRead
-                                                                                                    error:nil];
+                                                                                                    error:nil
+                                                                                          fromDeviceCache:YES];
   __block MSDocumentWrapper *wrapper;
   OCMStub([self.documentStoreMock readWithToken:OCMOCK_ANY documentId:OCMOCK_ANY documentType:OCMOCK_ANY]).andReturn(cachedDocumentWrapper);
   MSTokenResult *token = [MSTokenResult alloc];
@@ -542,6 +554,7 @@
                                  XCTAssertNotEqual(wrapper, cachedDocumentWrapper);
                                  XCTAssertEqual(wrapper.documentId, cachedDocumentWrapper.documentId);
                                  XCTAssertEqual(wrapper.pendingOperation, kMSPendingOperationReplace);
+                                 XCTAssertTrue(wrapper.fromDeviceCache);
                                  NSDictionary *actualDict = [wrapper.deserializedValue serializeToDictionary];
                                  XCTAssertEqual(actualDict[@"key"], @"value");
                                  OCMVerify([self.documentStoreMock upsertWithToken:token

--- a/AppCenterDataStorage/AppCenterDataStorageTests/MSDocumentUtilsTests.m
+++ b/AppCenterDataStorage/AppCenterDataStorageTests/MSDocumentUtilsTests.m
@@ -71,7 +71,9 @@
   NSString *badReference = @"bad reference";
 
   // When
-  MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromDictionary:badReference documentType:[NSString class]];
+  MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromDictionary:badReference
+                                                                  documentType:[NSString class]
+                                                               fromDeviceCache:NO];
 
   // Then
   XCTAssertNotNil(document);
@@ -82,6 +84,7 @@
   XCTAssertNil([document lastUpdatedDate]);
   XCTAssertNil([document partition]);
   XCTAssertNil([document jsonValue]);
+  XCTAssertFalse([document fromDeviceCache]);
 }
 
 - (void)testDocumentWrapperFromDictionaryWithSystemPropertiesAndPartition {
@@ -94,7 +97,9 @@
   dictionary[@"PartitionKey"] = @"readonly";
 
   // When
-  MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:[NSString class]];
+  MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromDictionary:dictionary
+                                                                  documentType:[NSString class]
+                                                               fromDeviceCache:YES];
 
   // Then
   XCTAssertNotNil(document);
@@ -105,12 +110,13 @@
   XCTAssertNotNil([document lastUpdatedDate]);
   XCTAssertTrue([[document partition] isEqualToString:@"readonly"]);
   XCTAssertNotNil([document jsonValue]);
+  XCTAssertTrue([document fromDeviceCache]);
 
   // If, system property has incorrect type
   dictionary[@"_ts"] = @"some unexpected timestamp";
 
   // When
-  document = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:[NSString class]];
+  document = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:[NSString class] fromDeviceCache:NO];
 
   // Then
   XCTAssertNotNil(document);
@@ -121,6 +127,7 @@
   XCTAssertNil([document lastUpdatedDate]);
   XCTAssertNil([document partition]);
   XCTAssertNil([document jsonValue]);
+  XCTAssertFalse([document fromDeviceCache]);
 }
 
 - (void)testDocumentWrapperFromDictionaryWithDocument {
@@ -134,7 +141,7 @@
   dictionary[@"document"] = @"this should be a dictionary";
 
   // When
-  MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:[NSString class]];
+  MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:[NSString class] fromDeviceCache:NO];
 
   // Then
   XCTAssertNotNil(document);
@@ -145,6 +152,7 @@
   XCTAssertNotNil([document lastUpdatedDate]);
   XCTAssertTrue([[document partition] isEqualToString:@"readonly"]);
   XCTAssertNotNil([document jsonValue]);
+  XCTAssertFalse([document fromDeviceCache]);
 
   // If, document is a dictionary
   dictionary[@"document"] = [NSMutableDictionary new];
@@ -152,7 +160,7 @@
   dictionary[@"document"][@"property2"] = @123;
 
   // When
-  document = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:[MSDictionaryDocument class]];
+  document = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:[MSDictionaryDocument class] fromDeviceCache:NO];
   NSDictionary *resultDictionary = [[document deserializedValue] serializeToDictionary];
 
   // Then
@@ -166,6 +174,7 @@
   XCTAssertNotNil([document lastUpdatedDate]);
   XCTAssertTrue([[document partition] isEqualToString:@"readonly"]);
   XCTAssertNotNil([document jsonValue]);
+  XCTAssertFalse([document fromDeviceCache]);
 }
 
 - (void)testDocumentWrapperFromDataNull {
@@ -174,7 +183,7 @@
   NSData *data;
 
   // When
-  MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromData:data documentType:[NSString class]];
+  MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromData:data documentType:[NSString class] fromDeviceCache:NO];
 
   // Then
   XCTAssertNotNil(document);
@@ -185,6 +194,7 @@
   XCTAssertNil([document lastUpdatedDate]);
   XCTAssertNil([document partition]);
   XCTAssertNil([document jsonValue]);
+  XCTAssertFalse([document fromDeviceCache]);
 }
 
 - (void)testDocumentWrapperFromDataFixture {
@@ -193,7 +203,7 @@
   NSData *data;
 
   // When
-  MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromData:data documentType:[NSString class]];
+  MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromData:data documentType:[NSString class] fromDeviceCache:YES];
 
   // Then
   XCTAssertNotNil(document);
@@ -204,12 +214,13 @@
   XCTAssertNil([document lastUpdatedDate]);
   XCTAssertNil([document partition]);
   XCTAssertNil([document jsonValue]);
+  XCTAssertFalse([document fromDeviceCache]); // An error case does not carry on the fromDeviceCache flag.
 
   // If, data is set to a valid document
   data = [self jsonFixture:@"validTestDocument"];
 
   // When
-  document = [MSDocumentUtils documentWrapperFromData:data documentType:[MSDictionaryDocument class]];
+  document = [MSDocumentUtils documentWrapperFromData:data documentType:[MSDictionaryDocument class] fromDeviceCache:YES];
   NSDictionary *resultDictionary = [[document deserializedValue] serializeToDictionary];
 
   // Then
@@ -223,6 +234,7 @@
   XCTAssertNotNil([document lastUpdatedDate]);
   XCTAssertTrue([[document partition] isEqualToString:@"readonly"]);
   XCTAssertNotNil([document jsonValue]);
+  XCTAssertTrue([document fromDeviceCache]);
 }
 
 - (void)testIsSerializableDocument {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Implement fromDeviceCache flag so a document wrapper (when not in error state) has the flag set to YES/true when no CosmosDB remote operation was performed.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
