### PR TITLE
Fix the default Prod token exchange URL

### DIFF
--- a/AppCenterDataStorage/AppCenterDataStorage/Internal/MSDataStorePrivate.h
+++ b/AppCenterDataStorage/AppCenterDataStorage/Internal/MSDataStorePrivate.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Base URL for HTTP for token exchange.
  */
-static NSString *const kMSDefaultApiUrl = @"https://api.appcenter.ms/v0.1";
+static NSString *const kMSDefaultApiUrl = @"https://tokens.appcenter.ms/v0.1";
 
 @interface MSDataStore () <MSAuthTokenContextDelegate>
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Sasquatch calls `[MSDataStore setTokenExchangeUrl:kMSIntTokenExchangeUrl];` with INT token exchange URL today, hence the incorrect "https://api.appcenter.ms/v0.1" URL is not used.

Let's fix the default token exchange. We can remove the `setTokenExchangeUrl:` call once token exchange is ready in Prod.

Same change as https://github.com/Microsoft/AppCenter-SDK-Android/pull/1096.