### PR TITLE
Refactored the Document Errors

### DIFF
--- a/AppCenterData/AppCenterData/Internal/Client/MSCosmosDb.h
+++ b/AppCenterData/AppCenterData/Internal/Client/MSCosmosDb.h
@@ -8,6 +8,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class MSDataError;
 @class MSSerializableDocument;
 @class MSTokenResult;
 
@@ -47,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A rich error object.
  */
-+ (NSError *)cosmosDbErrorWithResponse:(NSHTTPURLResponse *_Nullable)response underlyingError:(NSError *_Nullable)underlyingError;
++ (MSDataError *)cosmosDbErrorWithResponse:(NSHTTPURLResponse *_Nullable)response underlyingError:(NSError *_Nullable)underlyingError;
 
 @end
 

--- a/AppCenterData/AppCenterData/Internal/Client/MSCosmosDb.m
+++ b/AppCenterData/AppCenterData/Internal/Client/MSCosmosDb.m
@@ -5,6 +5,7 @@
 #import "AppCenter+Internal.h"
 #import "MSConstants+Internal.h"
 #import "MSDataConstants.h"
+#import "MSDataError.h"
 #import "MSDataErrors.h"
 #import "MSDataInternal.h"
 #import "MSDocumentUtils.h"
@@ -184,7 +185,7 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
   [httpClient sendAsync:sendURL method:httpMethod headers:httpHeaders data:body completionHandler:completionHandler];
 }
 
-+ (NSError *)cosmosDbErrorWithResponse:(NSHTTPURLResponse *_Nullable)response underlyingError:(NSError *_Nullable)error {
++ (MSDataError *)cosmosDbErrorWithResponse:(NSHTTPURLResponse *_Nullable)response underlyingError:(NSError *_Nullable)error {
 
   // Prepare user info properties.
   NSMutableDictionary *userInfo = [NSMutableDictionary new];
@@ -201,7 +202,7 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
   }
 
   // Return the error.
-  return [[NSError alloc] initWithDomain:kMSACDataErrorDomain code:MSACDataErrorHTTPError userInfo:userInfo];
+  return [[MSDataError alloc] initWithUserInfo:userInfo code:MSACDataErrorHTTPError];
 }
 
 @end

--- a/AppCenterData/AppCenterData/Internal/Client/MSDataOperationProxy.m
+++ b/AppCenterData/AppCenterData/Internal/Client/MSDataOperationProxy.m
@@ -5,6 +5,7 @@
 
 #import "MSData.h"
 #import "MSDataConstants.h"
+#import "MSDataError.h"
 #import "MSDataErrors.h"
 #import "MSDataInternal.h"
 #import "MSDataOperationProxy.h"
@@ -41,7 +42,8 @@
   if (![MSDataOperationProxy isValidOperation:operation]) {
     NSString *message = @"Operation is not supported";
     MSLogError([MSData logTag], message);
-    completionHandler([[MSDocumentWrapper alloc] initWithErrorCode:MSACDataLocalStoreError errorMessage:message documentId:documentId]);
+    MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil code:MSACDataLocalStoreError message:message];
+    completionHandler([[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId]);
     return;
   }
 
@@ -52,7 +54,8 @@
       NSString *message =
           [NSString stringWithFormat:@"Error while retrieving cached token, aborting operation: %@", [error localizedDescription]];
       MSLogError([MSData logTag], @"%@", message);
-      completionHandler([[MSDocumentWrapper alloc] initWithErrorCode:MSACDataLocalStoreError errorMessage:message documentId:documentId]);
+      MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil code:MSACDataLocalStoreError message:message];
+      completionHandler([[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId]);
       return;
     }
 
@@ -95,9 +98,8 @@
         else if ([kMSPendingOperationDelete isEqualToString:cachedDocument.pendingOperation]) {
           NSString *message = @"Document pending deletion in local storage";
           MSLogError([MSData logTag], message);
-          completionHandler([[MSDocumentWrapper alloc] initWithErrorCode:MSACDataErrorDocumentNotFound
-                                                            errorMessage:message
-                                                              documentId:documentId]);
+          MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil code:MSACDataErrorDocumentNotFound message:message];
+          completionHandler([[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId]);
         }
 
         // Cached document is valid.
@@ -150,7 +152,8 @@
                                          code:MSACDataErrorJSONSerializationFailed
                                      userInfo:@{NSLocalizedDescriptionKey : @"Dictionary contains values that cannot be serialized."}];
           MSLogError([MSData logTag], @"Error serializing document for local storage: %@", [jsonError localizedDescription]);
-          completionHandler([[MSDocumentWrapper alloc] initWithError:jsonError documentId:documentId]);
+          MSDataError *dataError = [[MSDataError alloc] initWithInnerError:jsonError code:0 message:nil];
+          completionHandler([[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId]);
           return;
         }
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&jsonError];
@@ -159,9 +162,8 @@
         } else {
           NSString *message = @"Error serializing document for local storage";
           MSLogError([MSData logTag], message);
-          completionHandler([[MSDocumentWrapper alloc] initWithErrorCode:MSACDataLocalStoreError
-                                                            errorMessage:message
-                                                              documentId:documentId]);
+          MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil code:MSACDataLocalStoreError message:message];
+          completionHandler([[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId]);
           return;
         }
 

--- a/AppCenterData/AppCenterData/Internal/LocalStore/MSDBDocumentStore.m
+++ b/AppCenterData/AppCenterData/Internal/LocalStore/MSDBDocumentStore.m
@@ -10,6 +10,7 @@
 #import "MSDBStoragePrivate.h"
 #import "MSData.h"
 #import "MSDataConstants.h"
+#import "MSDataError.h"
 #import "MSDataErrors.h"
 #import "MSDataInternal.h"
 #import "MSDocumentUtils.h"
@@ -138,10 +139,10 @@ static const NSUInteger kMSSchemaVersion = 1;
     NSString *errorMessage = [NSString
         stringWithFormat:@"Unable to find document in local store for partition '%@' and document ID '%@'", token.partition, documentId];
     MSLogWarning([MSData logTag], @"%@", errorMessage);
-    NSError *error = [[NSError alloc] initWithDomain:kMSACDataErrorDomain
-                                                code:MSACDataErrorDocumentNotFound
-                                            userInfo:@{NSLocalizedDescriptionKey : errorMessage}];
-    return [[MSDocumentWrapper alloc] initWithError:error documentId:documentId];
+
+    // Create error.
+    MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil code:MSACDataErrorDocumentNotFound message:errorMessage];
+    return [[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId];
   }
 
   // If the document is expired, return an error and delete it.
@@ -154,11 +155,11 @@ static const NSUInteger kMSSchemaVersion = 1;
           [NSString stringWithFormat:@"Local document for partition '%@' and document ID '%@' expired at %@, discarding it",
                                      token.partition, documentId, expirationDate];
       MSLogWarning([MSData logTag], @"%@", errorMessage);
-      NSError *error = [[NSError alloc] initWithDomain:kMSACDataErrorDomain
-                                                  code:MSACDataErrorLocalDocumentExpired
-                                              userInfo:@{NSLocalizedDescriptionKey : errorMessage}];
       [self deleteWithToken:token documentId:documentId];
-      return [[MSDocumentWrapper alloc] initWithError:error documentId:documentId];
+
+      // Create error.
+      MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil code:MSACDataErrorLocalDocumentExpired message:errorMessage];
+      return [[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId];
     }
   }
 

--- a/AppCenterData/AppCenterData/Internal/MSDocumentWrapperInternal.h
+++ b/AppCenterData/AppCenterData/Internal/MSDocumentWrapperInternal.h
@@ -38,18 +38,7 @@
  *
  * @return A new `MSDocumentWrapper` instance.
  */
-- (instancetype)initWithError:(NSError *)error documentId:(NSString *)documentId;
-
-/**
- * Initialize a `MSDocumentWrapper` instance.
- *
- * @param errorCode Error code in our module domain.
- * @param errorMessage Error message.
- * @param documentId Document Id.
- *
- * @return A new `MSDocumentWrapper` instance.
- */
-- (instancetype)initWithErrorCode:(NSInteger)errorCode errorMessage:(NSString *)errorMessage documentId:(NSString *)documentId;
+- (instancetype)initWithError:(MSDataError *)error documentId:(NSString *)documentId;
 
 /**
  * The type of pending operation, if any, that must be synchronized.

--- a/AppCenterData/AppCenterData/MSData.m
+++ b/AppCenterData/AppCenterData/MSData.m
@@ -220,14 +220,14 @@ static dispatch_once_t onceToken;
   @synchronized(self) {
 
     // Check preconditions.
-    NSError *error;
+    MSDataError *dataError;
     if (![self canBeUsed] || ![self isEnabled]) {
-      error = [self generateDisabledError:@"read" documentId:documentID];
+      dataError = [self generateDisabledError:@"read" documentId:documentID];
     } else if (![MSDocumentUtils isSerializableDocument:documentType]) {
-      error = [self generateInvalidClassError];
+      dataError = [self generateInvalidClassError];
     }
-    if (error) {
-      completionHandler([[MSDocumentWrapper alloc] initWithError:error documentId:documentID]);
+    if (dataError) {
+      completionHandler([[MSDocumentWrapper alloc] initWithError:dataError documentId:documentID]);
       return;
     }
 
@@ -277,8 +277,8 @@ static dispatch_once_t onceToken;
 
     // Check precondition.
     if (![self canBeUsed] || ![self isEnabled]) {
-      NSError *error = [self generateDisabledError:@"delete" documentId:documentID];
-      completionHandler([[MSDocumentWrapper alloc] initWithError:error documentId:documentID]);
+      MSDataError *dataError = [self generateDisabledError:@"delete" documentId:documentID];
+      completionHandler([[MSDocumentWrapper alloc] initWithError:dataError documentId:documentID]);
       return;
     }
 
@@ -317,8 +317,8 @@ static dispatch_once_t onceToken;
 
     // Check the precondition.
     if (![self canBeUsed] || ![self isEnabled]) {
-      NSError *error = [self generateDisabledError:@"create or replace" documentId:documentID];
-      completionHandler([[MSDocumentWrapper alloc] initWithError:error documentId:documentID]);
+      MSDataError *dataError = [self generateDisabledError:@"create or replace" documentId:documentID];
+      completionHandler([[MSDocumentWrapper alloc] initWithError:dataError documentId:documentID]);
       return;
     }
 
@@ -358,16 +358,14 @@ static dispatch_once_t onceToken;
   @synchronized(self) {
 
     // Check the preconditions.
-    NSError *error;
+    MSDataError *dataError;
     if (![self canBeUsed] || ![self isEnabled]) {
-      error = [self generateDisabledError:@"list" documentId:nil];
+      dataError = [self generateDisabledError:@"list" documentId:nil];
     } else if (![MSDocumentUtils isSerializableDocument:documentType]) {
-      error = [self generateInvalidClassError];
+      dataError = [self generateInvalidClassError];
     }
-    if (error) {
-      completionHandler([[MSPaginatedDocuments alloc] initWithError:[[MSDataError alloc] initWithError:error]
-                                                          partition:partition
-                                                       documentType:documentType]);
+    if (dataError) {
+      completionHandler([[MSPaginatedDocuments alloc] initWithError:dataError partition:partition documentType:documentType]);
       return;
     }
 
@@ -389,13 +387,13 @@ static dispatch_once_t onceToken;
                                                     NSError *_Nullable cosmosDbError) {
                                   // If not OK.
                                   if (response.statusCode != MSHTTPCodesNo200OK) {
-                                    NSError *actualError = [MSCosmosDb cosmosDbErrorWithResponse:response underlyingError:cosmosDbError];
+                                    MSDataError *actualDataError = [MSCosmosDb cosmosDbErrorWithResponse:response
+                                                                                         underlyingError:cosmosDbError];
                                     MSLogError([MSData logTag],
                                                @"Unable to list documents for partition %@: %@. Status code %ld when expecting %ld.",
-                                               partition, [actualError localizedDescription], (long)response.statusCode,
+                                               partition, [actualDataError localizedDescription], (long)response.statusCode,
                                                (long)MSHTTPCodesNo200OK);
-                                    MSDataError *dataCosmosDbError = [[MSDataError alloc] initWithError:actualError];
-                                    MSPaginatedDocuments *documents = [[MSPaginatedDocuments alloc] initWithError:dataCosmosDbError
+                                    MSPaginatedDocuments *documents = [[MSPaginatedDocuments alloc] initWithError:actualDataError
                                                                                                         partition:partition
                                                                                                      documentType:documentType];
                                     completionHandler(documents);
@@ -407,17 +405,17 @@ static dispatch_once_t onceToken;
                                   id jsonPayload = [NSJSONSerialization JSONObjectWithData:(NSData *)data
                                                                                    options:0
                                                                                      error:&deserializeError];
+
+                                  MSDataError *deserializeDataError = nil;
                                   if (!deserializeError && ![MSDocumentUtils isReferenceDictionaryWithKey:jsonPayload
                                                                                                       key:kMSDocumentsKey
                                                                                                   keyType:[NSArray class]]) {
-                                    deserializeError =
-                                        [[NSError alloc] initWithDomain:kMSACDataErrorDomain
-                                                                   code:MSACDataErrorJSONSerializationFailed
-                                                               userInfo:@{NSLocalizedDescriptionKey : @"Can't deserialize documents"}];
+                                    deserializeDataError = [[MSDataError alloc] initWithInnerError:deserializeError
+                                                                                              code:MSACDataErrorJSONSerializationFailed
+                                                                                           message:@"Can't deserialize documents"];
                                   }
-                                  if (deserializeError) {
-                                    MSDataError *dataDeserializeError = [[MSDataError alloc] initWithError:deserializeError];
-                                    MSPaginatedDocuments *documents = [[MSPaginatedDocuments alloc] initWithError:dataDeserializeError
+                                  if (deserializeDataError) {
+                                    MSPaginatedDocuments *documents = [[MSPaginatedDocuments alloc] initWithError:deserializeDataError
                                                                                                         partition:partition
                                                                                                      documentType:documentType];
                                     completionHandler(documents);
@@ -498,11 +496,12 @@ static dispatch_once_t onceToken;
                                                 NSError *_Nullable cosmosDbError) {
                               // If not created.
                               if (response.statusCode != MSHTTPCodesNo200OK) {
-                                NSError *actualError = [MSCosmosDb cosmosDbErrorWithResponse:response underlyingError:cosmosDbError];
+                                MSDataError *actualDataError = [MSCosmosDb cosmosDbErrorWithResponse:response
+                                                                                     underlyingError:cosmosDbError];
                                 MSLogError([MSData logTag],
                                            @"Unable to read document %@ with error: %@. Status code %ld when expecting %ld.", documentId,
-                                           [actualError localizedDescription], (long)response.statusCode, (long)MSHTTPCodesNo200OK);
-                                completionHandler([[MSDocumentWrapper alloc] initWithError:actualError documentId:documentId]);
+                                           [actualDataError localizedDescription], (long)response.statusCode, (long)MSHTTPCodesNo200OK);
+                                completionHandler([[MSDocumentWrapper alloc] initWithError:actualDataError documentId:documentId]);
                               }
 
                               // (Try to) deserialize the incoming document.
@@ -520,23 +519,27 @@ static dispatch_once_t onceToken;
                       additionalHeaders:(NSDictionary *)additionalHeaders
                       completionHandler:(MSDocumentWrapperCompletionHandler)completionHandler {
   // Perform the operation.
-  NSError *serializationError;
   NSDictionary *dic = [MSDocumentUtils documentPayloadWithDocumentId:documentId
                                                            partition:partition
                                                             document:[document serializeToDictionary]];
   if (![NSJSONSerialization isValidJSONObject:dic]) {
-    serializationError =
-        [[NSError alloc] initWithDomain:kMSACDataErrorDomain
-                                   code:MSACDataErrorJSONSerializationFailed
-                               userInfo:@{NSLocalizedDescriptionKey : @"Document dictionary contains values that cannot be serialized."}];
-    MSLogError([MSData logTag], @"Error serializing data: %@", [serializationError localizedDescription]);
-    completionHandler([[MSDocumentWrapper alloc] initWithError:serializationError documentId:documentId]);
+
+    MSDataError *serializationDataError =
+        [[MSDataError alloc] initWithInnerError:nil
+                                           code:MSACDataErrorJSONSerializationFailed
+                                        message:@"Document dictionary contains values that cannot be serialized."];
+    MSLogError([MSData logTag], @"Error serializing data: %@", [serializationDataError localizedDescription]);
+    completionHandler([[MSDocumentWrapper alloc] initWithError:serializationDataError documentId:documentId]);
     return;
   }
+  NSError *serializationError;
   NSData *body = [NSJSONSerialization dataWithJSONObject:dic options:0 error:&serializationError];
   if (!body || serializationError) {
-    MSLogError([MSData logTag], @"Error serializing data: %@", [serializationError localizedDescription]);
-    completionHandler([[MSDocumentWrapper alloc] initWithError:serializationError documentId:documentId]);
+    MSDataError *serializationDataError = [[MSDataError alloc] initWithInnerError:serializationError
+                                                                             code:MSACDataErrorJSONSerializationFailed
+                                                                          message:@"Can't deserialize data."];
+    MSLogError([MSData logTag], @"Error serializing data: %@", [serializationDataError localizedDescription]);
+    completionHandler([[MSDocumentWrapper alloc] initWithError:serializationDataError documentId:documentId]);
     return;
   }
   [self
@@ -550,12 +553,12 @@ static dispatch_once_t onceToken;
                                               NSError *_Nullable cosmosDbError) {
                             // If not created.
                             if (response.statusCode != MSHTTPCodesNo201Created && response.statusCode != MSHTTPCodesNo200OK) {
-                              NSError *actualError = [MSCosmosDb cosmosDbErrorWithResponse:response underlyingError:cosmosDbError];
+                              MSDataError *actualDataError = [MSCosmosDb cosmosDbErrorWithResponse:response underlyingError:cosmosDbError];
                               MSLogError([MSData logTag],
                                          @"Unable to create/replace document %@ with error: %@. Status code %ld when expecting %ld or %ld.",
-                                         documentId, [actualError localizedDescription], (long)response.statusCode,
+                                         documentId, [actualDataError localizedDescription], (long)response.statusCode,
                                          (long)MSHTTPCodesNo200OK, (long)MSHTTPCodesNo201Created);
-                              completionHandler([[MSDocumentWrapper alloc] initWithError:actualError documentId:documentId]);
+                              completionHandler([[MSDocumentWrapper alloc] initWithError:actualDataError documentId:documentId]);
                             }
 
                             // (Try to) deserialize saved document.
@@ -581,11 +584,13 @@ static dispatch_once_t onceToken;
                                                 NSError *_Nullable cosmosDbError) {
                               // If not deleted.
                               if (response.statusCode != MSHTTPCodesNo204NoContent) {
-                                NSError *actualError = [MSCosmosDb cosmosDbErrorWithResponse:response underlyingError:cosmosDbError];
+                                MSDataError *actualDataError = [MSCosmosDb cosmosDbErrorWithResponse:response
+                                                                                     underlyingError:cosmosDbError];
                                 MSLogError([MSData logTag],
                                            @"Unable to delete document %@ with error: %@. Status code %ld when expecting %ld.", documentId,
-                                           [actualError localizedDescription], (long)response.statusCode, (long)MSHTTPCodesNo204NoContent);
-                                completionHandler([[MSDocumentWrapper alloc] initWithError:actualError documentId:documentId]);
+                                           [actualDataError localizedDescription], (long)response.statusCode,
+                                           (long)MSHTTPCodesNo204NoContent);
+                                completionHandler([[MSDocumentWrapper alloc] initWithError:actualDataError documentId:documentId]);
                               }
 
                               // Return a non-error document wrapper object to confirm the operation.
@@ -606,21 +611,21 @@ static dispatch_once_t onceToken;
 
 #pragma mark - MSData error utils
 
-- (NSError *)generateDisabledError:(NSString *)operation documentId:(NSString *_Nullable)documentId {
-  NSError *error = [[NSError alloc] initWithDomain:kMSACErrorDomain
-                                              code:MSACDisabledErrorCode
-                                          userInfo:@{NSLocalizedDescriptionKey : kMSACDisabledErrorDesc}];
+- (MSDataError *)generateDisabledError:(NSString *)operation documentId:(NSString *_Nullable)documentId {
+  MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil
+                                                              code:MSACDisabledErrorCode
+                                                           message:(NSString *)kMSACDisabledErrorDesc];
   MSLogError([MSData logTag], @"Not able to perform %@ operation, document ID: %@; error: %@", operation, documentId,
-             [error localizedDescription]);
-  return error;
+             [dataError localizedDescription]);
+  return dataError;
 }
 
-- (NSError *)generateInvalidClassError {
-  NSError *error = [[NSError alloc] initWithDomain:kMSACDataErrorDomain
-                                              code:MSACDataInvalidClassCode
-                                          userInfo:@{NSLocalizedDescriptionKey : kMSACDataInvalidClassDesc}];
-  MSLogError([MSData logTag], @"Not able to validate document deserialization precondition: %@", [error localizedDescription]);
-  return error;
+- (MSDataError *)generateInvalidClassError {
+  MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil
+                                                              code:MSACDataInvalidClassCode
+                                                           message:(NSString *)kMSACDataInvalidClassDesc];
+  MSLogError([MSData logTag], @"Not able to validate document deserialization precondition: %@", [dataError localizedDescription]);
+  return dataError;
 }
 
 #pragma mark - MSServiceInternal
@@ -840,13 +845,13 @@ static dispatch_once_t onceToken;
                                               expirationTime:operationExpirationTime];
       shouldDeleteLocalCache = NO;
     }
-  } else if (documentWrapper.error.errorCode == MSHTTPCodesNo404NotFound || documentWrapper.error.errorCode == MSHTTPCodesNo409Conflict) {
+  } else if (documentWrapper.error.code == MSHTTPCodesNo404NotFound || documentWrapper.error.code == MSHTTPCodesNo409Conflict) {
     MSLogError([MSData logTag], @"Failed to call Cosmos with operation: %@. Remote operation failed with error code: %ld", pendingOperation,
-               (long)documentWrapper.error.errorCode);
+               (long)documentWrapper.error);
   } else if (documentWrapper.error) {
     shouldDeleteLocalCache = NO;
     MSLogError([MSData logTag], @"Failed to call Cosmos with operation:%@ API: %@", pendingOperation,
-               [documentWrapper.error.error localizedDescription]);
+               [documentWrapper.error localizedDescription]);
   }
 
   // Delete the document form the local cache.

--- a/AppCenterData/AppCenterData/MSDataError.h
+++ b/AppCenterData/AppCenterData/MSDataError.h
@@ -3,34 +3,38 @@
 
 #import <Foundation/Foundation.h>
 
-@interface MSDataError : NSObject
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MSDataError : NSError
 
 /**
- * Document error.
+ * Create a MSDataError object.
+ *
+ * @param innerError Inner error that provides more context about the actual error.
+ * @param code Error code.
+ * @param message Error message.
+ *
+ * @return Instance of error object.
  */
-@property(nonatomic, strong, readonly) NSError *error;
+- (instancetype)initWithInnerError:(NSError *_Nullable)innerError code:(NSInteger)code message:(NSString *_Nullable)message;
 
 /**
- * Error code.
+ * Create a MSDataError object.
+ *
+ * @param userInfo Contains context about the actual error.
+ * @param code Error code.
+ *
+ * @return Instance of error object.
  */
-@property(nonatomic, readonly) NSInteger errorCode;
+- (instancetype)initWithUserInfo:(NSDictionary *)userInfo code:(NSInteger)code;
 
 /**
- * Create an instance with error object.
+ * Get the inner error if exists.
  *
- * @param error An error object.
- *
- * @return A new `MSDataError` instance.
+ * @return The inner error.
  */
-- (instancetype)initWithError:(NSError *)error; // TODO move to internal
-
-/**
- * Extract an error code (HTTP) from any NSError instance.
- *
- * @param error An error object.
- *
- * @return The error code.
- */
-+ (NSInteger)errorCodeFromError:(NSError *)error NS_SWIFT_NAME(errorCode(from:));
+- (NSError *)innerError;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AppCenterData/AppCenterData/MSDataError.m
+++ b/AppCenterData/AppCenterData/MSDataError.m
@@ -2,32 +2,33 @@
 // Licensed under the MIT License.
 
 #import "MSDataError.h"
-#import "MSConstants.h"
-#import "MSDataConstants.h"
 #import "MSDataErrors.h"
 
 @implementation MSDataError
 
-@synthesize error = _error;
-@synthesize errorCode = _errorCode;
+- (instancetype)initWithInnerError:(NSError *_Nullable)innerError code:(NSInteger)code message:(NSString *_Nullable)message {
 
-- (instancetype)initWithError:(NSError *)error {
-  if ((self = [super init])) {
-    _error = error;
-    _errorCode = [MSDataError errorCodeFromError:error];
+  // Prepare user info properties.
+  NSMutableDictionary *userInfo = [NSMutableDictionary new];
+  if (innerError) {
+    [userInfo setValue:innerError forKey:NSUnderlyingErrorKey];
   }
-  return self;
+  if (message) {
+    [userInfo setValue:message forKey:NSLocalizedDescriptionKey];
+  }
+
+  // Return the error.
+  return [super initWithDomain:kMSACDataErrorDomain code:code userInfo:userInfo];
 }
 
-+ (NSInteger)errorCodeFromError:(NSError *)error {
+- (instancetype)initWithUserInfo:(NSDictionary *)userInfo code:(NSInteger)code {
 
-  // Try to extract the error from the user info dictionary.
-  if (error.userInfo[kMSCosmosDbHttpCodeKey]) {
-    return [(NSNumber *)error.userInfo[kMSCosmosDbHttpCodeKey] integerValue];
-  }
+  // Return the error.
+  return [super initWithDomain:kMSACDataErrorDomain code:code userInfo:userInfo];
+}
 
-  // Return default unknown error code.
-  return MSHTTPCodesNo0XXInvalidUnknown;
+- (NSError *)innerError {
+  return self.userInfo ? self.userInfo[NSUnderlyingErrorKey] : nil;
 }
 
 @end

--- a/AppCenterData/AppCenterData/MSDataErrors.h
+++ b/AppCenterData/AppCenterData/MSDataErrors.h
@@ -13,21 +13,16 @@ static NSString *const kMSACDataErrorDomain = MS_APP_CENTER_BASE_DOMAIN @"Data.E
 
 #pragma mark - General
 
-// TODO modernise/harmonize
 // Error codes.
-// FIXME: Re-index these codes (we have our own domain so we can index at 0 and reserve ranges for us).
-NS_ENUM(NSInteger){MSACDataErrorJSONSerializationFailed = -620000,
-                   MSACDataErrorHTTPError = -620001,
-                   MSACDataErrorDocumentNotFound = -620002,
-                   MSACDataErrorLocalDocumentExpired = -620003,
-                   MSACDataNotAuthenticated = -620004,
-                   MSACDataInvalidClassCode = -620005,
-                   MSACDataDontCache = -620006,
-                   MSACDataLocalStoreError = -620007,
-                   MSACDataDocumentIdError = -620008,
-                   MSACDataInvalidPartitionError = -620009,
-                   MSACDataInvalidTokenExchangeResponse = -620010,
-                   MSACDataUnableToGetTokenError = -620011};
+NS_ENUM(NSInteger){// System framework errors.
+                   MSACDataInvalidClassCode = 101, MSACDataErrorJSONSerializationFailed = 102,
+
+                   // Document errors.
+                   MSACDataErrorDocumentNotFound = 200, MSACDataLocalStoreError = 201, MSACDataErrorLocalDocumentExpired = 202,
+                   MSACDataDocumentIdError = 203, MSACDataInvalidPartitionError = 204, MSACDataInvalidTokenExchangeResponse = 205,
+
+                   // Network errors
+                   MSACDataErrorHTTPError = 300, MSACDataUnableToGetTokenError = 301};
 
 // Error descriptions.
 static NSString const *kMSACDataInvalidClassDesc = @"Provided class does not conform to serialization protocol (MSSerializableDocument).";

--- a/AppCenterData/AppCenterData/MSDocumentWrapper.m
+++ b/AppCenterData/AppCenterData/MSDocumentWrapper.m
@@ -34,19 +34,12 @@
   return self;
 }
 
-- (instancetype)initWithError:(NSError *)error documentId:(NSString *)documentId {
+- (instancetype)initWithError:(MSDataError *)error documentId:(NSString *)documentId {
   if ((self = [super init])) {
     _documentId = documentId;
-    _error = [[MSDataError alloc] initWithError:error];
+    _error = error;
   }
   return self;
-}
-
-- (instancetype)initWithErrorCode:(NSInteger)errorCode errorMessage:(NSString *)errorMessage documentId:(NSString *)documentId {
-  return [self initWithError:[[NSError alloc] initWithDomain:kMSACDataErrorDomain
-                                                        code:errorCode
-                                                    userInfo:@{NSLocalizedDescriptionKey : errorMessage}]
-                  documentId:documentId];
 }
 
 @end

--- a/AppCenterData/AppCenterDataTests/MSDBDocumentStoreTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDBDocumentStoreTests.m
@@ -172,8 +172,8 @@
   XCTAssertNotNil(documentWrapper);
   XCTAssertNotNil(documentWrapper.error);
   XCTAssertFalse(documentWrapper.fromDeviceCache);
-  XCTAssertEqualObjects(documentWrapper.error.error.domain, kMSACDataErrorDomain);
-  XCTAssertEqual(documentWrapper.error.error.code, MSACDataErrorLocalDocumentExpired);
+  XCTAssertEqualObjects(documentWrapper.error.domain, kMSACDataErrorDomain);
+  XCTAssertEqual(documentWrapper.error.code, MSACDataErrorLocalDocumentExpired);
   XCTAssertEqualObjects(documentWrapper.documentId, documentId);
   OCMVerify([self.sut deleteWithToken:self.appToken documentId:documentId]);
 }
@@ -193,8 +193,8 @@
   XCTAssertNotNil(documentWrapper);
   XCTAssertNotNil(documentWrapper.error);
   XCTAssertFalse(documentWrapper.fromDeviceCache);
-  XCTAssertEqualObjects(documentWrapper.error.error.domain, kMSACDataErrorDomain);
-  XCTAssertEqual(documentWrapper.error.error.code, MSACDataErrorDocumentNotFound);
+  XCTAssertEqualObjects(documentWrapper.error.domain, kMSACDataErrorDomain);
+  XCTAssertEqual(documentWrapper.error.code, MSACDataErrorDocumentNotFound);
   XCTAssertEqualObjects(documentWrapper.documentId, documentId);
 }
 
@@ -450,9 +450,9 @@
 }
 
 - (void)testNoPendingOperations {
-  
+
   // If DB is empty
-  
+
   // Then
   XCTAssertEqual([[self.sut pendingOperationsWithToken:self.appToken] count], 0);
 }

--- a/AppCenterData/AppCenterDataTests/MSDataErrorTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDataErrorTests.m
@@ -19,14 +19,18 @@
   NSDictionary *userInfo = @{@"MSHttpCodeKey" : @(expectedErrorCode)};
   NSError *error = [NSError errorWithDomain:kMSACErrorDomain code:0 userInfo:userInfo];
   id dataErrorMock = OCMClassMock([MSDataError class]);
+  NSInteger errorCode = 1;
+  NSString *errorMessage = @"A serious error message!";
 
   // When
-  MSDataError *dataError = [[MSDataError alloc] initWithError:error];
+  MSDataError *dataError = [[MSDataError alloc] initWithInnerError:error code:errorCode message:errorMessage];
 
   // Then
-  OCMVerify([dataErrorMock errorCodeFromError:OCMOCK_ANY]);
-  XCTAssertEqual(expectedErrorCode, dataError.errorCode);
-  XCTAssertEqualObjects(error, dataError.error);
+  XCTAssertEqual(errorCode, dataError.code);
+  NSError *innerError = [dataError innerError];
+  XCTAssertNotNil(innerError);
+  XCTAssertTrue([innerError.userInfo[@"MSHttpCodeKey"] integerValue] == expectedErrorCode);
+  XCTAssertEqualObjects(error, dataError.userInfo[NSUnderlyingErrorKey]);
   [dataErrorMock stopMocking];
 }
 
@@ -35,26 +39,12 @@
   // If
   NSInteger expectedErrorCode = MSHTTPCodesNo500InternalServerError;
   NSDictionary *userInfo = @{@"MSHttpCodeKey" : @(expectedErrorCode)};
-  NSError *error = [NSError errorWithDomain:kMSACErrorDomain code:0 userInfo:userInfo];
 
   // When
-  NSInteger actualErrorCode = [MSDataError errorCodeFromError:error];
+  MSDataError *dataError = [[MSDataError alloc] initWithUserInfo:userInfo code:0];
 
   // Then
-  XCTAssertEqual(expectedErrorCode, actualErrorCode);
-}
-
-- (void)testErrorCodeFromErrorReturnsUnknownWhenNoUserInfo {
-
-  // If
-  NSInteger expectedErrorCode = MSHTTPCodesNo0XXInvalidUnknown;
-  NSError *error = [NSError errorWithDomain:kMSACErrorDomain code:0 userInfo:nil];
-
-  // When
-  NSInteger actualErrorCode = [MSDataError errorCodeFromError:error];
-
-  // Then
-  XCTAssertEqual(expectedErrorCode, actualErrorCode);
+  XCTAssertTrue([dataError.userInfo[@"MSHttpCodeKey"] integerValue] == expectedErrorCode);
 }
 
 @end

--- a/AppCenterData/AppCenterDataTests/MSDataOperationProxyTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDataOperationProxyTests.m
@@ -32,7 +32,7 @@
   _documentStoreMock = OCMClassMock([MSDBDocumentStore class]);
   _reachability = OCMPartialMock([MS_Reachability reachabilityForInternetConnection]);
   _sut = [[MSDataOperationProxy alloc] initWithDocumentStore:_documentStoreMock reachability:self.reachability];
-  _dummyError = [NSError errorWithDomain:kMSACDataErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Some dummy error"}];
+  _dummyError = [[MSDataError alloc] initWithInnerError:nil code:-1 message:@"Some dummy error"];
 }
 
 - (void)tearDown {
@@ -72,7 +72,7 @@
                                  XCTAssertEqual(wrapper.documentId, @"documentId");
                                  XCTAssertEqual(wrapper.deserializedValue, nil);
                                  XCTAssertNotNil(wrapper.error);
-                                 XCTAssertEqual(wrapper.error.error.code, MSACDataLocalStoreError);
+                                 XCTAssertEqual(wrapper.error.code, MSACDataLocalStoreError);
                                }];
 }
 
@@ -106,7 +106,7 @@
                                  }
                                  XCTAssertEqual(wrapper.documentId, @"documentId");
                                  XCTAssertEqual(wrapper.deserializedValue, nil);
-                                 XCTAssertEqual(wrapper.error.error.code, MSACDataLocalStoreError);
+                                 XCTAssertEqual(wrapper.error.code, MSACDataLocalStoreError);
                                }];
 }
 
@@ -390,7 +390,7 @@
                                  }
                                  XCTAssertNotNil(wrapper.error);
                                  XCTAssertFalse(wrapper.fromDeviceCache); // Error state should not have from device cache set to YES.
-                                 XCTAssertEqual(wrapper.error.error.code, MSACDataErrorDocumentNotFound);
+                                 XCTAssertEqual(wrapper.error.code, MSACDataErrorDocumentNotFound);
                                }];
 }
 
@@ -614,9 +614,9 @@
                                  }
                                  XCTAssertNotNil(wrapper);
                                  XCTAssertNotNil(wrapper.error);
-                                 XCTAssertNotNil(wrapper.error.error);
-                                 XCTAssertEqual(wrapper.error.error.domain, expectedErrorDomain);
-                                 XCTAssertEqual(wrapper.error.error.code, expectedErrorCode);
+                                 XCTAssertNotNil(wrapper.error);
+                                 XCTAssertEqual(wrapper.error.domain, expectedErrorDomain);
+                                 XCTAssertEqual([wrapper.error innerError].code, expectedErrorCode);
                                  XCTAssertNotEqual(wrapper, cachedDocumentWrapper);
                                  XCTAssertEqual(wrapper.documentId, cachedDocumentWrapper.documentId);
                                }];
@@ -672,9 +672,9 @@
                                  }
                                  XCTAssertNotNil(wrapper);
                                  XCTAssertNotNil(wrapper.error);
-                                 XCTAssertNotNil(wrapper.error.error);
-                                 XCTAssertEqual(wrapper.error.error.domain, expectedErrorDomain);
-                                 XCTAssertEqual(wrapper.error.error.code, expectedErrorCode);
+                                 XCTAssertNotNil(wrapper.error);
+                                 XCTAssertEqual(wrapper.error.domain, expectedErrorDomain);
+                                 XCTAssertEqual([wrapper.error innerError].code, expectedErrorCode);
                                  XCTAssertNotEqual(wrapper, cachedDocumentWrapper);
                                  XCTAssertEqual(wrapper.documentId, cachedDocumentWrapper.documentId);
                                }];

--- a/AppCenterData/AppCenterDataTests/MSDataTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDataTests.m
@@ -159,8 +159,8 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                }];
   XCTAssertNotNil(actualDocumentWrapper);
   XCTAssertNotNil(actualDocumentWrapper.error);
-  XCTAssertEqual(actualDocumentWrapper.error.error.domain, kMSACErrorDomain);
-  XCTAssertEqual(actualDocumentWrapper.error.error.code, MSACDisabledErrorCode);
+  XCTAssertEqual(actualDocumentWrapper.error.domain, kMSACDataErrorDomain);
+  XCTAssertEqual(actualDocumentWrapper.error.code, MSACDisabledErrorCode);
   XCTAssertEqualObjects(actualDocumentWrapper.documentId, kMSDocumentIdTest);
 }
 
@@ -249,8 +249,8 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                }];
   XCTAssertNotNil(actualDocumentWrapper);
   XCTAssertNotNil(actualDocumentWrapper.error);
-  XCTAssertEqual(actualDocumentWrapper.error.error.domain, kMSACDataErrorDomain);
-  XCTAssertEqual(actualDocumentWrapper.error.error.code, MSACDataInvalidClassCode);
+  XCTAssertEqual(actualDocumentWrapper.error.domain, kMSACDataErrorDomain);
+  XCTAssertEqual(actualDocumentWrapper.error.code, MSACDataInvalidClassCode);
   XCTAssertEqualObjects(actualDocumentWrapper.documentId, kMSDocumentIdTest);
 }
 
@@ -281,8 +281,8 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                }];
   XCTAssertNotNil(actualDocumentWrapper);
   XCTAssertNotNil(actualDocumentWrapper.error);
-  XCTAssertEqual(actualDocumentWrapper.error.error.domain, kMSACErrorDomain);
-  XCTAssertEqual(actualDocumentWrapper.error.error.code, MSACDisabledErrorCode);
+  XCTAssertEqual(actualDocumentWrapper.error.domain, kMSACDataErrorDomain);
+  XCTAssertEqual(actualDocumentWrapper.error.code, MSACDisabledErrorCode);
   XCTAssertEqualObjects(actualDocumentWrapper.documentId, kMSDocumentIdTest);
 }
 
@@ -327,7 +327,6 @@ static NSString *const kMSDocumentIdTest = @"documentId";
               completionHandler:^(MSDocumentWrapper *data) {
                 completionHandlerCalled = YES;
                 actualDocumentWrapper = data;
-                [expectation fulfill];
               }];
 
   // Then
@@ -370,8 +369,8 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                }];
   XCTAssertNotNil(actualDocumentWrapper);
   XCTAssertNotNil(actualDocumentWrapper.error);
-  XCTAssertEqual(actualDocumentWrapper.error.error.domain, kMSACErrorDomain);
-  XCTAssertEqual(actualDocumentWrapper.error.error.code, MSACDisabledErrorCode);
+  XCTAssertEqual(actualDocumentWrapper.error.domain, kMSACDataErrorDomain);
+  XCTAssertEqual(actualDocumentWrapper.error.code, MSACDisabledErrorCode);
   XCTAssertEqualObjects(actualDocumentWrapper.documentId, kMSDocumentIdTest);
 }
 
@@ -400,10 +399,9 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                  }
                                }];
   XCTAssertNotNil(actualDataError);
-  XCTAssertNotNil(actualDataError.error);
-  XCTAssertEqual(actualDataError.error.domain, kMSACErrorDomain);
-  XCTAssertEqual(actualDataError.error.code, MSACDisabledErrorCode);
-  XCTAssertEqual(actualDataError.errorCode, MSHTTPCodesNo0XXInvalidUnknown);
+  XCTAssertNotNil(actualDataError);
+  XCTAssertEqual(actualDataError.domain, kMSACDataErrorDomain);
+  XCTAssertEqual(actualDataError.code, MSACDisabledErrorCode);
 }
 
 - (void)testListWhenDataModuleDisabled {
@@ -432,10 +430,9 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                }];
   XCTAssertNotNil(actualPaginatedDocuments);
   XCTAssertNotNil(actualPaginatedDocuments.currentPage.error);
-  XCTAssertNotNil(actualPaginatedDocuments.currentPage.error.error);
-  XCTAssertEqual(actualPaginatedDocuments.currentPage.error.error.domain, kMSACErrorDomain);
-  XCTAssertEqual(actualPaginatedDocuments.currentPage.error.error.code, MSACDisabledErrorCode);
-  XCTAssertEqual(actualPaginatedDocuments.currentPage.error.errorCode, MSHTTPCodesNo0XXInvalidUnknown);
+  XCTAssertNotNil(actualPaginatedDocuments.currentPage.error);
+  XCTAssertEqual(actualPaginatedDocuments.currentPage.error.domain, kMSACDataErrorDomain);
+  XCTAssertEqual(actualPaginatedDocuments.currentPage.error.code, MSACDisabledErrorCode);
 }
 
 - (void)testListWithInvalidDocumentType {
@@ -463,9 +460,9 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                }];
   XCTAssertNotNil(actualPaginatedDocuments);
   XCTAssertNotNil(actualPaginatedDocuments.currentPage.error);
-  XCTAssertNotNil(actualPaginatedDocuments.currentPage.error.error);
-  XCTAssertEqual(actualPaginatedDocuments.currentPage.error.error.domain, kMSACDataErrorDomain);
-  XCTAssertEqual(actualPaginatedDocuments.currentPage.error.error.code, MSACDataInvalidClassCode);
+  XCTAssertNotNil(actualPaginatedDocuments.currentPage.error);
+  XCTAssertEqual(actualPaginatedDocuments.currentPage.error.domain, kMSACDataErrorDomain);
+  XCTAssertEqual(actualPaginatedDocuments.currentPage.error.code, MSACDataInvalidClassCode);
 }
 
 - (void)testDefaultHeaderWithPartitionWithDictionaryNotNull {
@@ -981,8 +978,8 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }
                                  XCTAssertTrue(completionHandlerCalled);
-                                 XCTAssertEqualObjects(actualError.error.domain, kMSACDataErrorDomain);
-                                 XCTAssertEqual(actualError.error.code, MSACDataLocalStoreError);
+                                 XCTAssertEqualObjects(actualError.domain, kMSACDataErrorDomain);
+                                 XCTAssertEqual(actualError.code, MSACDataLocalStoreError);
                                }];
 }
 
@@ -1025,19 +1022,19 @@ static NSString *const kMSDocumentIdTest = @"documentId";
              }];
 
   // Then
-  [self waitForExpectationsWithTimeout:1
-                               handler:^(NSError *error) {
-                                 if (error) {
-                                   XCTFail(@"Expectation Failed with error: %@", error);
-                                 }
-                                 XCTAssertTrue(completionHandlerCalled);
-                                 XCTAssertEqualObjects(actualError.error.domain, kMSACDataErrorDomain);
-                                 XCTAssertEqual(actualError.error.code, MSACDataErrorHTTPError);
-                                 XCTAssertEqualObjects(actualError.error.userInfo[NSUnderlyingErrorKey], expectedCosmosDbError);
-                                 XCTAssertEqualObjects(actualError.error.userInfo[kMSCosmosDbHttpCodeKey],
-                                                       @(MSHTTPCodesNo500InternalServerError));
-                                 XCTAssertEqual(actualError.errorCode, expectedResponseCode);
-                               }];
+  [self
+      waitForExpectationsWithTimeout:1
+                             handler:^(NSError *error) {
+                               if (error) {
+                                 XCTFail(@"Expectation Failed with error: %@", error);
+                               }
+                               XCTAssertTrue(completionHandlerCalled);
+                               XCTAssertEqualObjects(actualError.domain, kMSACDataErrorDomain);
+                               XCTAssertEqual(actualError.code, MSACDataErrorHTTPError);
+                               XCTAssertEqualObjects(actualError.userInfo[NSUnderlyingErrorKey], expectedCosmosDbError);
+                               XCTAssertEqualObjects(actualError.userInfo[kMSCosmosDbHttpCodeKey], @(MSHTTPCodesNo500InternalServerError));
+                               XCTAssertEqual([actualError.userInfo[@"MSHttpCodeKey"] integerValue], expectedResponseCode);
+                             }];
 }
 
 - (void)testCreateWithPartitionWhenSerializationFails {
@@ -1087,9 +1084,9 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                  }
                                  XCTAssertTrue(completionHandlerCalled);
                                  XCTAssertNotNil(actualError);
-                                 XCTAssertNotNil(actualError.error);
-                                 XCTAssertEqual(actualError.error.domain, expectedErrorDomain);
-                                 XCTAssertEqual(actualError.error.code, expectedErrorCode);
+                                 XCTAssertNotNil(actualError);
+                                 XCTAssertEqual(actualError.domain, expectedErrorDomain);
+                                 XCTAssertEqual(actualError.code, expectedErrorCode);
                                }];
 }
 
@@ -1099,7 +1096,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
   XCTestExpectation *expectation = [self expectationWithDescription:@"Create with partition completed"];
   id<MSSerializableDocument> mockSerializableDocument = [[MSDictionaryDocument alloc] initFromDictionary:@{}];
   __block BOOL completionHandlerCalled = NO;
-  NSErrorDomain expectedErrorDomain = NSCocoaErrorDomain;
+  NSErrorDomain expectedErrorDomain = kMSACDataErrorDomain;
   NSInteger expectedErrorCode = 3840;
   __block MSDataError *actualError;
   MSTokenResult *testToken = [self mockTokenFetchingWithError:nil];
@@ -1137,8 +1134,8 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }
                                  XCTAssertTrue(completionHandlerCalled);
-                                 XCTAssertEqual(actualError.error.domain, expectedErrorDomain);
-                                 XCTAssertEqual(actualError.error.code, expectedErrorCode);
+                                 XCTAssertEqual(actualError.domain, expectedErrorDomain);
+                                 XCTAssertEqual([actualError innerError].code, expectedErrorCode);
                                }];
 }
 
@@ -1147,8 +1144,8 @@ static NSString *const kMSDocumentIdTest = @"documentId";
   // If
   XCTestExpectation *expectation = [self expectationWithDescription:@"Delete with partition completed"];
   __block BOOL completionHandlerCalled = NO;
-  NSInteger expectedResponseCode = MSHTTPCodesNo200OK;
-  __block NSInteger actualResponseCode;
+  NSInteger expectedResponseCode = MSHTTPCodesNo204NoContent;
+  __block MSDataError *actualDataError;
   MSTokenResult *testToken = [self mockTokenFetchingWithError:nil];
   OCMStub([self.cosmosDbMock performCosmosDbAsyncOperationWithHttpClient:OCMOCK_ANY
                                                              tokenResult:testToken
@@ -1161,7 +1158,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
       .andDo(^(NSInvocation *invocation) {
         MSHttpRequestCompletionHandler cosmosdbOperationCallback;
         [invocation getArgument:&cosmosdbOperationCallback atIndex:9];
-        cosmosdbOperationCallback(nil, [self generateResponseWithStatusCode:MSHTTPCodesNo200OK], nil);
+        cosmosdbOperationCallback(nil, [self generateResponseWithStatusCode:expectedResponseCode], nil);
       });
 
   // When
@@ -1169,7 +1166,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                      partition:kMSPartitionTest
              completionHandler:^(MSDocumentWrapper *wrapper) {
                completionHandlerCalled = YES;
-               actualResponseCode = wrapper.error.errorCode;
+               actualDataError = wrapper.error;
                [expectation fulfill];
              }];
 
@@ -1180,7 +1177,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }
                                  XCTAssertTrue(completionHandlerCalled);
-                                 XCTAssertEqual(actualResponseCode, expectedResponseCode);
+                                 XCTAssertNil(actualDataError);
                                }];
 }
 
@@ -1209,8 +1206,8 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }
                                  XCTAssertTrue(completionHandlerCalled);
-                                 XCTAssertEqualObjects(actualError.error.domain, kMSACDataErrorDomain);
-                                 XCTAssertEqual(actualError.error.code, MSACDataLocalStoreError);
+                                 XCTAssertEqualObjects(actualError.domain, kMSACDataErrorDomain);
+                                 XCTAssertEqual(actualError.code, MSACDataLocalStoreError);
                                }];
 }
 
@@ -1251,19 +1248,19 @@ static NSString *const kMSDocumentIdTest = @"documentId";
              }];
 
   // Then
-  [self waitForExpectationsWithTimeout:1
-                               handler:^(NSError *error) {
-                                 if (error) {
-                                   XCTFail(@"Expectation Failed with error: %@", error);
-                                 }
-                                 XCTAssertTrue(completionHandlerCalled);
-                                 XCTAssertEqualObjects(actualError.error.domain, kMSACDataErrorDomain);
-                                 XCTAssertEqual(actualError.error.code, MSACDataErrorHTTPError);
-                                 XCTAssertEqualObjects(actualError.error.userInfo[NSUnderlyingErrorKey], expectedCosmosDbError);
-                                 XCTAssertEqualObjects(actualError.error.userInfo[kMSCosmosDbHttpCodeKey],
-                                                       @(MSHTTPCodesNo500InternalServerError));
-                                 XCTAssertEqual(actualError.errorCode, expectedResponseCode);
-                               }];
+  [self
+      waitForExpectationsWithTimeout:1
+                             handler:^(NSError *error) {
+                               if (error) {
+                                 XCTFail(@"Expectation Failed with error: %@", error);
+                               }
+                               XCTAssertTrue(completionHandlerCalled);
+                               XCTAssertEqualObjects(actualError.domain, kMSACDataErrorDomain);
+                               XCTAssertEqual(actualError.code, MSACDataErrorHTTPError);
+                               XCTAssertEqualObjects(actualError.userInfo[NSUnderlyingErrorKey], expectedCosmosDbError);
+                               XCTAssertEqualObjects(actualError.userInfo[kMSCosmosDbHttpCodeKey], @(MSHTTPCodesNo500InternalServerError));
+                               // XCTAssertEqual(actualError.errorCode, expectedResponseCode);
+                             }];
 }
 
 - (void)testSetTokenExchangeUrl {
@@ -1506,8 +1503,8 @@ static NSString *const kMSDocumentIdTest = @"documentId";
            completionHandler:^(MSDocumentWrapper *_Nonnull document) {
              // Then
              XCTAssertNotNil(document.error);
-             XCTAssertEqualObjects(document.error.error.domain, kMSACDataErrorDomain);
-             XCTAssertEqual(document.error.error.code, MSACDataLocalStoreError);
+             XCTAssertEqualObjects(document.error.domain, kMSACDataErrorDomain);
+             XCTAssertEqual(document.error.code, MSACDataLocalStoreError);
              [expectation fulfill];
            }];
 
@@ -1678,8 +1675,8 @@ static NSString *const kMSDocumentIdTest = @"documentId";
            completionHandler:^(MSDocumentWrapper *_Nonnull document) {
              // Then
              XCTAssertNotNil(document.error);
-             XCTAssertEqualObjects(document.error.error.domain, kMSACDataErrorDomain);
-             XCTAssertEqual(document.error.error.code, MSACDataErrorDocumentNotFound);
+             XCTAssertEqualObjects(document.error.domain, kMSACDataErrorDomain);
+             XCTAssertEqual(document.error.code, MSACDataErrorDocumentNotFound);
              [expectation fulfill];
            }];
 
@@ -1835,10 +1832,10 @@ static NSString *const kMSDocumentIdTest = @"documentId";
   self.sut.dataOperationProxy.reachability = reachabilityMock;
 
   // Mock expired document in local storage.
-  NSError *expiredError = [NSError errorWithDomain:kMSACDataErrorDomain code:MSACDataErrorLocalDocumentExpired userInfo:nil];
+  MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil code:MSACDataErrorLocalDocumentExpired message:nil];
   id<MSDocumentStore> localStorageMock = OCMProtocolMock(@protocol(MSDocumentStore));
   self.sut.dataOperationProxy.documentStore = localStorageMock;
-  MSDocumentWrapper *expiredDocument = [[MSDocumentWrapper alloc] initWithError:expiredError documentId:@"4"];
+  MSDocumentWrapper *expiredDocument = [[MSDocumentWrapper alloc] initWithError:dataError documentId:@"4"];
   OCMStub([localStorageMock readWithToken:tokenResult documentId:OCMOCK_ANY documentType:OCMOCK_ANY]).andReturn(expiredDocument);
 
   // When
@@ -1848,8 +1845,8 @@ static NSString *const kMSDocumentIdTest = @"documentId";
            completionHandler:^(MSDocumentWrapper *_Nonnull document) {
              // Then
              XCTAssertNotNil(document.error);
-             XCTAssertEqualObjects(document.error.error.domain, kMSACDataErrorDomain);
-             XCTAssertEqual(document.error.error.code, MSACDataErrorLocalDocumentExpired);
+             XCTAssertEqualObjects(document.error.domain, kMSACDataErrorDomain);
+             XCTAssertEqual(document.error.code, MSACDataErrorLocalDocumentExpired);
              [expectation fulfill];
            }];
 


### PR DESCRIPTION
-Change the MSDataError to inherit from the NSError
-Added contractor to pass an inner error in order to pass/keep the error context

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

-Change the MSDataError to inherit from the NSError
-Added contractor to pass an inner error in order to pass/keep the error context