### PR TITLE
Fix different processing of json values offline and online

### DIFF
--- a/AppCenterData/AppCenterData.xcodeproj/project.pbxproj
+++ b/AppCenterData/AppCenterData.xcodeproj/project.pbxproj
@@ -567,13 +567,13 @@
 			isa = PBXGroup;
 			children = (
 				D3AD5EC41E5C4F6A001627AB /* Info.plist */,
-				04B61DCA2248F518008D0102 /* MSTokenExchangeTests.m */,
-				8F1E76E822652B9D00A6D39F /* MSDataOperationProxyTests.m */,
-				2ACE55FF2245277000FCD5DF /* MSDocumentUtilsTests.m */,
 				2ACE56092245340A00FCD5DF /* MSBaseOptionsTests.m */,
+				8F1E76E822652B9D00A6D39F /* MSDataOperationProxyTests.m */,
 				2ACE562022453BE600FCD5DF /* MSDataErrorTests.m */,
-				4ACEAC9D225418B600976AEA /* MSDBDocumentStoreTests.m */,
 				D3AD5EC21E5C4F6A001627AB /* MSDataTests.m */,
+				4ACEAC9D225418B600976AEA /* MSDBDocumentStoreTests.m */,
+				2ACE55FF2245277000FCD5DF /* MSDocumentUtilsTests.m */,
+				04B61DCA2248F518008D0102 /* MSTokenExchangeTests.m */,
 				4A9C4400223B23E3008548A7 /* MSTokenTests.m */,
 				8F4548E52256D5470021B0BF /* NSObject+MSTestFixture.h */,
 				8F4548E62256D5470021B0BF /* NSObject+MSTestFixture.m */,

--- a/AppCenterData/AppCenterData/Internal/Client/MSDataOperationProxy.m
+++ b/AppCenterData/AppCenterData/Internal/Client/MSDataOperationProxy.m
@@ -144,47 +144,15 @@
 
         // Serialize incoming document into a JSON string.
         NSDictionary *dictionary = [document serializeToDictionary];
-        NSString *jsonDocument;
-        NSError *jsonError;
-        if (![NSJSONSerialization isValidJSONObject:dictionary]) {
-          jsonError =
-              [[NSError alloc] initWithDomain:kMSACDataErrorDomain
-                                         code:MSACDataErrorJSONSerializationFailed
-                                     userInfo:@{NSLocalizedDescriptionKey : @"Dictionary contains values that cannot be serialized."}];
-          MSLogError([MSData logTag], @"Error serializing document for local storage: %@", [jsonError localizedDescription]);
-          MSDataError *dataError = [[MSDataError alloc] initWithInnerError:jsonError code:0 message:nil];
-          completionHandler([[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId]);
-          return;
-        }
-        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&jsonError];
-        if (!error) {
-          jsonDocument = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-        } else {
-          NSString *message = @"Error serializing document for local storage";
-          MSLogError([MSData logTag], message);
-          MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil code:MSACDataLocalStoreError message:message];
-          completionHandler([[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId]);
-          return;
-        }
-
-        // Create a create/replace document record.
-        MSDocumentWrapper *createdOrUpdatedDocument = [[MSDocumentWrapper alloc] initWithDeserializedValue:document
-                                                                                                 jsonValue:jsonDocument
-                                                                                                 partition:token.partition
-                                                                                                documentId:documentId
-                                                                                                      eTag:cachedDocument.eTag
-                                                                                           lastUpdatedDate:cachedDocument.lastUpdatedDate
-                                                                                          pendingOperation:operation
-                                                                                                     error:nil
-                                                                                           fromDeviceCache:YES];
+        MSDocumentWrapper *documentWrapper = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:documentType eTag:cachedDocument.eTag lastUpdatedDate:cachedDocument.lastUpdatedDate partition:token.partition documentId:documentId pendingOperation:operation fromDeviceCache:YES];
 
         // Update local store and return document.
         [self updateLocalStore:token
-            currentCachedDocument:cachedDocument
-                newCachedDocument:createdOrUpdatedDocument
-                 deviceTimeToLive:deviceTimeToLive
-                        operation:operation];
-        completionHandler(createdOrUpdatedDocument);
+         currentCachedDocument:cachedDocument
+             newCachedDocument:documentWrapper
+              deviceTimeToLive:deviceTimeToLive
+                     operation:operation];
+          completionHandler(documentWrapper);
       }
     }
   });

--- a/AppCenterData/AppCenterData/Internal/Client/MSDataOperationProxy.m
+++ b/AppCenterData/AppCenterData/Internal/Client/MSDataOperationProxy.m
@@ -144,15 +144,22 @@
 
         // Serialize incoming document into a JSON string.
         NSDictionary *dictionary = [document serializeToDictionary];
-        MSDocumentWrapper *documentWrapper = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:documentType eTag:cachedDocument.eTag lastUpdatedDate:cachedDocument.lastUpdatedDate partition:token.partition documentId:documentId pendingOperation:operation fromDeviceCache:YES];
+        MSDocumentWrapper *documentWrapper = [MSDocumentUtils documentWrapperFromDictionary:dictionary
+                                                                               documentType:documentType
+                                                                                       eTag:cachedDocument.eTag
+                                                                            lastUpdatedDate:cachedDocument.lastUpdatedDate
+                                                                                  partition:token.partition
+                                                                                 documentId:documentId
+                                                                           pendingOperation:operation
+                                                                            fromDeviceCache:YES];
 
         // Update local store and return document.
         [self updateLocalStore:token
-         currentCachedDocument:cachedDocument
-             newCachedDocument:documentWrapper
-              deviceTimeToLive:deviceTimeToLive
-                     operation:operation];
-          completionHandler(documentWrapper);
+            currentCachedDocument:cachedDocument
+                newCachedDocument:documentWrapper
+                 deviceTimeToLive:deviceTimeToLive
+                        operation:operation];
+        completionHandler(documentWrapper);
       }
     }
   });

--- a/AppCenterData/AppCenterData/Internal/LocalStore/MSDBDocumentStore.m
+++ b/AppCenterData/AppCenterData/Internal/LocalStore/MSDBDocumentStore.m
@@ -236,7 +236,7 @@ static const NSUInteger kMSSchemaVersion = 1;
       continue;
     }
 
-    // Convert documetn json string to dictionary.
+    // Convert document json string to dictionary.
     NSString *documetnJsonString = row[self.documentColumnIndex];
     NSData *data = [documetnJsonString dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *documentDictionary = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];

--- a/AppCenterData/AppCenterData/Internal/Util/MSDocumentUtils.h
+++ b/AppCenterData/AppCenterData/Internal/Util/MSDocumentUtils.h
@@ -70,6 +70,28 @@ NS_ASSUME_NONNULL_BEGIN
                                        fromDeviceCache:(BOOL)fromDeviceCache;
 
 /**
+ * Deserialize a document dictionary that contains no metadata.
+ *
+ * @param dictionary Dictionary from which to create the document wrapper.
+ * @param documentType The type of document to instantiate.
+ * @param eTag The eTag for the document.
+ * @param lastUpdatedDate The last time the document was updated.
+ * @param partition The partition of the document.
+ * @param documentId The DocumentId.
+ * @param pendingOperation The pending operation, or nil.
+ * @param fromDeviceCache Flag indicating if the document wrapper was retrieved remotely or not.
+ *
+ * @return Document wrapper (valid or in an error state).
+ */
++ (MSDocumentWrapper *)documentWrapperFromDictionary:(NSDictionary *)dictionary
+                                        documentType:(Class)documentType
+                                                eTag:(NSString *)eTag
+                                     lastUpdatedDate:(NSDate *)lastUpdatedDate
+                                           partition:(NSString *)partition
+                                          documentId:(NSString *)documentId
+                                    pendingOperation:(nullable NSString *)pendingOperation
+                                     fromDeviceCache:(BOOL)fromDeviceCache;
+/**
  * Check if a given class type implements the `MSSerializableDocument` protocol.
  *
  * @param classType The type to check.

--- a/AppCenterData/AppCenterData/Internal/Util/MSDocumentUtils.m
+++ b/AppCenterData/AppCenterData/Internal/Util/MSDocumentUtils.m
@@ -170,7 +170,7 @@ static NSString *const kMSDocumentKey = @"document";
   NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&serializationError];
   if (serializationError) {
     NSString *errorMessage = @"Document could not be serialized.";
-    MSDataError *dataError = [[MSDataError alloc] initWithInnerError:serializationError code:MSACDataErrorJSONSerializationFailed message:errorMessage];
+    MSDataError *dataError = [[MSDataError alloc] initWithErrorCode:MSACDataErrorJSONSerializationFailed innerError:serializationError message:errorMessage];
     MSLogError([MSData logTag], errorMessage);
     return [[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId];
   }

--- a/AppCenterData/AppCenterData/Internal/Util/MSDocumentUtils.m
+++ b/AppCenterData/AppCenterData/Internal/Util/MSDocumentUtils.m
@@ -121,7 +121,8 @@ static NSString *const kMSDocumentKey = @"document";
   if (![MSDocumentUtils isReferenceDictionaryWithKey:object key:kMSDocumentIdKey keyType:[NSString class]] ||
       ![MSDocumentUtils isReferenceDictionaryWithKey:object key:kMSDocumentTimestampKey keyType:[NSNumber class]] ||
       ![MSDocumentUtils isReferenceDictionaryWithKey:object key:kMSDocumentEtagKey keyType:[NSString class]] ||
-      ![MSDocumentUtils isReferenceDictionaryWithKey:object key:kMSPartitionKey keyType:[NSString class]]) {
+      ![MSDocumentUtils isReferenceDictionaryWithKey:object key:kMSPartitionKey keyType:[NSString class]] ||
+      ![MSDocumentUtils isReferenceDictionaryWithKey:object key:kMSDocumentKey keyType:[NSDictionary class]]) {
 
     // Prepare and return error.
     NSString *errorMessage = @"Can't deserialize document (missing system properties or partition key)";
@@ -134,7 +135,7 @@ static NSString *const kMSDocumentKey = @"document";
   NSDate *lastUpdatedDate = [NSDate dateWithTimeIntervalSince1970:[(NSNumber *)dictionary[kMSDocumentTimestampKey] doubleValue]];
   NSString *eTag = dictionary[kMSDocumentEtagKey];
   NSString *partition = dictionary[kMSPartitionKey];
-  return [self documentWrapperFromDictionary:dictionary
+  return [self documentWrapperFromDictionary:(NSDictionary *)dictionary[kMSDocumentKey]
                                 documentType:documentType
                                         eTag:eTag
                              lastUpdatedDate:lastUpdatedDate
@@ -142,6 +143,52 @@ static NSString *const kMSDocumentKey = @"document";
                                   documentId:documentId
                             pendingOperation:nil
                              fromDeviceCache:fromDeviceCache];
+}
+
++ (MSDocumentWrapper *)documentWrapperFromDictionary:(NSDictionary *)dictionary
+                                        documentType:(Class)documentType
+                                                eTag:(NSString *)eTag
+                                     lastUpdatedDate:(NSDate *)lastUpdatedDate
+                                           partition:(NSString *)partition
+                                          documentId:(NSString *)documentId
+                                    pendingOperation:(nullable NSString *)pendingOperation
+                                     fromDeviceCache:(BOOL)fromDeviceCache {
+
+  // Validate dictionary
+  if (![NSJSONSerialization isValidJSONObject:dictionary]) {
+    NSString *errorMessage = @"Dictionary cannot be processed as JSON.";
+    MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil code:MSACDataErrorJSONSerializationFailed message:errorMessage];
+    MSLogError([MSData logTag], errorMessage);
+    return [[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId];
+  }
+
+  // Serialize dictionary intermediate to JSON string.
+  NSError *serializationError;
+  NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&serializationError];
+  if (serializationError) {
+    NSString *errorMessage = @"Document could not be serialized.";
+    MSDataError *dataError = [[MSDataError alloc] initWithInnerError:serializationError code:MSACDataErrorJSONSerializationFailed message:errorMessage];
+    MSLogError([MSData logTag], errorMessage);
+    return [[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId];
+  }
+
+  // Extract json value.
+  NSString *jsonValue = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+
+  // Deserialize document.
+  id<MSSerializableDocument> deserializedValue = [(id<MSSerializableDocument>)[documentType alloc] initFromDictionary:dictionary];
+  MSLogDebug([MSData logTag], @"Successfully deserialized document: %@ (partition: %@)", documentId, partition);
+
+  // Return document wrapper.
+  return [[MSDocumentWrapper alloc] initWithDeserializedValue:deserializedValue
+                                                    jsonValue:jsonValue
+                                                    partition:partition
+                                                   documentId:documentId
+                                                         eTag:eTag
+                                              lastUpdatedDate:lastUpdatedDate
+                                             pendingOperation:pendingOperation
+                                                        error:nil
+                                              fromDeviceCache:fromDeviceCache];
 }
 
 + (BOOL)isSerializableDocument:(Class)classType {
@@ -167,64 +214,6 @@ static NSString *const kMSDocumentKey = @"document";
 
 + (NSString *)outgoingOperationIdWithPartition:(NSString *)partition documentId:(NSString *)documentId {
   return [NSString stringWithFormat:@"%@_%@", partition, documentId];
-}
-
-#pragma mark Private
-
-+ (MSDocumentWrapper *)documentWrapperFromDictionary:(NSDictionary *)dictionary
-                                        documentType:(Class)documentType
-                                                eTag:(NSString *)eTag
-                                     lastUpdatedDate:(NSDate *)lastUpdatedDate
-                                           partition:(NSString *)partition
-                                          documentId:(NSString *)documentId
-                                    pendingOperation:(nullable NSString *)pendingOperation
-                                     fromDeviceCache:(BOOL)fromDeviceCache {
-
-  // Extract json value.
-  NSString *jsonValue;
-  NSError *error;
-
-  // Validate dictionary
-  if (![NSJSONSerialization isValidJSONObject:dictionary]) {
-
-    NSString *errorMessage = @"Dictionary contains values that cannot be serialized.";
-    MSDataError *dataError = [[MSDataError alloc] initWithInnerError:nil code:MSACDataErrorJSONSerializationFailed message:errorMessage];
-    MSLogError([MSData logTag], @"Error deserializing data: %@", [dataError localizedDescription]);
-    return [[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId];
-  }
-
-  NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&error];
-  if (!error) {
-    jsonValue = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-  }
-
-  // Deserialize document.
-  MSDataError *dataError = nil;
-  id<MSSerializableDocument> deserializedValue;
-  if (!error && ![MSDocumentUtils isReferenceDictionaryWithKey:dictionary key:kMSDocumentKey keyType:[NSDictionary class]]) {
-
-    dataError = [[MSDataError alloc] initWithInnerError:error
-                                                   code:MSACDataErrorJSONSerializationFailed
-                                                message:@"Can't deserialize document (missing document property)"];
-    MSLogError([MSData logTag], @"Error deserializing data: %@", [dataError localizedDescription]);
-  }
-
-  // If no serialization error.
-  if (!dataError) {
-    deserializedValue = [(id<MSSerializableDocument>)[documentType alloc] initFromDictionary:(NSDictionary *)dictionary[kMSDocumentKey]];
-    MSLogDebug([MSData logTag], @"Successfully deserialized document: %@ (partition: %@)", documentId, partition);
-  }
-
-  // Return document wrapper.
-  return [[MSDocumentWrapper alloc] initWithDeserializedValue:deserializedValue
-                                                    jsonValue:jsonValue
-                                                    partition:partition
-                                                   documentId:documentId
-                                                         eTag:eTag
-                                              lastUpdatedDate:lastUpdatedDate
-                                             pendingOperation:pendingOperation
-                                                        error:dataError
-                                              fromDeviceCache:fromDeviceCache];
 }
 
 @end

--- a/AppCenterData/AppCenterData/Internal/Util/MSDocumentUtils.m
+++ b/AppCenterData/AppCenterData/Internal/Util/MSDocumentUtils.m
@@ -157,9 +157,12 @@ static NSString *const kMSDocumentKey = @"document";
 
   // Validate dictionary
   if (![NSJSONSerialization isValidJSONObject:dictionary]) {
-    NSString *errorMessage = @"Dictionary cannot be processed as JSON.";
+    NSString *errorMessage = @"Dictionary contains values that cannot be processed as JSON.";
+    NSError *jsonError = [[NSError alloc] initWithDomain:kMSACDataErrorDomain
+                                                    code:MSACDataErrorJSONSerializationFailed
+                                                userInfo:@{NSLocalizedDescriptionKey : errorMessage}];
     MSDataError *dataError = [[MSDataError alloc] initWithErrorCode:MSACDataErrorJSONSerializationFailed
-                                                         innerError:nil
+                                                         innerError:jsonError
                                                             message:errorMessage];
     MSLogError([MSData logTag], errorMessage);
     return [[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId];
@@ -170,7 +173,9 @@ static NSString *const kMSDocumentKey = @"document";
   NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&serializationError];
   if (serializationError) {
     NSString *errorMessage = @"Document could not be serialized.";
-    MSDataError *dataError = [[MSDataError alloc] initWithErrorCode:MSACDataErrorJSONSerializationFailed innerError:serializationError message:errorMessage];
+    MSDataError *dataError = [[MSDataError alloc] initWithErrorCode:MSACDataErrorJSONSerializationFailed
+                                                         innerError:serializationError
+                                                            message:errorMessage];
     MSLogError([MSData logTag], errorMessage);
     return [[MSDocumentWrapper alloc] initWithError:dataError documentId:documentId];
   }

--- a/AppCenterData/AppCenterData/Internal/Util/MSDocumentUtils.m
+++ b/AppCenterData/AppCenterData/Internal/Util/MSDocumentUtils.m
@@ -158,7 +158,7 @@ static NSString *const kMSDocumentKey = @"document";
   id<MSSerializableDocument> deserializedValue;
   NSString *jsonValue = [self jsonValueForDictionary:dictionary dataError:&dataError];
   if (jsonValue) {
-    
+
     // Deserialize document.
     deserializedValue = [(id<MSSerializableDocument>)[documentType alloc] initFromDictionary:dictionary];
     MSLogDebug([MSData logTag], @"Successfully deserialized document: %@ (partition: %@)", documentId, partition);
@@ -174,29 +174,27 @@ static NSString *const kMSDocumentKey = @"document";
                                               fromDeviceCache:fromDeviceCache];
 }
 
-+ (NSString *)jsonValueForDictionary:(NSDictionary *)dictionary dataError:(MSDataError * __autoreleasing *)dataError {
-  
++ (NSString *)jsonValueForDictionary:(NSDictionary *)dictionary dataError:(MSDataError *__autoreleasing *)dataError {
+
   // Validate dictionary
   if (![NSJSONSerialization isValidJSONObject:dictionary]) {
     NSString *errorMessage = @"Dictionary contains values that cannot be processed as JSON.";
     NSError *jsonError = [[NSError alloc] initWithDomain:kMSACDataErrorDomain
                                                     code:MSACDataErrorJSONSerializationFailed
                                                 userInfo:@{NSLocalizedDescriptionKey : errorMessage}];
-    *dataError = [[MSDataError alloc] initWithErrorCode:MSACDataErrorJSONSerializationFailed
-                                            innerError:jsonError
-                                               message:errorMessage];
+    *dataError = [[MSDataError alloc] initWithErrorCode:MSACDataErrorJSONSerializationFailed innerError:jsonError message:errorMessage];
     MSLogError([MSData logTag], errorMessage);
     return nil;
   }
-  
+
   // Serialize dictionary intermediate to JSON string.
   NSError *serializationError;
   NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&serializationError];
   if (serializationError) {
     NSString *errorMessage = @"Document could not be serialized.";
     *dataError = [[MSDataError alloc] initWithErrorCode:MSACDataErrorJSONSerializationFailed
-                                            innerError:serializationError
-                                               message:errorMessage];
+                                             innerError:serializationError
+                                                message:errorMessage];
     MSLogError([MSData logTag], errorMessage);
     return nil;
   }

--- a/AppCenterData/AppCenterDataTests/MSDBDocumentStoreTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDBDocumentStoreTests.m
@@ -73,7 +73,7 @@
   // If
   NSString *documentId = @"12829";
   NSString *eTag = @"398";
-  NSString *jsonString = @"{ \"document\": {\"key\": \"value\"}}";
+  NSString *jsonString = @"{\"key\": \"value\"}";
   NSString *pendingOperation = kMSPendingOperationReplace;
   [self addJsonStringToTable:jsonString
                         eTag:eTag
@@ -129,7 +129,7 @@
   // If
   NSString *documentId = @"12829";
   NSString *eTag = @"398";
-  NSString *jsonString = @"{ \"document\": {\"key\": \"value\"}}";
+  NSString *jsonString = @"{\"key\": \"value\"}";
   [self addJsonStringToTable:jsonString
                         eTag:eTag
                    partition:self.appToken.partition
@@ -155,7 +155,7 @@
   // If
   NSString *documentId = @"12829";
   NSString *eTag = @"398";
-  NSString *jsonString = @"{ \"document\": {\"key\": \"value\"}}";
+  NSString *jsonString = @"{\"key\": \"value\"}";
   [self addJsonStringToTable:jsonString
                         eTag:eTag
                    partition:self.appToken.partition
@@ -462,7 +462,7 @@
   // If
   NSString *documentId1 = @"doc_id_1";
   NSString *eTag = @"123456789";
-  NSString *jsonString = @"{ \"document\": {\"key\": \"value\"}}";
+  NSString *jsonString = @"{\"key\": \"value\"}";
   NSString *pendingOperation = kMSPendingOperationReplace;
   [self addJsonStringToTable:jsonString
                         eTag:eTag

--- a/AppCenterData/AppCenterDataTests/MSDataOperationProxyTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDataOperationProxyTests.m
@@ -474,7 +474,7 @@
   dict[@"key"] = @"value";
   [self.sut performOperation:kMSPendingOperationCreate
       documentId:@"documentId"
-      documentType:[NSString class]
+      documentType:[MSDictionaryDocument class]
       document:[[MSDictionaryDocument alloc] initFromDictionary:dict]
       baseOptions:nil
       cachedTokenBlock:^(MSCachedTokenCompletionHandler _Nonnull handler) {
@@ -532,7 +532,7 @@
   dict[@"key"] = @"value";
   [self.sut performOperation:kMSPendingOperationReplace
       documentId:@"documentId"
-      documentType:[NSString class]
+      documentType:[MSDictionaryDocument class]
       document:[[MSDictionaryDocument alloc] initFromDictionary:dict]
       baseOptions:nil
       cachedTokenBlock:^(MSCachedTokenCompletionHandler _Nonnull handler) {
@@ -593,7 +593,7 @@
   dict[@"shouldFail"] = [NSSet set];
   [self.sut performOperation:kMSPendingOperationCreate
       documentId:@"documentId"
-      documentType:[NSString class]
+      documentType:[MSDictionaryDocument class]
       document:[[MSDictionaryDocument alloc] initFromDictionary:dict]
       baseOptions:nil
       cachedTokenBlock:^(MSCachedTokenCompletionHandler _Nonnull handler) {
@@ -613,7 +613,6 @@
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }
                                  XCTAssertNotNil(wrapper);
-                                 XCTAssertNotNil(wrapper.error);
                                  XCTAssertNotNil(wrapper.error);
                                  XCTAssertEqual(wrapper.error.domain, expectedErrorDomain);
                                  XCTAssertEqual([wrapper.error innerError].code, expectedErrorCode);
@@ -651,7 +650,7 @@
   dict[@"shouldFail"] = [NSSet set];
   [self.sut performOperation:kMSPendingOperationReplace
       documentId:@"documentId"
-      documentType:[NSString class]
+      documentType:[MSDictionaryDocument class]
       document:[[MSDictionaryDocument alloc] initFromDictionary:dict]
       baseOptions:nil
       cachedTokenBlock:^(MSCachedTokenCompletionHandler _Nonnull handler) {

--- a/AppCenterData/AppCenterDataTests/MSDataTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDataTests.m
@@ -1568,6 +1568,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                  }
                                }];
 }
+
 - (void)testReadsFromLocalStorageWhenOnlineIfCreatePendingOperation {
 
   // If

--- a/AppCenterData/AppCenterDataTests/MSDocumentUtilsTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDocumentUtilsTests.m
@@ -88,49 +88,6 @@
   XCTAssertFalse([document fromDeviceCache]);
 }
 
-- (void)testDocumentWrapperFromDictionaryWithSystemPropertiesAndPartition {
-
-  // If
-  NSMutableDictionary *dictionary = [NSMutableDictionary new];
-  dictionary[@"id"] = @"document-id";
-  dictionary[@"_etag"] = @"etag";
-  dictionary[@"_ts"] = @0;
-  dictionary[@"PartitionKey"] = @"readonly";
-
-  // When
-  MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromDictionary:dictionary
-                                                                  documentType:[NSString class]
-                                                               fromDeviceCache:YES];
-
-  // Then
-  XCTAssertNotNil(document);
-  XCTAssertNotNil([document error]);
-  XCTAssertTrue([[document documentId] isEqualToString:@"document-id"]);
-  XCTAssertNil([document deserializedValue]);
-  XCTAssertTrue([[document eTag] isEqualToString:@"etag"]);
-  XCTAssertNotNil([document lastUpdatedDate]);
-  XCTAssertTrue([[document partition] isEqualToString:@"readonly"]);
-  XCTAssertNil([document jsonValue]);
-  XCTAssertTrue([document fromDeviceCache]);
-
-  // If, system property has incorrect type
-  dictionary[@"_ts"] = @"some unexpected timestamp";
-
-  // When
-  document = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:[NSString class] fromDeviceCache:NO];
-
-  // Then
-  XCTAssertNotNil(document);
-  XCTAssertNotNil([document error]);
-  XCTAssertNil([document documentId]);
-  XCTAssertNil([document deserializedValue]);
-  XCTAssertNil([document eTag]);
-  XCTAssertNil([document lastUpdatedDate]);
-  XCTAssertNil([document partition]);
-  XCTAssertNil([document jsonValue]);
-  XCTAssertFalse([document fromDeviceCache]);
-}
-
 - (void)testDocumentWrapperFromDictionaryWithDocument {
 
   // If
@@ -139,7 +96,9 @@
   dictionary[@"_etag"] = @"etag";
   dictionary[@"_ts"] = @0;
   dictionary[@"PartitionKey"] = @"readonly";
-  dictionary[@"document"] = @"this should be a dictionary";
+  
+  // Invalid JSON
+  dictionary[@"document"] = @{@"key":[NSDate new]};
 
   // When
   MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:[NSString class] fromDeviceCache:NO];

--- a/AppCenterData/AppCenterDataTests/MSDocumentUtilsTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDocumentUtilsTests.m
@@ -96,9 +96,9 @@
   dictionary[@"_etag"] = @"etag";
   dictionary[@"_ts"] = @0;
   dictionary[@"PartitionKey"] = @"readonly";
-  
+
   // Invalid JSON
-  dictionary[@"document"] = @{@"key":[NSDate new]};
+  dictionary[@"document"] = @{@"key" : [NSDate new]};
 
   // When
   MSDocumentWrapper *document = [MSDocumentUtils documentWrapperFromDictionary:dictionary documentType:[NSString class] fromDeviceCache:NO];

--- a/AppCenterData/AppCenterDataTests/MSDocumentUtilsTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDocumentUtilsTests.m
@@ -110,7 +110,7 @@
   XCTAssertTrue([[document eTag] isEqualToString:@"etag"]);
   XCTAssertNotNil([document lastUpdatedDate]);
   XCTAssertTrue([[document partition] isEqualToString:@"readonly"]);
-  XCTAssertNotNil([document jsonValue]);
+  XCTAssertNil([document jsonValue]);
   XCTAssertTrue([document fromDeviceCache]);
 
   // If, system property has incorrect type
@@ -152,7 +152,7 @@
   XCTAssertTrue([[document eTag] isEqualToString:@"etag"]);
   XCTAssertNotNil([document lastUpdatedDate]);
   XCTAssertTrue([[document partition] isEqualToString:@"readonly"]);
-  XCTAssertNotNil([document jsonValue]);
+  XCTAssertNil([document jsonValue]);
   XCTAssertFalse([document fromDeviceCache]);
 
   // If, document is a dictionary


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fixes for #60954 and #60953 where json was inconsistent between offline and online scenarios.
The json value must always be customer content in sqlite and in memory objects.