### PR TITLE
Reference MSUserInformationh in Auth Module

### DIFF
--- a/AppCenter.xcworkspace/contents.xcworkspacedata
+++ b/AppCenter.xcworkspace/contents.xcworkspacedata
@@ -189,6 +189,9 @@
       location = "group:AppCenter/AppCenter.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:AppCenterAuth/AppCenterAuth.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:AppCenterAnalytics/AppCenterAnalytics.xcodeproj">
    </FileRef>
    <FileRef
@@ -199,9 +202,6 @@
    </FileRef>
    <FileRef
       location = "group:AppCenterDistribute/AppCenterDistribute.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:AppCenterAuth/AppCenterAuth.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:AppCenterPush/AppCenterPush.xcodeproj">

--- a/AppCenterAuth/AppCenterAuth.xcodeproj/project.pbxproj
+++ b/AppCenterAuth/AppCenterAuth.xcodeproj/project.pbxproj
@@ -109,7 +109,7 @@
 		38F796D421F93ED6007E7C15 /* MSAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 38F796D121F93ED6007E7C15 /* MSAuthority.m */; };
 		38F796D521F93ED6007E7C15 /* MSAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 38F796D121F93ED6007E7C15 /* MSAuthority.m */; };
 		60F5B6CE2277E36C00D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */;  settings = {ATTRIBUTES = (Public, ); }; };
-		60F5B6CF2277E38700D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */; };
+		60F5B6CF2277E38700D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */;  settings = {ATTRIBUTES = (Public, ); };};
 		6E0684381D35A3B900A8CC6C /* OCHamcrestIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E0684371D35A3B900A8CC6C /* OCHamcrestIOS.framework */; };
 		995BA5D321EFEF6D000E3212 /* AppCenter+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */; };
 		995BA5D421EFEF6D000E3212 /* AppCenter+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */; };

--- a/AppCenterAuth/AppCenterAuth.xcodeproj/project.pbxproj
+++ b/AppCenterAuth/AppCenterAuth.xcodeproj/project.pbxproj
@@ -109,7 +109,7 @@
 		38F796D421F93ED6007E7C15 /* MSAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 38F796D121F93ED6007E7C15 /* MSAuthority.m */; };
 		38F796D521F93ED6007E7C15 /* MSAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 38F796D121F93ED6007E7C15 /* MSAuthority.m */; };
 		60F5B6CE2277E36C00D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */;  settings = {ATTRIBUTES = (Public, ); }; };
-		60F5B6CF2277E38700D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */;  settings = {ATTRIBUTES = (Public, ); };};
+		60F5B6CF2277E38700D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */;  settings = {ATTRIBUTES = (Public, ); }; };
 		6E0684381D35A3B900A8CC6C /* OCHamcrestIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E0684371D35A3B900A8CC6C /* OCHamcrestIOS.framework */; };
 		995BA5D321EFEF6D000E3212 /* AppCenter+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */; };
 		995BA5D421EFEF6D000E3212 /* AppCenter+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */; };
@@ -807,7 +807,6 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);

--- a/AppCenterAuth/AppCenterAuth.xcodeproj/project.pbxproj
+++ b/AppCenterAuth/AppCenterAuth.xcodeproj/project.pbxproj
@@ -108,8 +108,8 @@
 		38F796D321F93ED6007E7C15 /* MSAuthority.h in Headers */ = {isa = PBXBuildFile; fileRef = 38F796D021F93ED6007E7C15 /* MSAuthority.h */; };
 		38F796D421F93ED6007E7C15 /* MSAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 38F796D121F93ED6007E7C15 /* MSAuthority.m */; };
 		38F796D521F93ED6007E7C15 /* MSAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 38F796D121F93ED6007E7C15 /* MSAuthority.m */; };
-		60F5B6CE2277E36C00D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */;  settings = {ATTRIBUTES = (Public, ); }; };
-		60F5B6CF2277E38700D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */;  settings = {ATTRIBUTES = (Public, ); }; };
+		60F5B6CE2277E36C00D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		60F5B6CF2277E38700D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6E0684381D35A3B900A8CC6C /* OCHamcrestIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E0684371D35A3B900A8CC6C /* OCHamcrestIOS.framework */; };
 		995BA5D321EFEF6D000E3212 /* AppCenter+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */; };
 		995BA5D421EFEF6D000E3212 /* AppCenter+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */; };
@@ -602,10 +602,10 @@
 		E85547B71D2D6253002DF6E2 = {
 			isa = PBXGroup;
 			children = (
-				60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */,
 				04B1C8CB2252AF2300CBD876 /* MSAppCenterErrors.h */,
 				04A082051F74BB8600DC776D /* MSService.h */,
 				387C77041D6CC39400D68CC1 /* MSServiceAbstract.h */,
+				60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */,
 				E85547C21D2D6253002DF6E2 /* AppCenterAuth */,
 				E85547D61D2D6723002DF6E2 /* AppCenterAuthTests */,
 				04E96C40226A50A6007E6DD1 /* MSAL */,

--- a/AppCenterAuth/AppCenterAuth.xcodeproj/project.pbxproj
+++ b/AppCenterAuth/AppCenterAuth.xcodeproj/project.pbxproj
@@ -108,7 +108,7 @@
 		38F796D321F93ED6007E7C15 /* MSAuthority.h in Headers */ = {isa = PBXBuildFile; fileRef = 38F796D021F93ED6007E7C15 /* MSAuthority.h */; };
 		38F796D421F93ED6007E7C15 /* MSAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 38F796D121F93ED6007E7C15 /* MSAuthority.m */; };
 		38F796D521F93ED6007E7C15 /* MSAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 38F796D121F93ED6007E7C15 /* MSAuthority.m */; };
-		60F5B6CE2277E36C00D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */; };
+		60F5B6CE2277E36C00D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */;  settings = {ATTRIBUTES = (Public, ); }; };
 		60F5B6CF2277E38700D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */; };
 		6E0684381D35A3B900A8CC6C /* OCHamcrestIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E0684371D35A3B900A8CC6C /* OCHamcrestIOS.framework */; };
 		995BA5D321EFEF6D000E3212 /* AppCenter+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */; };

--- a/AppCenterAuth/AppCenterAuth.xcodeproj/project.pbxproj
+++ b/AppCenterAuth/AppCenterAuth.xcodeproj/project.pbxproj
@@ -108,6 +108,8 @@
 		38F796D321F93ED6007E7C15 /* MSAuthority.h in Headers */ = {isa = PBXBuildFile; fileRef = 38F796D021F93ED6007E7C15 /* MSAuthority.h */; };
 		38F796D421F93ED6007E7C15 /* MSAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 38F796D121F93ED6007E7C15 /* MSAuthority.m */; };
 		38F796D521F93ED6007E7C15 /* MSAuthority.m in Sources */ = {isa = PBXBuildFile; fileRef = 38F796D121F93ED6007E7C15 /* MSAuthority.m */; };
+		60F5B6CE2277E36C00D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */; };
+		60F5B6CF2277E38700D42DA0 /* MSUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */; };
 		6E0684381D35A3B900A8CC6C /* OCHamcrestIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E0684371D35A3B900A8CC6C /* OCHamcrestIOS.framework */; };
 		995BA5D321EFEF6D000E3212 /* AppCenter+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */; };
 		995BA5D421EFEF6D000E3212 /* AppCenter+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */; };
@@ -336,6 +338,7 @@
 		38F796CB21F93E33007E7C15 /* MSAuthConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSAuthConfig.m; sourceTree = "<group>"; };
 		38F796D021F93ED6007E7C15 /* MSAuthority.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSAuthority.h; sourceTree = "<group>"; };
 		38F796D121F93ED6007E7C15 /* MSAuthority.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSAuthority.m; sourceTree = "<group>"; };
+		60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MSUserInformation.h; path = ../AppCenter/AppCenter/MSUserInformation.h; sourceTree = "<group>"; };
 		6E0684371D35A3B900A8CC6C /* OCHamcrestIOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OCHamcrestIOS.framework; path = ../../Vendor/iOS/OCHamcrest/OCHamcrestIOS.framework; sourceTree = "<group>"; };
 		995BA5D221EFEF6D000E3212 /* AppCenter+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "AppCenter+Internal.h"; path = "../../../AppCenter/AppCenter/Internals/AppCenter+Internal.h"; sourceTree = "<group>"; };
 		995BA5DB21EFF414000E3212 /* MSAuthPrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSAuthPrivate.h; sourceTree = "<group>"; };
@@ -599,6 +602,7 @@
 		E85547B71D2D6253002DF6E2 = {
 			isa = PBXGroup;
 			children = (
+				60F5B6C32277E36C00D42DA0 /* MSUserInformation.h */,
 				04B1C8CB2252AF2300CBD876 /* MSAppCenterErrors.h */,
 				04A082051F74BB8600DC776D /* MSService.h */,
 				387C77041D6CC39400D68CC1 /* MSServiceAbstract.h */,
@@ -670,6 +674,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				60F5B6CF2277E38700D42DA0 /* MSUserInformation.h in Headers */,
 				995BA5DD21EFF414000E3212 /* MSAuthPrivate.h in Headers */,
 				995BA5D421EFEF6D000E3212 /* AppCenter+Internal.h in Headers */,
 				35BCB33C22382EA300E948A4 /* MSAuthConstants.h in Headers */,
@@ -691,6 +696,7 @@
 			files = (
 				04B1C8CC2252AF2300CBD876 /* MSAppCenterErrors.h in Headers */,
 				995BA5DC21EFF414000E3212 /* MSAuthPrivate.h in Headers */,
+				60F5B6CE2277E36C00D42DA0 /* MSUserInformation.h in Headers */,
 				995BA5D321EFEF6D000E3212 /* AppCenter+Internal.h in Headers */,
 				35BCB33B22382EA100E948A4 /* MSAuthConstants.h in Headers */,
 				B2B25644220B365A00716D6A /* MSAuthAppDelegate.h in Headers */,
@@ -801,6 +807,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);

--- a/AppCenterAuth/AppCenterAuth/AppCenterAuth.h
+++ b/AppCenterAuth/AppCenterAuth/AppCenterAuth.h
@@ -5,3 +5,4 @@
 
 #import "MSAuth.h"
 #import "MSAuthErrors.h"
+#import "MSUserInformation.h"


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
The `MSUserInformation.h` header is in core but used in the Auth module by the SignIn API. The problem is because it's not imported by the Auth module itself the customer have to also import the Core module. It's not straightforward because there is no message/error mentioning the missing import. 

-- Import the MSUserInformation.h header to the Auth project as a reference
-- Add an import line in AppCenterAuth.h to import this header

## Related PRs or issues



## Misc

