### PR TITLE
Refresh token after coming back online

### DIFF
--- a/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
+++ b/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
@@ -96,7 +96,7 @@ typedef void (^MSAcquireTokenCompletionHandler)(MSUserInformation *_Nullable use
 /**
  * Perform sign in with completion handler.
  */
-- (void)signInInWithCompletionHandler:(MSSignInCompletionHandler _Nullable)completionHandler;
+- (void)signInWithCompletionHandler:(MSSignInCompletionHandler _Nullable)completionHandler;
 
 /**
  * Refreshes token for given accountId.

--- a/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
+++ b/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
@@ -47,6 +47,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property(atomic, nullable) MSSignInCompletionHandler signInCompletionHandler;
 
 /**
+ * The flag indicates whether sign-in is already in progress.
+ */
+@property BOOL signInInProgress;
+
+/**
+ * The flag indicates whether refresh is already in progress.
+ */
+@property BOOL refreshInProgress;
+
+/**
  * Rest singleton instance.
  */
 + (void)resetSharedInstance;

--- a/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
+++ b/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(atomic, nullable) MSSignInCompletionHandler signInCompletionHandler;
 
 /**
- * TODO
+ * Completion handler for refresh completion.
  */
 @property(atomic, nullable) MSSignInCompletionHandler refreshCompletionHandler;
 
@@ -86,12 +86,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)configAuthenticationClient;
 
 /**
- * TODO
+ * Perform sign in with completion handler.
  */
 - (void)signInInWithCompletionHandler:(MSSignInCompletionHandler _Nullable)completionHandler;
 
 /**
- * TODO
+ * Refreshes token for given accountId.
  */
 - (void)refreshTokenForAccountId:(NSString *)accountId withNetworkConnected:(BOOL)networkConnected;
 

--- a/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
+++ b/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
@@ -47,6 +47,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(atomic, nullable) MSSignInCompletionHandler signInCompletionHandler;
 
 /**
+ * The home account id that should be used for refreshing token after coming back online.
+ */
+@property(nonatomic, nullable, copy) NSString *homeAccountIdToRefresh;
+
+/**
  * The flag indicates whether sign-in is already in progress.
  */
 @property BOOL signInInProgress;

--- a/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
+++ b/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
@@ -114,6 +114,14 @@ typedef void (^MSAcquireTokenCompletionHandler)(MSUserInformation *_Nullable use
                                  uiFallback:(BOOL)uiFallback
                 keyPathForCompletionHandler:(NSString *)completionHandlerKeyPath;
 
+/**
+ * Cancel pending sign-in and refresh token operation.
+ *
+ * @param errorCode The error code that indicates a reason of cancellation.
+ * @param message The message describes a reason of cancellation.
+ */
+- (void)cancelPendingOperationsWithErrorCode:(NSInteger)errorCode message:(NSString *)message;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
+++ b/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
@@ -103,6 +103,17 @@ typedef void (^MSAcquireTokenCompletionHandler)(MSUserInformation *_Nullable use
  */
 - (void)refreshTokenForAccountId:(NSString *)accountId withNetworkConnected:(BOOL)networkConnected;
 
+/**
+ * Acquires token in background with the given account.
+ *
+ * @param account The account that is used for acquiring token.
+ * @param uiFallback The flag for fallback to interactive sign-in when it fails.
+ * @param completionHandlerKeyPath The key path of completion handler to process sign-in or refresh token.
+ */
+- (void)acquireTokenSilentlyWithMSALAccount:(MSALAccount *)account
+                                 uiFallback:(BOOL)uiFallback
+                keyPathForCompletionHandler:(NSString *)completionHandlerKeyPath;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
+++ b/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Completion handler for refresh completion.
  */
-@property(atomic, nullable) MSSignInCompletionHandler refreshCompletionHandler;
+@property(atomic, nullable) MSAcquireTokenCompletionHandler refreshCompletionHandler;
 
 /**
  * The home account id that should be used for refreshing token after coming back online.

--- a/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
+++ b/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
@@ -47,19 +47,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property(atomic, nullable) MSSignInCompletionHandler signInCompletionHandler;
 
 /**
+ * TODO
+ */
+@property(atomic, nullable) MSSignInCompletionHandler refreshCompletionHandler;
+
+/**
  * The home account id that should be used for refreshing token after coming back online.
  */
 @property(nonatomic, nullable, copy) NSString *homeAccountIdToRefresh;
-
-/**
- * The flag indicates whether sign-in is already in progress.
- */
-@property BOOL signInInProgress;
-
-/**
- * The flag indicates whether refresh is already in progress.
- */
-@property BOOL refreshInProgress;
 
 /**
  * Rest singleton instance.
@@ -91,17 +86,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)configAuthenticationClient;
 
 /**
- * Retrieve an updated token without user interaction.
- *
- * @param account The MSALAccount that is used to retrieve an authentication token.
- * @param uiFallback `YES` if an interactive request can be used, otherwise `NO`.
+ * TODO
  */
-- (void)acquireTokenSilentlyWithMSALAccount:(MSALAccount *)account uiFallback:(BOOL)uiFallback;
+- (void)signInInWithCompletionHandler:(MSSignInCompletionHandler _Nullable)completionHandler;
 
 /**
- * Retrieve an updated token with user interaction.
+ * TODO
  */
-- (void)acquireTokenInteractively;
+- (void)refreshTokenForAccountId:(NSString *)accountId withNetworkConnected:(BOOL)networkConnected;
 
 @end
 

--- a/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
+++ b/AppCenterAuth/AppCenterAuth/Internals/MSAuthPrivate.h
@@ -14,6 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class MSALPublicClientApplication;
 
+/**
+ * Completion handler triggered when complete getting a token.
+ *
+ * @param userInformation User information for signed in user.
+ * @param error Error for sign-in failure.
+ */
+typedef void (^MSAcquireTokenCompletionHandler)(MSUserInformation *_Nullable userInformation, NSError *_Nullable error);
+
 @interface MSAuth () <MSServiceInternal, MSAuthTokenContextDelegate>
 
 /**
@@ -44,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Completion handler for sign-in.
  */
-@property(atomic, nullable) MSSignInCompletionHandler signInCompletionHandler;
+@property(atomic, nullable) MSAcquireTokenCompletionHandler signInCompletionHandler;
 
 /**
  * Completion handler for refresh completion.

--- a/AppCenterAuth/AppCenterAuth/MSAuth.h
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.h
@@ -21,14 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void (^MSSignInCompletionHandler)(MSUserInformation *_Nullable userInformation, NSError *_Nullable error);
 
 /**
- * Completion handler triggered when complete getting a token.
- *
- * @param userInformation User information for signed in user.
- * @param error Error for sign-in failure.
- */
-typedef void (^MSAcquireTokenCompletionHandler)(MSUserInformation *_Nullable userInformation, NSError *_Nullable error);
-
-/**
  * App Center Auth service.
  */
 @interface MSAuth : MSServiceAbstract

--- a/AppCenterAuth/AppCenterAuth/MSAuth.h
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.h
@@ -21,6 +21,14 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void (^MSSignInCompletionHandler)(MSUserInformation *_Nullable userInformation, NSError *_Nullable error);
 
 /**
+ * Completion handler triggered when complete getting a token.
+ *
+ * @param userInformation User information for signed in user.
+ * @param error Error for sign-in failure.
+ */
+typedef void (^MSAcquireTokenCompletionHandler)(MSUserInformation *_Nullable userInformation, NSError *_Nullable error);
+
+/**
  * App Center Auth service.
  */
 @interface MSAuth : MSServiceAbstract

--- a/AppCenterAuth/AppCenterAuth/MSAuth.m
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.m
@@ -513,7 +513,7 @@ static dispatch_once_t onceToken;
 
 - (void)networkStateChanged:(NSNotificationCenter *)__unused notification {
   BOOL networkConnected = [[MS_Reachability reachabilityForInternetConnection] currentReachabilityStatus] != NotReachable;
-  if (networkConnected && !self.homeAccountIdToRefresh) {
+  if (networkConnected && self.homeAccountIdToRefresh) {
     NSString *accountId = self.homeAccountIdToRefresh;
     self.homeAccountIdToRefresh = nil;
     [self refreshTokenForAccountId:accountId withNetworkConnected:YES];

--- a/AppCenterAuth/AppCenterAuth/MSAuth.m
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.m
@@ -478,7 +478,7 @@ static dispatch_once_t onceToken;
     self.refreshInProgress = YES;
     MSALAccount *account = [self retrieveAccountWithAccountId:accountId];
     if (account) {
-      [self acquireTokenSilentlyWithMSALAccount:account];
+      [self acquireTokenSilentlyWithMSALAccount:account uiFallback:NO];
     } else {
 
       // If account not found, start an anonymous session to avoid deadlock.

--- a/AppCenterAuth/AppCenterAuth/MSAuth.m
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.m
@@ -119,6 +119,8 @@ static dispatch_once_t onceToken;
     self.clientApplication = nil;
     [self clearConfigurationCache];
     self.ingestion = nil;
+    self.signInInProgress = NO;
+    self.refreshInProgress = NO;
     NSError *error = [[NSError alloc] initWithDomain:kMSACAuthErrorDomain
                                                 code:MSACAuthErrorServiceDisabled
                                             userInfo:@{NSLocalizedDescriptionKey : @"Auth is disabled."}];

--- a/AppCenterAuth/AppCenterAuth/MSAuth.m
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.m
@@ -216,7 +216,7 @@ static dispatch_once_t onceToken;
   [MSAuth sharedInstance].configUrl = configUrl;
 }
 
-- (void)callCompletionHandler:(MSSignInCompletionHandler _Nullable)completionHandler
+- (void)callCompletionHandler:(MSAcquireTokenCompletionHandler _Nullable)completionHandler
                 withErrorCode:(NSInteger)errorCode
                    andMessage:(NSString *)errorMessage {
   if (completionHandler) {
@@ -384,7 +384,7 @@ static dispatch_once_t onceToken;
                           account:account
                   completionBlock:^(MSALResult *result, NSError *error) {
                     typeof(self) strongSelf = weakSelf;
-                    MSSignInCompletionHandler handler = [strongSelf valueForKey:completionHandlerKeyPath];
+                    MSAcquireTokenCompletionHandler handler = [strongSelf valueForKey:completionHandlerKeyPath];
                     if (!handler) {
                       MSLogDebug([MSAuth logTag], @"Silent acquisition has been interrupted. Ignoring the result.");
                       return;
@@ -423,7 +423,7 @@ static dispatch_once_t onceToken;
   [self.clientApplication acquireTokenForScopes:@[ (NSString * __nonnull) self.authConfig.authScope ]
                                 completionBlock:^(MSALResult *result, NSError *error) {
                                   typeof(self) strongSelf = weakSelf;
-                                  MSSignInCompletionHandler handler = [strongSelf valueForKey:completionHandlerKeyPath];
+                                  MSAcquireTokenCompletionHandler handler = [strongSelf valueForKey:completionHandlerKeyPath];
                                   if (!handler) {
                                     MSLogDebug([MSAuth logTag], @"Sign-in has been interrupted. Ignoring the result.");
                                     return;

--- a/AppCenterAuth/AppCenterAuth/MSAuth.m
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.m
@@ -119,7 +119,6 @@ static dispatch_once_t onceToken;
 #endif
     [[MSAuthTokenContext sharedInstance] removeDelegate:self];
     [MS_NOTIFICATION_CENTER removeObserver:self];
-
     [self clearAuthData];
     self.clientApplication = nil;
     [self clearConfigurationCache];

--- a/AppCenterAuth/AppCenterAuth/MSAuth.m
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.m
@@ -501,9 +501,6 @@ static dispatch_once_t onceToken;
 #pragma mark - MSAuthTokenContextDelegate
 
 - (void)authTokenContext:(MSAuthTokenContext *)__unused authTokenContext refreshAuthTokenForAccountId:(nullable NSString *)accountId {
-  if (!accountId) {
-    return;
-  }
   BOOL networkConnected = [[MS_Reachability reachabilityForInternetConnection] currentReachabilityStatus] != NotReachable;
   [self refreshTokenForAccountId:(NSString *)accountId withNetworkConnected:networkConnected];
 }

--- a/AppCenterAuth/AppCenterAuth/MSAuth.m
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.m
@@ -152,7 +152,7 @@ static dispatch_once_t onceToken;
 + (void)signInWithCompletionHandler:(MSSignInCompletionHandler _Nullable)completionHandler {
   @synchronized([MSAuth sharedInstance]) {
     if ([[MSAuth sharedInstance] canBeUsed] && [[MSAuth sharedInstance] isEnabled]) {
-      [[MSAuth sharedInstance] signInInWithCompletionHandler:completionHandler];
+      [[MSAuth sharedInstance] signInWithCompletionHandler:completionHandler];
     } else {
       [[MSAuth sharedInstance] callCompletionHandler:completionHandler
                                        withErrorCode:MSACAuthErrorServiceDisabled
@@ -165,7 +165,7 @@ static dispatch_once_t onceToken;
   [[MSAuth sharedInstance] signOut];
 }
 
-- (void)signInInWithCompletionHandler:(MSSignInCompletionHandler _Nullable)completionHandler {
+- (void)signInWithCompletionHandler:(MSSignInCompletionHandler _Nullable)completionHandler {
   if (self.signInCompletionHandler) {
     MSLogError([MSAuth logTag], @"signIn already in progress.");
     [self callCompletionHandler:completionHandler

--- a/AppCenterAuth/AppCenterAuth/MSAuthErrors.h
+++ b/AppCenterAuth/AppCenterAuth/MSAuthErrors.h
@@ -20,6 +20,7 @@ static NSString *const kMSACAuthErrorDomain = MS_APP_CENTER_BASE_DOMAIN @"Auth.E
  * Error code for Auth.
  */
 NS_ENUM(NSInteger){MSACAuthErrorServiceDisabled = -420000, MSACAuthErrorPreviousSignInRequestInProgress = -420001,
-                   MSACAuthErrorSignInBackgroundOrNotConfigured = -420002, MSACAuthErrorSignInWhenNoConnection = -420003};
+                   MSACAuthErrorSignInBackgroundOrNotConfigured = -420002, MSACAuthErrorSignInWhenNoConnection = -420003,
+                   MSACAuthErrorInterruptedByAnotherOperation = -420004};
 
 NS_ASSUME_NONNULL_END

--- a/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
+++ b/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
@@ -698,7 +698,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   OCMStub([authTokenContextMock sharedInstance]).andReturn(authTokenContextMock);
 
   // When
-  [self.sut signInInWithCompletionHandler:^(MSUserInformation *_Nullable __unused userInformation, NSError *_Nullable __unused error){
+  [self.sut signInWithCompletionHandler:^(MSUserInformation *_Nullable __unused userInformation, NSError *_Nullable __unused error){
   }];
   MSAuthTokenInfo *actualAuthTokenInfo = [[[MSAuthTokenContext sharedInstance] authTokenHistory] lastObject];
 
@@ -732,7 +732,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   OCMStub([authTokenContextMock sharedInstance]).andReturn(authTokenContextMock);
 
   // When
-  [self.sut signInInWithCompletionHandler:^(MSUserInformation *_Nullable __unused userInformation, NSError *_Nullable __unused error){
+  [self.sut signInWithCompletionHandler:^(MSUserInformation *_Nullable __unused userInformation, NSError *_Nullable __unused error){
   }];
 
   // Then

--- a/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
+++ b/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
@@ -698,7 +698,8 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   OCMStub([authMock canBeUsed]).andReturn(YES);
 
   // When
-  [self.sut acquireTokenSilentlyWithMSALAccount:accountMock uiFallback:YES];
+  // TODO use [self.sut signInInWithCompletionHandler:]
+  //[self.sut acquireTokenSilentlyWithMSALAccount:accountMock uiFallback:YES keyPathForCompletionHandler:@"TODO"];
   MSAuthTokenInfo *actualAuthTokenInfo = [[[MSAuthTokenContext sharedInstance] authTokenHistory] lastObject];
 
   // Then
@@ -730,7 +731,8 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
       });
 
   // When
-  [self.sut acquireTokenSilentlyWithMSALAccount:OCMOCK_ANY uiFallback:YES];
+  // TODO use [self.sut signInInWithCompletionHandler:]
+  //[self.sut acquireTokenSilentlyWithMSALAccount:OCMOCK_ANY uiFallback:YES];
 
   // Then
   OCMVerify([self.clientApplicationMock acquireTokenForScopes:OCMOCK_ANY completionBlock:OCMOCK_ANY]);
@@ -1174,7 +1176,6 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   OCMStub([authMock canBeUsed]).andReturn(YES);
   MSALAccount *accountMock = OCMClassMock([MSALAccount class]);
   OCMStub([authMock retrieveAccountWithAccountId:fakeAccountId]).andReturn(accountMock);
-  OCMStub([authMock acquireTokenSilentlyWithMSALAccount:accountMock uiFallback:NO]);
 
   // When
   [authMock startWithChannelGroup:OCMProtocolMock(@protocol(MSChannelGroupProtocol))
@@ -1184,7 +1185,8 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   [[MSAuthTokenContext sharedInstance] checkIfTokenNeedsToBeRefreshed:fakeValidityInfo];
 
   // Then
-  OCMVerify([authMock acquireTokenSilentlyWithMSALAccount:accountMock uiFallback:NO]);
+  // TODO verify MSAL call instead
+  // OCMVerify([authMock acquireTokenSilentlyWithMSALAccount:accountMock uiFallback:NO]);
   [authMock stopMocking];
 }
 
@@ -1202,7 +1204,9 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   OCMStub([authMock sharedInstance]).andReturn(authMock);
   OCMStub([authMock canBeUsed]).andReturn(YES);
   OCMStub([authMock retrieveAccountWithAccountId:fakeAccountId]).andReturn(nil);
-  OCMReject([authMock acquireTokenSilentlyWithMSALAccount:OCMOCK_ANY uiFallback:NO]);
+
+  // TODO Reject MSAL call instead
+  // OCMReject([authMock acquireTokenSilentlyWithMSALAccount:OCMOCK_ANY uiFallback:NO]);
   id authTokenContextMock = OCMPartialMock([MSAuthTokenContext sharedInstance]);
   OCMStub([authTokenContextMock sharedInstance]).andReturn(authTokenContextMock);
 

--- a/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
+++ b/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
@@ -720,23 +720,24 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   id msalResultMock = OCMPartialMock([MSALResult new]);
   NSString *expectedAuthToken = @"fakeAuthToken";
   OCMStub([msalResultMock idToken]).andReturn(expectedAuthToken);
-  id authMock = OCMPartialMock(self.sut);
-  OCMStub([authMock sharedInstance]).andReturn(authMock);
-  OCMStub([authMock canBeUsed]).andReturn(YES);
+
   OCMStub([self.clientApplicationMock acquireTokenSilentForScopes:OCMOCK_ANY account:OCMOCK_ANY completionBlock:OCMOCK_ANY])
       .andDo(^(NSInvocation *invocation) {
         __block MSALCompletionBlock completionBlock;
         [invocation getArgument:&completionBlock atIndex:4];
         completionBlock(msalResultMock, OCMOCK_ANY);
       });
+  id authTokenContextMock = OCMPartialMock([MSAuthTokenContext sharedInstance]);
+  NSString *expectedHomeAccountId = @"fakeHomeAccountId";
+  OCMStub([authTokenContextMock accountId]).andReturn(expectedHomeAccountId);
+  OCMStub([authTokenContextMock sharedInstance]).andReturn(authTokenContextMock);
 
   // When
-  // TODO use [self.sut signInInWithCompletionHandler:]
-  //[self.sut acquireTokenSilentlyWithMSALAccount:OCMOCK_ANY uiFallback:YES];
+  [self.sut signInInWithCompletionHandler:^(MSUserInformation *_Nullable __unused userInformation, NSError *_Nullable __unused error){
+  }];
 
   // Then
   OCMVerify([self.clientApplicationMock acquireTokenForScopes:OCMOCK_ANY completionBlock:OCMOCK_ANY]);
-  [authMock stopMocking];
 }
 
 - (void)testSignInTriggersInteractiveAuthentication {

--- a/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
+++ b/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
@@ -720,7 +720,6 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   id msalResultMock = OCMPartialMock([MSALResult new]);
   NSString *expectedAuthToken = @"fakeAuthToken";
   OCMStub([msalResultMock idToken]).andReturn(expectedAuthToken);
-
   OCMStub([self.clientApplicationMock acquireTokenSilentForScopes:OCMOCK_ANY account:OCMOCK_ANY completionBlock:OCMOCK_ANY])
       .andDo(^(NSInvocation *invocation) {
         __block MSALCompletionBlock completionBlock;
@@ -1175,6 +1174,11 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   OCMStub([fakeValidityInfo authToken]).andReturn(fakeAuthToken);
   OCMStub([authMock sharedInstance]).andReturn(authMock);
   OCMStub([authMock canBeUsed]).andReturn(YES);
+  self.sut.authConfig = [MSAuthConfig new];
+  self.sut.authConfig.authScope = @"fake";
+  OCMStub([authMock configAuthenticationClient]).andDo(^(NSInvocation *__unused invocation) {
+    self.sut.clientApplication = self.clientApplicationMock;
+  });
   MSALAccount *accountMock = OCMClassMock([MSALAccount class]);
   OCMStub([authMock retrieveAccountWithAccountId:fakeAccountId]).andReturn(accountMock);
 
@@ -1186,8 +1190,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   [[MSAuthTokenContext sharedInstance] checkIfTokenNeedsToBeRefreshed:fakeValidityInfo];
 
   // Then
-  // TODO verify MSAL call instead
-  // OCMVerify([authMock acquireTokenSilentlyWithMSALAccount:accountMock uiFallback:NO]);
+  OCMVerify([self.sut.clientApplication acquireTokenSilentForScopes:OCMOCK_ANY account:OCMOCK_ANY completionBlock:OCMOCK_ANY]);
   [authMock stopMocking];
 }
 

--- a/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
+++ b/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
@@ -1208,9 +1208,12 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   OCMStub([authMock sharedInstance]).andReturn(authMock);
   OCMStub([authMock canBeUsed]).andReturn(YES);
   OCMStub([authMock retrieveAccountWithAccountId:fakeAccountId]).andReturn(nil);
-
-  // TODO Reject MSAL call instead
-  // OCMReject([authMock acquireTokenSilentlyWithMSALAccount:OCMOCK_ANY uiFallback:NO]);
+  self.sut.authConfig = [MSAuthConfig new];
+  self.sut.authConfig.authScope = @"fake";
+  OCMStub([authMock configAuthenticationClient]).andDo(^(NSInvocation *__unused invocation) {
+    self.sut.clientApplication = self.clientApplicationMock;
+  });
+  OCMReject([self.sut.clientApplication acquireTokenSilentForScopes:OCMOCK_ANY account:OCMOCK_ANY completionBlock:OCMOCK_ANY]);
   id authTokenContextMock = OCMPartialMock([MSAuthTokenContext sharedInstance]);
   OCMStub([authTokenContextMock sharedInstance]).andReturn(authTokenContextMock);
 

--- a/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
+++ b/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
@@ -1284,6 +1284,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
 
   // Then
   OCMVerify([authMock cancelPendingOperationsWithErrorCode:MSACAuthErrorServiceDisabled message:OCMOCK_ANY]);
+  [authMock stopMocking];
 }
 
 - (void)testCancelPendingOperationWhenSignOut {
@@ -1298,6 +1299,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
 
   // Then
   OCMVerify([authMock cancelPendingOperationsWithErrorCode:MSACAuthErrorInterruptedByAnotherOperation message:OCMOCK_ANY]);
+  [authMock stopMocking];
 }
 
 @end


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

When no network and we try to silent sign in (which happens automatically on refresh token), it fails and we are signed out as a result, and offline storage stops working altogether (everything is cleared).

If we need to silent sign in for an automatic SDK behavior, we need to delay it until network comes back online and then submit the call to msal.

## Related PRs or issues

https://github.com/Microsoft/AppCenter-SDK-Android/pull/1087
[AB#60235](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/60235)

