### PR TITLE
Remove swift name from setTokenExchangeUrl, the default works

### DIFF
--- a/AppCenterData/AppCenterData/MSData.h
+++ b/AppCenterData/AppCenterData/MSData.h
@@ -54,7 +54,7 @@ typedef void (^MSPaginatedDocumentsCompletionHandler)(MSPaginatedDocuments *docu
  *
  * @param tokenExchangeUrl The new URL.
  */
-+ (void)setTokenExchangeUrl:(NSString *)tokenExchangeUrl NS_SWIFT_NAME(setTokenExchangeUrl(_:));
++ (void)setTokenExchangeUrl:(NSString *)tokenExchangeUrl;
 
 /**
  * Read a document.


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Default Swift names are OK in Auth. Just removing useless swift name in Data for set `setTokenExchangeUrl`.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
