### PR TITLE
Fix obfuscation when no whitespace characters found in token

### DIFF
--- a/AppCenter/AppCenter/Internals/HttpClient/Util/MSHttpUtil.m
+++ b/AppCenter/AppCenter/Internals/HttpClient/Util/MSHttpUtil.m
@@ -41,7 +41,11 @@
 + (NSString *)hideAuthToken:(NSString *)token {
 
   // Hide token value.
-  NSString *prefix = [[token componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]] firstObject];
+  NSArray<NSString *> *tokenArray = [token componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+  if (tokenArray.count == 1) {
+    return @"***";
+  }
+  NSString *prefix = [tokenArray firstObject];
   return [prefix stringByAppendingString:@" ***"];
 }
 

--- a/AppCenter/AppCenterTests/MSHttpUtilTests.m
+++ b/AppCenter/AppCenterTests/MSHttpUtilTests.m
@@ -56,6 +56,18 @@
   assertThat(hiddenToken, is(@"Bearer ***"));
 }
 
+- (void)testHideAuthTokenThatHasNoSpaces {
+
+  // If
+  NSString *token = @"type%3Dresource%26ver%3D1%26sig%3pjGyKiHTIwDwAaZywx9xj1AkvbaA%2";
+
+  // When
+  NSString *hiddenToken = [MSHttpUtil hideAuthToken:token];
+
+  // Then
+  assertThat(hiddenToken, is(@"***"));
+}
+
 - (void)testIsNoInternetConnectionError {
 
   // When


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
When no whitespace chars were found inside token, token would be printed in the log without obuscation. This PR makes sure that if there are no whitespace chars, we just mask token with `***`
## Related PRs or issues
[Issue #61226](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/61226)