### PR TITLE
Add API to set latency of sending events

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param groupId The id used by the channel to determine a group of logs.
  * @param priority The priority of logs being sent by the channel.
- * @param flushInterval The interval in seconds after which a new batch will be finished. Must be between 3 and 86400.
+ * @param flushInterval The interval in seconds after which a new batch will be finished. Must be between 3 and 86400 (1 day).
  * @param batchSizeLimit The maximum number of logs after which a new batch will be finished.
  * @param pendingBatchesLimit The maximum number of batches that have currently been forwarded to another component.
  *
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Initializes a new instance with flushInterval.
  *
  * @param groupId The id used by the channel to determine a group of logs.
- * @param flushInterval The interval in seconds after which a new batch will be finished. Must be between 3 and 86400.
+ * @param flushInterval The interval in seconds after which a new batch will be finished. Must be between 3 and 86400 (1 day).
  *
  * @return a fully configured `MSChannelConfiguration` instance with flushInterval.
  */

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#import <Foundation/Foundation.h>
-
 #import "MSConstants+Internal.h"
 #import "MSConstants.h"
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
@@ -60,6 +60,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initDefaultConfigurationWithGroupId:(NSString *)groupId;
 
+/**
+ * Initializes a new instance with flushInterval.
+ *
+ * @param groupId The id used by the channel to determine a group of logs.
+ * @param flushInterval The interval after which a new batch will be finished.
+ *
+ * @return a fully configured `MSChannelConfiguration` instance with flushInterval.
+ */
+- (instancetype)initWithGroupId:(NSString *)groupId flushInterval:(float)flushInterval;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param groupId The id used by the channel to determine a group of logs.
  * @param priority The priority of logs being sent by the channel.
- * @param flushInterval The interval after which a new batch will be finished.
+ * @param flushInterval The interval in seconds after which a new batch will be finished. Must be between 3 and 86400.
  * @param batchSizeLimit The maximum number of logs after which a new batch will be finished.
  * @param pendingBatchesLimit The maximum number of batches that have currently been forwarded to another component.
  *
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Initializes a new instance with flushInterval.
  *
  * @param groupId The id used by the channel to determine a group of logs.
- * @param flushInterval The interval after which a new batch will be finished.
+ * @param flushInterval The interval in seconds after which a new batch will be finished. Must be between 3 and 86400.
  *
  * @return a fully configured `MSChannelConfiguration` instance with flushInterval.
  */

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
@@ -3,6 +3,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "MSConstants+Internal.h"
 #import "MSConstants.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -32,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Interval for flushing the queue.
  */
-@property(nonatomic, readonly) float flushInterval;
+@property(nonatomic, readonly) NSUInteger flushInterval;
 
 /**
  * Initializes a new instance based on given settings.
@@ -47,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithGroupId:(NSString *)groupId
                        priority:(MSPriority)priority
-                  flushInterval:(float)flushInterval
+                  flushInterval:(NSUInteger)flushInterval
                  batchSizeLimit:(NSUInteger)batchSizeLimit
             pendingBatchesLimit:(NSUInteger)pendingBatchesLimit;
 
@@ -68,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return a fully configured `MSChannelConfiguration` instance with flushInterval.
  */
-- (instancetype)initWithGroupId:(NSString *)groupId flushInterval:(float)flushInterval;
+- (instancetype)initWithGroupId:(NSString *)groupId flushInterval:(NSUInteger)flushInterval;
 
 @end
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.h
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return a fully configured `MSChannelConfiguration` instance with flushInterval.
  */
-- (instancetype)initWithGroupId:(NSString *)groupId flushInterval:(NSUInteger)flushInterval;
+- (instancetype)initDefaultConfigurationWithGroupId:(NSString *)groupId flushInterval:(NSUInteger)flushInterval;
 
 @end
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.m
@@ -20,8 +20,12 @@
   return self;
 }
 
+- (instancetype)initWithGroupId:(NSString *)groupId flushInterval:(float)flushInterval {
+  return [self initWithGroupId:groupId priority:MSPriorityDefault flushInterval:flushInterval batchSizeLimit:50 pendingBatchesLimit:3];
+}
+
 - (instancetype)initDefaultConfigurationWithGroupId:(NSString *)groupId {
-  return [self initWithGroupId:groupId priority:MSPriorityDefault flushInterval:3.0 batchSizeLimit:50 pendingBatchesLimit:3];
+  return [self initWithGroupId:groupId flushInterval:3.0];
 }
 
 @end

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.m
@@ -25,7 +25,7 @@
 }
 
 - (instancetype)initDefaultConfigurationWithGroupId:(NSString *)groupId {
-  return [self initWithGroupId:groupId flushInterval:3.0];
+  return [self initWithGroupId:groupId flushInterval:MSFlushIntervalDefault];
 }
 
 @end

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.m
@@ -20,12 +20,12 @@
   return self;
 }
 
-- (instancetype)initWithGroupId:(NSString *)groupId flushInterval:(NSUInteger)flushInterval {
+- (instancetype)initDefaultConfigurationWithGroupId:(NSString *)groupId flushInterval:(NSUInteger)flushInterval {
   return [self initWithGroupId:groupId priority:MSPriorityDefault flushInterval:flushInterval batchSizeLimit:50 pendingBatchesLimit:3];
 }
 
 - (instancetype)initDefaultConfigurationWithGroupId:(NSString *)groupId {
-  return [self initWithGroupId:groupId flushInterval:kMSFlushIntervalDefault];
+  return [self initDefaultConfigurationWithGroupId:groupId flushInterval:kMSFlushIntervalDefault];
 }
 
 @end

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitConfiguration.m
@@ -7,7 +7,7 @@
 
 - (instancetype)initWithGroupId:(NSString *)groupId
                        priority:(MSPriority)priority
-                  flushInterval:(float)flushInterval
+                  flushInterval:(NSUInteger)flushInterval
                  batchSizeLimit:(NSUInteger)batchSizeLimit
             pendingBatchesLimit:(NSUInteger)pendingBatchesLimit {
   if ((self = [super init])) {
@@ -20,12 +20,12 @@
   return self;
 }
 
-- (instancetype)initWithGroupId:(NSString *)groupId flushInterval:(float)flushInterval {
+- (instancetype)initWithGroupId:(NSString *)groupId flushInterval:(NSUInteger)flushInterval {
   return [self initWithGroupId:groupId priority:MSPriorityDefault flushInterval:flushInterval batchSizeLimit:50 pendingBatchesLimit:3];
 }
 
 - (instancetype)initDefaultConfigurationWithGroupId:(NSString *)groupId {
-  return [self initWithGroupId:groupId flushInterval:MSFlushIntervalDefault];
+  return [self initWithGroupId:groupId flushInterval:kMSFlushIntervalDefault];
 }
 
 @end

--- a/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
@@ -41,7 +41,7 @@ static NSString *const kMSBaseErrorMsg = @"Log validation failed.";
   if (![self isOneCollectorGroup:groupId]) {
     NSString *oneCollectorGroupId = [NSString stringWithFormat:@"%@%@", channel.configuration.groupId, kMSOneCollectorGroupIdSuffix];
     MSChannelUnitConfiguration *channelUnitConfiguration =
-        [[MSChannelUnitConfiguration alloc] initDefaultConfigurationWithGroupId:oneCollectorGroupId];
+        [[MSChannelUnitConfiguration alloc] initWithGroupId:oneCollectorGroupId flushInterval:channel.configuration.flushInterval];
     id<MSChannelUnitProtocol> channelUnit = [channelGroup addChannelUnitWithConfiguration:channelUnitConfiguration
                                                                             withIngestion:self.oneCollectorIngestion];
     self.oneCollectorChannels[groupId] = channelUnit;

--- a/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSOneCollectorChannelDelegate.m
@@ -41,7 +41,8 @@ static NSString *const kMSBaseErrorMsg = @"Log validation failed.";
   if (![self isOneCollectorGroup:groupId]) {
     NSString *oneCollectorGroupId = [NSString stringWithFormat:@"%@%@", channel.configuration.groupId, kMSOneCollectorGroupIdSuffix];
     MSChannelUnitConfiguration *channelUnitConfiguration =
-        [[MSChannelUnitConfiguration alloc] initWithGroupId:oneCollectorGroupId flushInterval:channel.configuration.flushInterval];
+        [[MSChannelUnitConfiguration alloc] initDefaultConfigurationWithGroupId:oneCollectorGroupId
+                                                                  flushInterval:channel.configuration.flushInterval];
     id<MSChannelUnitProtocol> channelUnit = [channelGroup addChannelUnitWithConfiguration:channelUnitConfiguration
                                                                             withIngestion:self.oneCollectorIngestion];
     self.oneCollectorChannels[groupId] = channelUnit;

--- a/AppCenter/AppCenter/Internals/MSServiceCommon.h
+++ b/AppCenter/AppCenter/Internals/MSServiceCommon.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The channel configuration for this service.
  */
-@property(nonatomic, readonly) MSChannelUnitConfiguration *channelUnitConfiguration;
+@property(nonatomic) MSChannelUnitConfiguration *channelUnitConfiguration;
 
 @required
 

--- a/AppCenter/AppCenter/Internals/Util/MSConstants+Internal.h
+++ b/AppCenter/AppCenter/Internals/Util/MSConstants+Internal.h
@@ -90,3 +90,8 @@ static const NSUInteger kMSPersistenceFlagsMask = 0xFF;
  * Common schema prefix separator used in various field values.
  */
 static NSString *const kMSCommonSchemaPrefixSeparator = @":";
+
+/**
+ * Default flush interval for channel.
+ */
+static NSUInteger const kMSFlushIntervalDefault = 3.0;

--- a/AppCenter/AppCenter/Internals/Util/MSConstants+Internal.h
+++ b/AppCenter/AppCenter/Internals/Util/MSConstants+Internal.h
@@ -94,4 +94,4 @@ static NSString *const kMSCommonSchemaPrefixSeparator = @":";
 /**
  * Default flush interval for channel.
  */
-static NSUInteger const kMSFlushIntervalDefault = 3.0;
+static NSUInteger const kMSFlushIntervalDefault = 3;

--- a/AppCenter/AppCenter/MSConstants.h
+++ b/AppCenter/AppCenter/MSConstants.h
@@ -44,11 +44,6 @@ typedef NS_ENUM(NSUInteger, MSLogLevel) {
   MSLogLevelNone = 99
 };
 
-/**
- * Default flush interval for channel.
- */
-static NSUInteger const MSFlushIntervalDefault = 3.0;
-
 typedef NSString * (^MSLogMessageProvider)(void);
 typedef void (^MSLogHandler)(MSLogMessageProvider messageProvider, MSLogLevel logLevel, NSString *tag, const char *file,
                              const char *function, uint line);

--- a/AppCenter/AppCenter/MSConstants.h
+++ b/AppCenter/AppCenter/MSConstants.h
@@ -44,6 +44,11 @@ typedef NS_ENUM(NSUInteger, MSLogLevel) {
   MSLogLevelNone = 99
 };
 
+/**
+ * Default flush interval for channel.
+ */
+static NSUInteger const MSFlushIntervalDefault = 3.0;
+
 typedef NSString * (^MSLogMessageProvider)(void);
 typedef void (^MSLogHandler)(MSLogMessageProvider messageProvider, MSLogLevel logLevel, NSString *tag, const char *file,
                              const char *function, uint line);

--- a/AppCenter/AppCenterTests/MSAuthTokenContextTests.m
+++ b/AppCenter/AppCenterTests/MSAuthTokenContextTests.m
@@ -6,8 +6,8 @@
 #import "MSAuthTokenContextPrivate.h"
 #import "MSAuthTokenInfo.h"
 #import "MSAuthTokenValidityInfo.h"
-#import "MSConstants.h"
 #import "MSConstants+Internal.h"
+#import "MSConstants.h"
 #import "MSMockUserDefaults.h"
 #import "MSTestFrameworks.h"
 #import "MSUserInformation.h"
@@ -397,7 +397,9 @@
   OCMReject([delegateMock authTokenContext:OCMOCK_ANY refreshAuthTokenForAccountId:OCMOCK_ANY]);
 
   NSArray<MSAuthTokenInfo *> *authTokenHistory = @[ [[MSAuthTokenInfo alloc] initWithAuthToken:expectedAuthToken
-                                                                                              accountId:@"test" startTime:nil expiresOn:nil] ];
+                                                                                     accountId:@"test"
+                                                                                     startTime:nil
+                                                                                     expiresOn:nil] ];
   [self.sut setAuthTokenHistory:authTokenHistory];
   MSAuthTokenValidityInfo *authToken = [[MSAuthTokenValidityInfo alloc] initWithAuthToken:expectedAuthToken
                                                                                 startTime:startDate

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -30,7 +30,7 @@
 - (void)setUp {
   NSString *groupId = @"AppCenter";
   MSPriority priority = MSPriorityDefault;
-  float flushInterval = 1.0;
+  NSUInteger flushInterval = 3;
   NSUInteger batchSizeLimit = 10;
   NSUInteger pendingBatchesLimit = 3;
   self.ingestionMock = OCMClassMock([MSAppCenterIngestion class]);

--- a/AppCenter/AppCenterTests/MSChannelUnitConfigurationTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitConfigurationTests.m
@@ -21,7 +21,7 @@
   MSPriority priority = MSPriorityDefault;
   NSUInteger batchSizeLimit = 10;
   NSUInteger pendingBatchesLimit = 20;
-  float flushInterval = 9.9f;
+  NSUInteger flushInterval = 9;
 
   // When
   MSChannelUnitConfiguration *sut = [[MSChannelUnitConfiguration alloc] initWithGroupId:groupId
@@ -36,7 +36,7 @@
   XCTAssertTrue(sut.priority == priority);
   assertThatUnsignedInteger(sut.batchSizeLimit, equalToUnsignedInteger(batchSizeLimit));
   assertThatUnsignedInteger(sut.pendingBatchesLimit, equalToUnsignedInteger(pendingBatchesLimit));
-  assertThatFloat(sut.flushInterval, equalToFloat(flushInterval));
+  assertThatUnsignedInteger(sut.flushInterval, equalToUnsignedInteger(flushInterval));
 }
 
 - (void)testNewInstanceWithDefaultSettings {
@@ -53,7 +53,7 @@
   XCTAssertTrue(sut.priority == MSPriorityDefault);
   assertThatUnsignedInteger(sut.batchSizeLimit, equalToUnsignedInteger(50));
   assertThatUnsignedInteger(sut.pendingBatchesLimit, equalToUnsignedInteger(3));
-  assertThatFloat(sut.flushInterval, equalToFloat(3));
+  assertThatUnsignedInteger(sut.flushInterval, equalToUnsignedInteger(3));
 }
 
 @end

--- a/AppCenterAnalytics/AppCenterAnalytics/Internals/MSAnalyticsPrivate.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/Internals/MSAnalyticsPrivate.h
@@ -21,6 +21,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, nullable) id<MSAnalyticsDelegate> delegate;
 
+@property(nonatomic) NSUInteger flushInterval;
+
+@property(nonatomic) MSChannelUnitConfiguration *channelUnitConfiguration;
+
 /**
  * Transmission targets.
  */

--- a/AppCenterAnalytics/AppCenterAnalytics/Internals/MSAnalyticsPrivate.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/Internals/MSAnalyticsPrivate.h
@@ -23,8 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic) NSUInteger flushInterval;
 
-@property(nonatomic) MSChannelUnitConfiguration *channelUnitConfiguration;
-
 /**
  * Transmission targets.
  */

--- a/AppCenterAnalytics/AppCenterAnalytics/Internals/Util/MSAnalyticsConstants.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/Internals/Util/MSAnalyticsConstants.h
@@ -11,7 +11,7 @@ static const int kMSDateTimeMetadataTypeId = 9;
 /**
  * Minimum flush interval for channel.
  */
-static NSUInteger const kMSFlushIntervalMinimum = 3.0;
+static NSUInteger const kMSFlushIntervalMinimum = 3;
 
 /**
  * Maximum flush interval for channel.

--- a/AppCenterAnalytics/AppCenterAnalytics/Internals/Util/MSAnalyticsConstants.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/Internals/Util/MSAnalyticsConstants.h
@@ -7,3 +7,13 @@
 static const int kMSLongMetadataTypeId = 4;
 static const int kMSDoubleMetadataTypeId = 6;
 static const int kMSDateTimeMetadataTypeId = 9;
+
+/**
+ * Minimum flush interval for channel.
+ */
+static NSUInteger const MSFlushIntervalMinimum = 3.0;
+
+/**
+ * Maximum flush interval for channel.
+ */
+static NSUInteger const MSFlushIntervalMaximum = 24 * 60 * 60;

--- a/AppCenterAnalytics/AppCenterAnalytics/Internals/Util/MSAnalyticsConstants.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/Internals/Util/MSAnalyticsConstants.h
@@ -11,9 +11,9 @@ static const int kMSDateTimeMetadataTypeId = 9;
 /**
  * Minimum flush interval for channel.
  */
-static NSUInteger const MSFlushIntervalMinimum = 3.0;
+static NSUInteger const kMSFlushIntervalMinimum = 3.0;
 
 /**
  * Maximum flush interval for channel.
  */
-static NSUInteger const MSFlushIntervalMaximum = 24 * 60 * 60;
+static NSUInteger const kMSFlushIntervalMaximum = 24 * 60 * 60;

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.h
@@ -202,6 +202,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Set the send time interval for non-critical logs.
  * Must be between 3 seconds and 86400 seconds (1 day).
+ * Must be called before Analytics service start.
  *
  * @param interval The flush interval for logs.
  */

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.h
@@ -199,6 +199,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (MSAnalyticsTransmissionTarget *)transmissionTargetForToken:(NSString *)token;
 
+/**
+ * Set the time interval for normal logs
+ *
+ * @param interval The flush interval for logs
+ */
++ (void)setTransmissionInterval:(NSUInteger)interval;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.h
@@ -200,9 +200,10 @@ NS_ASSUME_NONNULL_BEGIN
 + (MSAnalyticsTransmissionTarget *)transmissionTargetForToken:(NSString *)token;
 
 /**
- * Set the time interval for normal logs
+ * Set the send time interval for non-critical logs.
+ * Must be between 3 seconds and 86400 seconds.
  *
- * @param interval The flush interval for logs
+ * @param interval The flush interval for logs.
  */
 + (void)setTransmissionInterval:(NSUInteger)interval;
 @end

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.h
@@ -201,7 +201,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Set the send time interval for non-critical logs.
- * Must be between 3 seconds and 86400 seconds.
+ * Must be between 3 seconds and 86400 seconds (1 day).
  *
  * @param interval The flush interval for logs.
  */

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -58,9 +58,6 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
     _sessionTracker = [[MSSessionTracker alloc] init];
     _sessionTracker.delegate = self;
 
-    // Init channel configuration.
-    _channelUnitConfiguration = [[MSChannelUnitConfiguration alloc] initWithGroupId:[self groupId] flushInterval:self.flushInterval];
-
     // Set up transmission target dictionary.
     _transmissionTargets = [NSMutableDictionary<NSString *, MSAnalyticsTransmissionTarget *> new];
   }
@@ -86,6 +83,10 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
                     appSecret:(nullable NSString *)appSecret
       transmissionTargetToken:(nullable NSString *)token
               fromApplication:(BOOL)fromApplication {
+
+  // Init channel configuration.
+  self.channelUnitConfiguration = [[MSChannelUnitConfiguration alloc] initDefaultConfigurationWithGroupId:[self groupId]
+                                                                                            flushInterval:self.flushInterval];
   [super startWithChannelGroup:channelGroup appSecret:appSecret transmissionTargetToken:token fromApplication:fromApplication];
   if (token) {
 
@@ -381,17 +382,15 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
 }
 
 - (void)setTransmissionInterval:(NSUInteger)interval {
-  if (interval > kMSFlushIntervalMaximum || interval < kMSFlushIntervalMinimum) {
-    MSLogWarning([MSAnalytics logTag],
-                 @"The transmission interval is invalid, it should be between 3 second and 1 day (86400 seconds).");
+  if (self.started) {
+    MSLogError([MSAnalytics logTag], @"The transmission interval should be set before the MSAnalytics service is started.");
     return;
   }
-  if (self.started) {
-    MSLogWarning([MSAnalytics logTag], @"The transmission interval should be set before the MSAnalytics service is started.");
+  if (interval > kMSFlushIntervalMaximum || interval < kMSFlushIntervalMinimum) {
+    MSLogError([MSAnalytics logTag], @"The transmission interval is not valid, it should be between 3 second and 1 day (86400 seconds).");
     return;
   }
   self.flushInterval = interval;
-  self.channelUnitConfiguration = [[MSChannelUnitConfiguration alloc] initWithGroupId:[self groupId] flushInterval:self.flushInterval];
 }
 
 - (MSAnalyticsTransmissionTarget *)transmissionTargetForToken:(NSString *)transmissionTargetToken {

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -386,14 +386,13 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
 - (void)setTransmissionInterval:(NSUInteger)interval {
   if (interval > MSFlushIntervalMaximum || interval < MSFlushIntervalMinimum) {
     MSLogWarning([MSAnalytics logTag],
-                 @"Interval property is in invalid period, it should be greater than 3 second and lower than 1 day (in seconds).");
+                 @"Interval property is in invalid period, it should be greater than 3 second and lower than 1 day (86400 seconds).");
     return;
   }
   if (self.started) {
-    MSLogWarning([MSAnalytics logTag], @"Set transmission interval API must be called before MSAnalytics service starts.");
+    MSLogWarning([MSAnalytics logTag], @"setTransmissionInterval API must be called before MSAnalytics service starts.");
     return;
   }
-
   self.flushInterval = interval;
   self.channelUnitConfiguration = [[MSChannelUnitConfiguration alloc] initWithGroupId:[self groupId] flushInterval:self.flushInterval];
 }

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -4,6 +4,7 @@
 #import "MSAnalytics.h"
 #import "MSAnalytics+Validation.h"
 #import "MSAnalyticsCategory.h"
+#import "MSAnalyticsConstants.h"
 #import "MSAnalyticsPrivate.h"
 #import "MSAnalyticsTransmissionTargetInternal.h"
 #import "MSChannelGroupProtocol.h"
@@ -20,16 +21,12 @@
 #import "MSTypedProperty.h"
 #import "MSUserIdContext.h"
 #import "MSUtility+StringFormatting.h"
-#import "MSAnalyticsConstants.h"
 
 // Service name for initialization.
 static NSString *const kMSServiceName = @"Analytics";
 
 // The group Id for Analytics.
 static NSString *const kMSGroupId = @"Analytics";
-
-// The default value for logs flush Interval.
-static NSUInteger const kMSDefaultInterval = 3.0;
 
 // Singleton
 static MSAnalytics *sharedInstance = nil;
@@ -55,7 +52,7 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
 
     // Set defaults.
     _autoPageTrackingEnabled = NO;
-    _flushInterval = kMSDefaultInterval;
+    _flushInterval = kMSFlushIntervalDefault;
 
     // Init session tracker.
     _sessionTracker = [[MSSessionTracker alloc] init];
@@ -384,7 +381,7 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
 }
 
 - (void)setTransmissionInterval:(NSUInteger)interval {
-  if (interval > MSFlushIntervalMaximum || interval < MSFlushIntervalMinimum) {
+  if (interval > kMSFlushIntervalMaximum || interval < kMSFlushIntervalMinimum) {
     MSLogWarning([MSAnalytics logTag],
                  @"Interval property is in invalid period, it should be greater than 3 second and lower than 1 day (86400 seconds).");
     return;

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -383,11 +383,11 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
 - (void)setTransmissionInterval:(NSUInteger)interval {
   if (interval > kMSFlushIntervalMaximum || interval < kMSFlushIntervalMinimum) {
     MSLogWarning([MSAnalytics logTag],
-                 @"Interval property is in invalid period, it should be greater than 3 second and lower than 1 day (86400 seconds).");
+                 @"The transmission interval is invalid, it should be between 3 second and 1 day (86400 seconds).");
     return;
   }
   if (self.started) {
-    MSLogWarning([MSAnalytics logTag], @"setTransmissionInterval API must be called before MSAnalytics service starts.");
+    MSLogWarning([MSAnalytics logTag], @"The transmission interval should be set before the MSAnalytics service is started.");
     return;
   }
   self.flushInterval = interval;

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -20,6 +20,7 @@
 #import "MSTypedProperty.h"
 #import "MSUserIdContext.h"
 #import "MSUtility+StringFormatting.h"
+#import "MSAnalyticsConstants.h"
 
 // Service name for initialization.
 static NSString *const kMSServiceName = @"Analytics";

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -387,7 +387,7 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
     return;
   }
   if (interval > kMSFlushIntervalMaximum || interval < kMSFlushIntervalMinimum) {
-    MSLogError([MSAnalytics logTag], @"The transmission interval is not valid, it should be between 3 second and 1 day (86400 seconds).");
+    MSLogError([MSAnalytics logTag], @"The transmission interval is not valid, it should be between 3 seconds and 1 day (86400 seconds).");
     return;
   }
   self.flushInterval = interval;

--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -383,12 +383,11 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
 }
 
 - (void)setTransmissionInterval:(NSUInteger)interval {
-  if (interval > 24 * 60 * 60 || interval < 3) {
+  if (interval > MSFlushIntervalMaximum || interval < MSFlushIntervalMinimum) {
     MSLogWarning([MSAnalytics logTag],
-                 @"Interval property is in invalid period, it should be greater than 2 second and lower than 1 day's seconds.");
+                 @"Interval property is in invalid period, it should be greater than 3 second and lower than 1 day (in seconds).");
     return;
   }
-
   if (self.started) {
     MSLogWarning([MSAnalytics logTag], @"Set transmission interval API must be called before MSAnalytics service starts.");
     return;
@@ -396,11 +395,6 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
 
   self.flushInterval = interval;
   self.channelUnitConfiguration = [[MSChannelUnitConfiguration alloc] initWithGroupId:[self groupId] flushInterval:self.flushInterval];
-
-  // Propagate to transmission targets.
-  for (NSString *token in self.transmissionTargets) {
-    [self.transmissionTargets[token] setTransmissionInterval:interval];
-  }
 }
 
 - (MSAnalyticsTransmissionTarget *)transmissionTargetForToken:(NSString *)transmissionTargetToken {

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
@@ -142,14 +142,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)resume;
 
-/**
- * Set flush interval for this transmission target.
- *
- * @param interval interval time.
- *
- */
-- (void)setTransmissionInterval:(NSUInteger)interval;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.h
@@ -142,6 +142,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)resume;
 
+/**
+ * Set flush interval for this transmission target.
+ *
+ * @param interval interval time.
+ *
+ */
+- (void)setTransmissionInterval:(NSUInteger)interval;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
@@ -6,8 +6,6 @@
 #import "MSAnalyticsTransmissionTargetInternal.h"
 #import "MSAnalyticsTransmissionTargetPrivate.h"
 #import "MSCSExtensions.h"
-#import "MSChannelUnitConfiguration.h"
-#import "MSChannelUnitProtocol.h"
 #import "MSCommonSchemaLog.h"
 #import "MSEventPropertiesInternal.h"
 #import "MSLogger.h"
@@ -15,9 +13,6 @@
 #import "MSProtocolExtension.h"
 #import "MSServiceAbstractInternal.h"
 #import "MSUtility+StringFormatting.h"
-
-// The group Id for Analytics.
-static NSString *const kMSGroupId = @"Analytics";
 
 @implementation MSAnalyticsTransmissionTarget
 
@@ -216,25 +211,4 @@ static MSAnalyticsAuthenticationProvider *_authenticationProvider;
   return self.parentTarget ? self.parentTarget.isEnabled : [MSAnalytics isEnabled];
 }
 
-- (void)setTransmissionInterval:(NSUInteger)interval {
-  if (interval > 24 * 60 * 60 || interval < 3) {
-    MSLogWarning([MSAnalytics logTag],
-                 @"Interval property is in invalid period, it should be greater than 2 second and lower than 1 day's seconds.");
-    return;
-  }
-    
-  @synchronized([MSAnalytics sharedInstance]) {
-    id<MSChannelUnitProtocol> channelUnit = [self.channelGroup channelUnitForGroupId:kMSGroupId];
-    if (channelUnit) {
-      MSChannelUnitConfiguration *configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSGroupId
-                                                                                        flushInterval:interval];
-      [channelUnit setConfiguration:configuration];
-
-      // Propagate to nested transmission targets.
-      for (NSString *token in self.childTransmissionTargets) {
-        [self.childTransmissionTargets[token] setTransmissionInterval:interval];
-      }
-    }
-  }
-}
 @end

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSAnalyticsTransmissionTarget.m
@@ -6,6 +6,8 @@
 #import "MSAnalyticsTransmissionTargetInternal.h"
 #import "MSAnalyticsTransmissionTargetPrivate.h"
 #import "MSCSExtensions.h"
+#import "MSChannelUnitConfiguration.h"
+#import "MSChannelUnitProtocol.h"
 #import "MSCommonSchemaLog.h"
 #import "MSEventPropertiesInternal.h"
 #import "MSLogger.h"
@@ -13,6 +15,9 @@
 #import "MSProtocolExtension.h"
 #import "MSServiceAbstractInternal.h"
 #import "MSUtility+StringFormatting.h"
+
+// The group Id for Analytics.
+static NSString *const kMSGroupId = @"Analytics";
 
 @implementation MSAnalyticsTransmissionTarget
 
@@ -211,4 +216,25 @@ static MSAnalyticsAuthenticationProvider *_authenticationProvider;
   return self.parentTarget ? self.parentTarget.isEnabled : [MSAnalytics isEnabled];
 }
 
+- (void)setTransmissionInterval:(NSUInteger)interval {
+  if (interval > 24 * 60 * 60 || interval < 3) {
+    MSLogWarning([MSAnalytics logTag],
+                 @"Interval property is in invalid period, it should be greater than 2 second and lower than 1 day's seconds.");
+    return;
+  }
+    
+  @synchronized([MSAnalytics sharedInstance]) {
+    id<MSChannelUnitProtocol> channelUnit = [self.channelGroup channelUnitForGroupId:kMSGroupId];
+    if (channelUnit) {
+      MSChannelUnitConfiguration *configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSGroupId
+                                                                                        flushInterval:interval];
+      [channelUnit setConfiguration:configuration];
+
+      // Propagate to nested transmission targets.
+      for (NSString *token in self.childTransmissionTargets) {
+        [self.childTransmissionTargets[token] setTransmissionInterval:interval];
+      }
+    }
+  }
+}
 @end

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
@@ -156,7 +156,7 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 - (void)testSetTransmissionIntervalApplied {
 
   // If
-  NSUInteger testInterval = 5.0;
+  NSUInteger testInterval = 5;
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Wait for addChannelUnitWithConfiguration to be called with right configuration"];
   id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
@@ -188,14 +188,14 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 - (void)testSetTransmissionIntervalNotApplied {
 
   // If
-  NSUInteger testInterval = 2.0;
+  NSUInteger testInterval = 2;
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Wait for addChannelUnitWithConfiguration to be called with right configuration"];
   id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     MSChannelUnitConfiguration *channelUnitConfiguration;
     [invocation getArgument:&channelUnitConfiguration atIndex:2];
-    XCTAssertEqual([channelUnitConfiguration flushInterval], 3.0);
+    XCTAssertEqual([channelUnitConfiguration flushInterval], 3);
     [expectation fulfill];
   });
 
@@ -227,7 +227,7 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     MSChannelUnitConfiguration *channelUnitConfiguration;
     [invocation getArgument:&channelUnitConfiguration atIndex:2];
-    XCTAssertEqual([channelUnitConfiguration flushInterval], 3.0);
+    XCTAssertEqual([channelUnitConfiguration flushInterval], 3);
     [expectation fulfill];
   });
 
@@ -250,20 +250,20 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 }
 
 - (void)testSetTransmissionIntervalNotAppliedAfterStart {
-  
+
   // If
   NSUInteger testInterval = 5;
   id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
-  
+
   // When
   [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
                                             appSecret:kMSTestAppSecret
                               transmissionTargetToken:nil
                                       fromApplication:YES];
-  
+
   // Make sure that interval is not set after service start.
   [MSAnalytics setTransmissionInterval:testInterval];
-  
+
   // Then
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
@@ -13,6 +13,7 @@
 #import "MSBooleanTypedProperty.h"
 #import "MSChannelGroupDefault.h"
 #import "MSChannelUnitDefault.h"
+#import "MSChannelUnitConfiguration.h"
 #import "MSConstants+Internal.h"
 #import "MSDateTimeTypedProperty.h"
 #import "MSDoubleTypedProperty.h"
@@ -150,6 +151,102 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
+}
+
+- (void)testSetTransmissionIntervalApplied {
+  
+  // If
+  NSUInteger testInterval = 5.0;
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for addChannelUnitWithConfiguration to be called with right configuration"];
+  id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
+  OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY])
+  .andDo(^(NSInvocation *invocation) {
+    MSChannelUnitConfiguration *channelUnitConfiguration;
+    [invocation getArgument:&channelUnitConfiguration atIndex:2];
+    XCTAssertEqual([channelUnitConfiguration flushInterval], testInterval);
+    [expectation fulfill];
+  });
+  
+  // When
+  [MSAnalytics setTransmissionInterval: testInterval];
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil
+                                      fromApplication:YES];
+  
+  //Then
+  // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
+  [[MSAnalytics sharedInstance].sessionTracker stop];
+  [self waitForExpectationsWithTimeout:1
+                               handler:^(NSError *error) {
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                               }];
+}
+
+- (void)testSetTransmissionIntervalNotApplied {
+  
+  // If
+  NSUInteger testInterval = 2.0;
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for addChannelUnitWithConfiguration to be called with right configuration"];
+  id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
+  OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY])
+  .andDo(^(NSInvocation *invocation) {
+    MSChannelUnitConfiguration *channelUnitConfiguration;
+    [invocation getArgument:&channelUnitConfiguration atIndex:2];
+    XCTAssertEqual([channelUnitConfiguration flushInterval], 3.0);
+    [expectation fulfill];
+  });
+  
+  // When
+  [MSAnalytics setTransmissionInterval: testInterval];
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil
+                                      fromApplication:YES];
+  
+  //Then
+  // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
+  [[MSAnalytics sharedInstance].sessionTracker stop];
+  [self waitForExpectationsWithTimeout:1
+                               handler:^(NSError *error) {
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                               }];
+}
+
+- (void)testSetTransmissionIntervalNotAppliedIfHigherThanDay {
+  
+  // If
+  NSUInteger testInterval = 25 * 60 * 60;
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for addChannelUnitWithConfiguration to be called with right configuration"];
+  id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
+  OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY])
+  .andDo(^(NSInvocation *invocation) {
+    MSChannelUnitConfiguration *channelUnitConfiguration;
+    [invocation getArgument:&channelUnitConfiguration atIndex:2];
+    XCTAssertEqual([channelUnitConfiguration flushInterval], 3.0);
+    [expectation fulfill];
+  });
+  
+  // When
+  [MSAnalytics setTransmissionInterval: testInterval];
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil
+                                      fromApplication:YES];
+  
+  //Then
+  // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
+  [[MSAnalytics sharedInstance].sessionTracker stop];
+  [self waitForExpectationsWithTimeout:1
+                               handler:^(NSError *error) {
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                               }];
 }
 
 - (void)testDisablingAnalyticsClearsSessionHistory {

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
@@ -249,6 +249,27 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
                                }];
 }
 
+- (void)testSetTransmissionIntervalNotAppliedAfterStart {
+  
+  // If
+  NSUInteger testInterval = 5;
+  id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
+  
+  // When
+  [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:nil
+                                      fromApplication:YES];
+  
+  // Make sure that interval is not set after service start.
+  [MSAnalytics setTransmissionInterval:testInterval];
+  
+  // Then
+  // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
+  [[MSAnalytics sharedInstance].sessionTracker stop];
+  XCTAssertNotEqual([MSAnalytics sharedInstance].flushInterval, testInterval);
+}
+
 - (void)testDisablingAnalyticsClearsSessionHistory {
   [[MSAnalytics sharedInstance] startWithChannelGroup:OCMProtocolMock(@protocol(MSChannelGroupProtocol))
                                             appSecret:kMSTestAppSecret

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
@@ -12,8 +12,8 @@
 #import "MSAuthTokenContextPrivate.h"
 #import "MSBooleanTypedProperty.h"
 #import "MSChannelGroupDefault.h"
-#import "MSChannelUnitDefault.h"
 #import "MSChannelUnitConfiguration.h"
+#import "MSChannelUnitDefault.h"
 #import "MSConstants+Internal.h"
 #import "MSDateTimeTypedProperty.h"
 #import "MSDoubleTypedProperty.h"
@@ -154,27 +154,27 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 }
 
 - (void)testSetTransmissionIntervalApplied {
-  
+
   // If
   NSUInteger testInterval = 5.0;
-  XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for addChannelUnitWithConfiguration to be called with right configuration"];
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Wait for addChannelUnitWithConfiguration to be called with right configuration"];
   id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
-  OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY])
-  .andDo(^(NSInvocation *invocation) {
+  OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     MSChannelUnitConfiguration *channelUnitConfiguration;
     [invocation getArgument:&channelUnitConfiguration atIndex:2];
     XCTAssertEqual([channelUnitConfiguration flushInterval], testInterval);
     [expectation fulfill];
   });
-  
+
   // When
-  [MSAnalytics setTransmissionInterval: testInterval];
+  [MSAnalytics setTransmissionInterval:testInterval];
   [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
                                             appSecret:kMSTestAppSecret
                               transmissionTargetToken:nil
                                       fromApplication:YES];
-  
-  //Then
+
+  // Then
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
   [self waitForExpectationsWithTimeout:1
@@ -186,27 +186,27 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 }
 
 - (void)testSetTransmissionIntervalNotApplied {
-  
+
   // If
   NSUInteger testInterval = 2.0;
-  XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for addChannelUnitWithConfiguration to be called with right configuration"];
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Wait for addChannelUnitWithConfiguration to be called with right configuration"];
   id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
-  OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY])
-  .andDo(^(NSInvocation *invocation) {
+  OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     MSChannelUnitConfiguration *channelUnitConfiguration;
     [invocation getArgument:&channelUnitConfiguration atIndex:2];
     XCTAssertEqual([channelUnitConfiguration flushInterval], 3.0);
     [expectation fulfill];
   });
-  
+
   // When
-  [MSAnalytics setTransmissionInterval: testInterval];
+  [MSAnalytics setTransmissionInterval:testInterval];
   [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
                                             appSecret:kMSTestAppSecret
                               transmissionTargetToken:nil
                                       fromApplication:YES];
-  
-  //Then
+
+  // Then
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
   [self waitForExpectationsWithTimeout:1
@@ -218,27 +218,27 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
 }
 
 - (void)testSetTransmissionIntervalNotAppliedIfHigherThanDay {
-  
+
   // If
   NSUInteger testInterval = 25 * 60 * 60;
-  XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for addChannelUnitWithConfiguration to be called with right configuration"];
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Wait for addChannelUnitWithConfiguration to be called with right configuration"];
   id<MSChannelGroupProtocol> channelGroupMock = OCMProtocolMock(@protocol(MSChannelGroupProtocol));
-  OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY])
-  .andDo(^(NSInvocation *invocation) {
+  OCMStub([channelGroupMock addChannelUnitWithConfiguration:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     MSChannelUnitConfiguration *channelUnitConfiguration;
     [invocation getArgument:&channelUnitConfiguration atIndex:2];
     XCTAssertEqual([channelUnitConfiguration flushInterval], 3.0);
     [expectation fulfill];
   });
-  
+
   // When
-  [MSAnalytics setTransmissionInterval: testInterval];
+  [MSAnalytics setTransmissionInterval:testInterval];
   [[MSAnalytics sharedInstance] startWithChannelGroup:channelGroupMock
                                             appSecret:kMSTestAppSecret
                               transmissionTargetToken:nil
                                       fromApplication:YES];
-  
-  //Then
+
+  // Then
   // FIXME: logManager holds session tracker somehow and it causes other test failures. Stop it for hack.
   [[MSAnalytics sharedInstance].sessionTracker stop];
   [self waitForExpectationsWithTimeout:1
@@ -461,11 +461,12 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
                                             appSecret:kMSTestAppSecret
                               transmissionTargetToken:nil
                                       fromApplication:YES];
-  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSEventLog class]] flags:MSFlagsDefault]).andDo(^(NSInvocation *invocation) {
-    MSEventLog *log;
-    [invocation getArgument:&log atIndex:2];
-    propertiesCount = log.typedProperties.properties.count;
-  });
+  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSEventLog class]] flags:MSFlagsDefault])
+      .andDo(^(NSInvocation *invocation) {
+        MSEventLog *log;
+        [invocation getArgument:&log atIndex:2];
+        propertiesCount = log.typedProperties.properties.count;
+      });
 
   // When
   NSMutableDictionary *properties = [NSMutableDictionary new];
@@ -488,11 +489,12 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
                                             appSecret:kMSTestAppSecret
                               transmissionTargetToken:nil
                                       fromApplication:YES];
-  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSEventLog class]] flags:MSFlagsDefault]).andDo(^(NSInvocation *invocation) {
-    MSEventLog *log;
-    [invocation getArgument:&log atIndex:2];
-    tag = log.tag;
-  });
+  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSEventLog class]] flags:MSFlagsDefault])
+      .andDo(^(NSInvocation *invocation) {
+        MSEventLog *log;
+        [invocation getArgument:&log atIndex:2];
+        tag = log.tag;
+      });
 
   // When
   MSAnalyticsTransmissionTarget *target = [MSAnalytics transmissionTargetForToken:@"test"];
@@ -512,9 +514,10 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
                                             appSecret:kMSTestAppSecret
                               transmissionTargetToken:nil
                                       fromApplication:YES];
-  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSEventLog class]] flags:MSFlagsDefault]).andDo(^(NSInvocation *invocation) {
-    [invocation getArgument:&log atIndex:2];
-  });
+  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSEventLog class]] flags:MSFlagsDefault])
+      .andDo(^(NSInvocation *invocation) {
+        [invocation getArgument:&log atIndex:2];
+      });
 
   // When
   [MSAnalytics trackEvent:@"Some event"];
@@ -602,13 +605,14 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   __block MSEventProperties *eventProperties;
   NSString *expectedName = @"gotACoffee";
   NSDictionary *expectedProperties = @{@"milk" : @"yes", @"cookie" : @"of course"};
-  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSEventLog class]] flags:MSFlagsDefault]).andDo(^(NSInvocation *invocation) {
-    MSEventLog *log;
-    [invocation getArgument:&log atIndex:2];
-    type = log.type;
-    name = log.name;
-    eventProperties = log.typedProperties;
-  });
+  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSEventLog class]] flags:MSFlagsDefault])
+      .andDo(^(NSInvocation *invocation) {
+        MSEventLog *log;
+        [invocation getArgument:&log atIndex:2];
+        type = log.type;
+        name = log.name;
+        eventProperties = log.typedProperties;
+      });
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
   [[MSAnalytics sharedInstance] startWithChannelGroup:self.channelGroupMock
                                             appSecret:kMSTestAppSecret
@@ -642,13 +646,14 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   [expectedProperties setInt64:123 forKey:@"longKey"];
   [expectedProperties setDouble:1.23e2 forKey:@"doubleKey"];
   NSString *expectedName = @"gotACoffee";
-  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSEventLog class]] flags:MSFlagsDefault]).andDo(^(NSInvocation *invocation) {
-    MSEventLog *log;
-    [invocation getArgument:&log atIndex:2];
-    type = log.type;
-    name = log.name;
-    eventProperties = log.typedProperties;
-  });
+  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSEventLog class]] flags:MSFlagsDefault])
+      .andDo(^(NSInvocation *invocation) {
+        MSEventLog *log;
+        [invocation getArgument:&log atIndex:2];
+        type = log.type;
+        name = log.name;
+        eventProperties = log.typedProperties;
+      });
   [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
   [[MSAnalytics sharedInstance] startWithChannelGroup:self.channelGroupMock
                                             appSecret:kMSTestAppSecret

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSEventPropertiesTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSEventPropertiesTests.m
@@ -20,7 +20,7 @@
 - (void)testInitWithStringDictionaryWhenStringDictionaryHasValues {
 
   // If
-  NSDictionary *stringProperties = @{ @"key1" : @"val1", @"key2" : @"val2" };
+  NSDictionary *stringProperties = @{@"key1" : @"val1", @"key2" : @"val2"};
 
   // When
   MSEventProperties *sut = [[MSEventProperties alloc] initWithStringDictionary:stringProperties];


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [X] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

1. Add setTransmissionInterval API  for Analytics and MSAnalyticsTransmissionTarget. The API must be called before App Center start. 
2. Once call SetTransmissionInterval() API , it will apply the new interval to telemetry logs of all the tenants or sub tenants for that app. 
3. Upper limit should be a day and lower limit can be 3 seconds. 