### PR TITLE
Batching on custom interval

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -372,8 +372,9 @@ static NSString *const kMSStartTimestampPrefix = @"MSChannelStartTimer";
 - (void)checkPendingLogs {
 
   // Skip checking pending logs if the channel is paused.
-  if (self.paused)
+  if (self.paused) {
     return;
+  }
 
   // If the interval is default and we reached batchSizeLimit flush logs now.
   if (self.configuration.flushInterval == kMSFlushIntervalDefault && self.itemsCount >= self.configuration.batchSizeLimit) {
@@ -463,7 +464,6 @@ static NSString *const kMSStartTimestampPrefix = @"MSChannelStartTimer";
     else {
       flushInterval -= (NSUInteger)[now timeIntervalSinceDate:startTime];
     }
-    return MAX(flushInterval, kMSFlushIntervalDefault);
   }
   return flushInterval;
 }

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -371,19 +371,30 @@ static NSString *const kMSStartTimestampPrefix = @"MSChannelStartTimer";
 
 - (void)checkPendingLogs {
 
-  // Flush now if current batch is full or delay to later.
-  if (self.itemsCount >= self.configuration.batchSizeLimit) {
-    [self flushQueue];
-  } else if (self.itemsCount > 0 && !self.paused) {
+  // Skip checking pending logs if the channel is paused.
+  if (self.paused)
+    return;
 
-    // Only start timer if channel is not paused. Otherwise, logs will stack.
-    [self startTimer];
+  // If the interval is default and we reached batchSizeLimit flush logs now.
+  if (self.configuration.flushInterval == kMSFlushIntervalDefault && self.itemsCount >= self.configuration.batchSizeLimit) {
+    [self flushQueue];
+  } else if (self.itemsCount > 0) {
+    NSInteger flushInterval = [self resolveFlushInterval];
+    if (flushInterval == 0) {
+
+      // If the interval is over, send all logs without any additional timers.
+      [self flushQueue];
+    } else {
+
+      // Postpone sending logs.
+      [self startTimer:flushInterval];
+    }
   }
 }
 
 #pragma mark - Timer
 
-- (void)startTimer {
+- (void)startTimer:(NSUInteger)flushInterval {
 
   // Don't start timer while disabled.
   if (!self.enabled) {
@@ -395,7 +406,6 @@ static NSString *const kMSStartTimestampPrefix = @"MSChannelStartTimer";
 
   // Create new timer.
   self.timerSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.logsDispatchQueue);
-  NSUInteger flushInterval = [self resolveFlushInterval];
 
   /**
    * Cast (NSEC_PER_SEC * flushInterval) to (int64_t) silence warning. The compiler otherwise complains that we're using
@@ -428,17 +438,30 @@ static NSString *const kMSStartTimestampPrefix = @"MSChannelStartTimer";
  */
 - (NSUInteger)resolveFlushInterval {
   NSUInteger flushInterval = self.configuration.flushInterval;
+
+  // If the interval is custom.
   if (flushInterval > kMSFlushIntervalDefault) {
-    NSDate *date = [NSDate date];
+    NSDate *now = [NSDate date];
     NSDate *startTime = [MS_USER_DEFAULTS objectForKey:[self startTimeKey]];
+
+    // The timer isn't started, so start it and store the current time.
     if (startTime == nil) {
-      [MS_USER_DEFAULTS setObject:date forKey:[self startTimeKey]];
+      [MS_USER_DEFAULTS setObject:now forKey:[self startTimeKey]];
     }
-    // If a user has incorrect timestamp that is greater than current time ingore it and clear.
-    else if ([date compare:startTime] == NSOrderedAscending) {
+
+    // Handle invalid values (start time in the future).
+    else if ([now compare:startTime] == NSOrderedAscending) {
       [MS_USER_DEFAULTS removeObjectForKey:[self startTimeKey]];
-    } else {
-      flushInterval -= (NSUInteger)[date timeIntervalSinceDate:startTime];
+    }
+
+    // If the interval is over.
+    else if ([now compare:[startTime dateByAddingTimeInterval:flushInterval]] == NSOrderedDescending) {
+      return 0;
+    }
+
+    // We still have to wait for the rest of the interval.
+    else {
+      flushInterval -= (NSUInteger)[now timeIntervalSinceDate:startTime];
     }
     return MAX(flushInterval, kMSFlushIntervalDefault);
   }

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -132,6 +132,35 @@ static NSString *const kMSTestGroupId = @"GroupId";
   [dateMock stopMocking];
 }
 
+- (void)testResolveFlushIntervalTimeIsOut {
+
+  // If
+  __block NSDate *date;
+  id dateMock = OCMClassMock([NSDate class]);
+  NSUInteger flushInterval = 2000;
+
+  // Configure channel.
+  self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
+                                                                      priority:MSPriorityDefault
+                                                                 flushInterval:flushInterval
+                                                                batchSizeLimit:50
+                                                           pendingBatchesLimit:1];
+  OCMStub(ClassMethod([dateMock date])).andDo(^(NSInvocation *invocation) {
+    date = [[NSDate alloc] initWithTimeIntervalSince1970:3000];
+    [invocation setReturnValue:&date];
+  });
+  [self.settingsMock setObject:[[NSDate alloc] initWithTimeIntervalSince1970:500] forKey:self.sut.startTimeKey];
+
+  // When
+  NSUInteger resultFlushInterval = [self.sut resolveFlushInterval];
+
+  // Then
+  XCTAssertEqual(resultFlushInterval, 0);
+
+  // Clear
+  [dateMock stopMocking];
+}
+
 - (void)testResolveFlushIntervalTimestampLaterThanNow {
 
   // If

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -212,7 +212,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   NSUInteger resultFlushInterval = [self.sut resolveFlushInterval];
 
   // Then
-  XCTAssertEqual(resultFlushInterval, kMSFlushIntervalDefault);
+  XCTAssertEqual(resultFlushInterval, 0);
 
   // Clear
   [dateMock stopMocking];


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

If a customer wants to send logs only once every day, the SDK must not ignore that time interval once 50 logs are pending.

The send immediately 50 logs rule must apply only when the default of 3 seconds is used.

We must still split logs sent to ingestion by batches of 50 (would be better byte size based but that's out of scope) to avoid hitting payload size limit.

So if SDK has 200 logs, it must still wait transmission interval (1 day for example) and then send all the 200 logs at once (send 3 batches of 50, wait 1 to complete, send the 4th one immediately after 1 of the batches completed).

## Related PRs or issues

https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/61888/

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
