### PR TITLE
Fix tokens enumeration

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -300,28 +300,28 @@
                         if (logArray.count > 0) {
                           MSLogContainer *container = [[MSLogContainer alloc] initWithBatchId:batchId andLogs:logArray];
                           [self sendLogContainer:container withAuthTokenFromArray:tokenArray atIndex:tokenIndex];
-                        } else {
+                        }
 
-                          // No logs available with given params.
-                          if (tokenIndex == 0 && tokenArray[tokenIndex].endTime != nil &&
-                              [self.storage countLogsBeforeDate:tokenArray[tokenIndex].endTime] == 0) {
+                        // No logs available with given params.
+                        else if (tokenIndex == 0 && tokenArray[tokenIndex].endTime != nil &&
+                            [self.storage countLogsBeforeDate:tokenArray[tokenIndex].endTime] == 0) {
 
-                            // Delete token from history if we don't have logs fitting it in DB.
-                            [[MSAuthTokenContext sharedInstance] removeAuthToken:tokenInfo.authToken];
-                          }
-
-                          // Check to determine if the next index is within bounds.
-                          if (tokenIndex + 1 < tokenArray.count) {
-
-                            // Iterate to next token in array.
-                            [self flushQueueForTokenArray:tokenArray withTokenIndex:tokenIndex + 1];
-                          }
+                          // Delete token from history if we don't have logs fitting it in DB.
+                          [[MSAuthTokenContext sharedInstance] removeAuthToken:tokenInfo.authToken];
                         }
                       }];
 
   // Flush again if there is another batch to send.
-  if (self.availableBatchFromStorage && !self.pendingBatchQueueFull) {
-    [self flushQueueForTokenArray:tokenArray withTokenIndex:tokenIndex];
+  if (!self.pendingBatchQueueFull) {
+
+    // Check if there are more logs for this token, if not - move to the next one.
+    if (self.availableBatchFromStorage) {
+      [self flushQueueForTokenArray:tokenArray withTokenIndex:tokenIndex];
+    } else if (tokenIndex + 1 < tokenArray.count) {
+
+      // Iterate to next token in array.
+      [self flushQueueForTokenArray:tokenArray withTokenIndex:tokenIndex + 1];
+    }
   }
 }
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -304,7 +304,7 @@
 
                         // No logs available with given params.
                         else if (tokenIndex == 0 && tokenArray[tokenIndex].endTime != nil &&
-                            [self.storage countLogsBeforeDate:tokenArray[tokenIndex].endTime] == 0) {
+                                 [self.storage countLogsBeforeDate:tokenArray[tokenIndex].endTime] == 0) {
 
                           // Delete token from history if we don't have logs fitting it in DB.
                           [[MSAuthTokenContext sharedInstance] removeAuthToken:tokenInfo.authToken];

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -280,8 +280,8 @@ static NSString *const kMSStartTimestampPrefix = @"MSChannelStartTimer";
                 self.pendingBatchQueueFull = NO;
 
                 // Try to flush again if batch queue is not full anymore.
-                if (succeeded && self.availableBatchFromStorage) {
-                  [self flushQueueForTokenArray:tokenArray withTokenIndex:tokenIndex];
+                if (succeeded) {
+                  [self flushNextBatchFromQueueForTokenArray:tokenArray withTokenIndex:tokenIndex];
                 }
               }
             });
@@ -317,16 +317,21 @@ static NSString *const kMSStartTimestampPrefix = @"MSChannelStartTimer";
                       }];
 
   // Flush again if there is another batch to send.
-  if (!self.pendingBatchQueueFull) {
+  [self flushNextBatchFromQueueForTokenArray:tokenArray withTokenIndex:tokenIndex];
+}
 
-    // Check if there are more logs for this token, if not - move to the next one.
-    if (self.availableBatchFromStorage) {
-      [self flushQueueForTokenArray:tokenArray withTokenIndex:tokenIndex];
-    } else if (tokenIndex + 1 < tokenArray.count) {
+- (void)flushNextBatchFromQueueForTokenArray:(NSArray<MSAuthTokenValidityInfo *> *)tokenArray withTokenIndex:(NSUInteger)tokenIndex {
+  if (self.pendingBatchQueueFull) {
+    return;
+  }
 
-      // Iterate to next token in array.
-      [self flushQueueForTokenArray:tokenArray withTokenIndex:tokenIndex + 1];
-    }
+  // Check if there are more logs for this token, if not - move to the next one.
+  if (self.availableBatchFromStorage) {
+    [self flushQueueForTokenArray:tokenArray withTokenIndex:tokenIndex];
+  } else if (tokenIndex + 1 < tokenArray.count) {
+
+    // Iterate to next token in array.
+    [self flushQueueForTokenArray:tokenArray withTokenIndex:tokenIndex + 1];
   }
 }
 

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -95,7 +95,6 @@ static NSString *const kMSTestGroupId = @"GroupId";
   [MSDispatchTestUtil awaitAndSuspendDispatchQueue:self.logsDispatchQueue];
 
   // Stop mocks.
-  [self.configMock stopMocking];
   [self.settingsMock stopMocking];
   [self.authTokenContextMock stopMocking];
   [MSAuthTokenContext resetSharedInstance];

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -1297,7 +1297,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
     [[MSAuthTokenValidityInfo alloc] initWithAuthToken:@"token3" startTime:date3 endTime:date4]
   ];
 
-  // Configure channel.
+  // Configure storage mock.
   NSString *batchId = @"batchId";
   __block NSDate *dateAfter;
   __block NSDate *dateBefore;

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -1299,7 +1299,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   [tokenValidityArray addObject:token1];
   [tokenValidityArray addObject:token2];
   [tokenValidityArray addObject:token3];
-  NSArray<id<MSLog>> *logsForToken1 = [self getValidMockLogArrayForDate:date1 andCount:0];
+  NSArray<id<MSLog>> *logsForToken1 = [self getValidMockLogArrayForDate:date1 andCount:3];
   NSArray<id<MSLog>> *logsForToken2 = [self getValidMockLogArrayForDate:date2 andCount:0];
   NSArray<id<MSLog>> *logsForToken3 = [self getValidMockLogArrayForDate:date3 andCount:5];
   NSString *batchId = @"batchId";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@
 
 * **[Fix]** Remove Keychain permission pop-up on macOS.
 * **[Fix]** Improve encryption security.
-* **[Fix]** Fix the case when logs could be sent only on the next launch after changing signed in user or after pause/resume of the module.
 
 ### AppCenterAnalytics
 
 * **[Feature]** Support setting latency of sending events via `[MSAnalytics setTransmissionInterval:]`.
+
+### AppCenterAuth
+
+* **[Fix]** Fix changing signing status may cause logs (e.g., events) to be delayed.
 
 ### AppCenterData
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### AppCenter
 * **[Fix]** Remove Keychain permission pop-up on macOS.
 * **[Fix]** Improve encryption security.
+* **[Fix]** Fix the case when logs could be sent only on the next launch after changing signed in user or after pause/resume of the module.
 
 ### AppCenterData
 


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Resuming Analytics doesn't send pending Analytics logs from all tokens. It actually send logs corresponding to the oldest entry in the token history only. Resuming (or Pause/resuming) again triggers the sending for logs corresponding to other entries in the token history.

Repro:
1) Sign-out
2) Pause Analytics
3) Track an event
4) Sign-in 
5) Track an event
6) Resume (the anonymous event is sent)
7) Pause/Resume (the authenticated event is sent)

Expected behavior: Both events are sent on step 6)

## Related PRs or issues

[AB#61939](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/61939)
