### PR TITLE
Fix store interval when channel paused

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelUnitDefault.m
@@ -396,33 +396,6 @@ static NSString *const kMSStartTimestampPrefix = @"MSChannelStartTimer";
 
 #pragma mark - Timer
 
-- (NSUInteger)resolveFlushInterval {
-  NSUInteger flushInterval = self.configuration.flushInterval;
-
-  // If the interval is custom.
-  if (flushInterval > kMSFlushIntervalDefault) {
-    NSDate *now = [NSDate date];
-    NSDate *oldestPendingLogTimestamp = [MS_USER_DEFAULTS objectForKey:[self oldestPendingLogTimestampKey]];
-
-    // The timer isn't started or has invalid value (start time in the future), so start it and store the current time.
-    if (oldestPendingLogTimestamp == nil || [now compare:oldestPendingLogTimestamp] == NSOrderedAscending) {
-      [MS_USER_DEFAULTS setObject:now forKey:[self oldestPendingLogTimestampKey]];
-    }
-
-    // If the interval is over.
-    else if ([now compare:[oldestPendingLogTimestamp dateByAddingTimeInterval:flushInterval]] == NSOrderedDescending) {
-      [MS_USER_DEFAULTS removeObjectForKey:[self oldestPendingLogTimestampKey]];
-      return 0;
-    }
-
-    // We still have to wait for the rest of the interval.
-    else {
-      flushInterval -= (NSUInteger)[now timeIntervalSinceDate:oldestPendingLogTimestamp];
-    }
-  }
-  return flushInterval;
-}
-
 - (void)startTimer:(NSUInteger)flushInterval {
 
   // Don't start timer while disabled.
@@ -458,6 +431,33 @@ static NSString *const kMSStartTimestampPrefix = @"MSChannelStartTimer";
     }
   });
   dispatch_resume(self.timerSource);
+}
+
+- (NSUInteger)resolveFlushInterval {
+  NSUInteger flushInterval = self.configuration.flushInterval;
+
+  // If the interval is custom.
+  if (flushInterval > kMSFlushIntervalDefault) {
+    NSDate *now = [NSDate date];
+    NSDate *oldestPendingLogTimestamp = [MS_USER_DEFAULTS objectForKey:[self oldestPendingLogTimestampKey]];
+
+    // The timer isn't started or has invalid value (start time in the future), so start it and store the current time.
+    if (oldestPendingLogTimestamp == nil || [now compare:oldestPendingLogTimestamp] == NSOrderedAscending) {
+      [MS_USER_DEFAULTS setObject:now forKey:[self oldestPendingLogTimestampKey]];
+    }
+
+    // If the interval is over.
+    else if ([now compare:[oldestPendingLogTimestamp dateByAddingTimeInterval:flushInterval]] == NSOrderedDescending) {
+      [MS_USER_DEFAULTS removeObjectForKey:[self oldestPendingLogTimestampKey]];
+      return 0;
+    }
+
+    // We still have to wait for the rest of the interval.
+    else {
+      flushInterval -= (NSUInteger)[now timeIntervalSinceDate:oldestPendingLogTimestamp];
+    }
+  }
+  return flushInterval;
 }
 
 - (NSString *)oldestPendingLogTimestampKey {

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -131,7 +131,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   [self waitForExpectationsWithTimeout:kMSTestTimeout
                                handler:^(NSError *error) {
                                  NSDate *resultDate = [self.settingsMock objectForKey:self.sut.oldestPendingLogTimestampKey];
-                                 XCTAssertEqual(date, resultDate);
+                                 XCTAssertTrue([date isEqualToDate:resultDate]);
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -104,6 +104,43 @@ static NSString *const kMSTestGroupId = @"GroupId";
 
 #pragma mark - Tests
 
+- (void)testPendingLogsStoresStartTimeWhenPaused {
+
+  // If
+  [self initChannelEndJobExpectation];
+  id dateMock = OCMClassMock([NSDate class]);
+  NSObject *object = [NSObject new];
+  NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:3000];
+  OCMStub([dateMock date]).andReturn(date);
+
+  // Configure channel with custom interval.
+  self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
+                                                                      priority:MSPriorityDefault
+                                                                 flushInterval:60
+                                                                batchSizeLimit:50
+                                                           pendingBatchesLimit:3];
+
+  // When
+  [self.sut pauseWithIdentifyingObjectSync:object];
+
+  // Trigger checkPengingLogs. Should save timestamp now.
+  [self.sut enqueueItem:[self getValidMockLog] flags:MSFlagsDefault];
+  [self enqueueChannelEndJobExpectation];
+
+  // Then
+  [self waitForExpectationsWithTimeout:kMSTestTimeout
+                               handler:^(NSError *error) {
+                                 NSDate *resultDate = [self.settingsMock objectForKey:self.sut.oldestPendingLogTimestampKey];
+                                 XCTAssertEqual(date, resultDate);
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                               }];
+
+  // Clear
+  [dateMock stopMocking];
+}
+
 - (void)testCustomFlushIntervalSending200Logs {
 
   // If


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Tracking an event with 1min interval / pause / resume after 30s / event is sent after 30s. Pausing doesn’t reset the timer. It’s probably fine since it's the same behavior if paused for any reasons like going to background on iOS or network down.
The issue is the behavior is different if the `trackEvent` happens while pausing; in this case the timer will wait for the entire latency. For instance: Pause / Tracking an event with 1min interval / resume after 30s / event is sent after 1min 30s.

Fix: store the oldest log timestamp even when the channel is paused.

## Related PRs or issues

[AB#62191](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/62191/)

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
