### PR TITLE
Delete Document API Bug

### DIFF
--- a/AppCenterData/AppCenterData/Internal/Client/MSCosmosDb.m
+++ b/AppCenterData/AppCenterData/Internal/Client/MSCosmosDb.m
@@ -46,7 +46,7 @@ static NSString *const kMSDocumentDbAuthorizationHeaderFormat = @"type=master&ve
 /**
  * Url character set to skip(utf8 encoding).
  */
-static NSString *const kMSUrlCharactersToEscape = @"!*'();:@&=+$,/?%#[] ";
+static NSString *const kMSUrlCharactersToEscape = @"!*'();:@&=+$,/?%#[]\" ";
 
 /**
  * RFC1123 locale.
@@ -127,7 +127,8 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
 + (NSString *)documentUrlWithTokenResult:(MSTokenResult *)tokenResult documentId:(NSString *_Nullable)documentId {
   NSString *documentResourceIdPrefix = [MSCosmosDb documentBaseUrlWithDatabaseName:tokenResult.dbName
                                                                     collectionName:tokenResult.dbCollectionName
-                                                                        documentId:documentId];
+                                                                        documentId:[MSCosmosDb encodeUrl:(NSString *)documentId]];
+
   return [MSCosmosDb documentDbEndpointWithDbAccount:tokenResult.dbAccount documentResourceId:documentResourceIdPrefix];
 }
 

--- a/AppCenterData/AppCenterData/Internal/Client/MSCosmosDb.m
+++ b/AppCenterData/AppCenterData/Internal/Client/MSCosmosDb.m
@@ -128,7 +128,6 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
   NSString *documentResourceIdPrefix = [MSCosmosDb documentBaseUrlWithDatabaseName:tokenResult.dbName
                                                                     collectionName:tokenResult.dbCollectionName
                                                                         documentId:documentId];
-
   return [MSCosmosDb documentDbEndpointWithDbAccount:tokenResult.dbAccount documentResourceId:documentResourceIdPrefix];
 }
 

--- a/AppCenterData/AppCenterData/Internal/Client/MSCosmosDb.m
+++ b/AppCenterData/AppCenterData/Internal/Client/MSCosmosDb.m
@@ -127,7 +127,7 @@ static NSString *const kMSHeaderMsDate = @"x-ms-date";
 + (NSString *)documentUrlWithTokenResult:(MSTokenResult *)tokenResult documentId:(NSString *_Nullable)documentId {
   NSString *documentResourceIdPrefix = [MSCosmosDb documentBaseUrlWithDatabaseName:tokenResult.dbName
                                                                     collectionName:tokenResult.dbCollectionName
-                                                                        documentId:[MSCosmosDb encodeUrl:(NSString *)documentId]];
+                                                                        documentId:documentId];
 
   return [MSCosmosDb documentDbEndpointWithDbAccount:tokenResult.dbAccount documentResourceId:documentResourceIdPrefix];
 }

--- a/AppCenterData/AppCenterData/MSData.m
+++ b/AppCenterData/AppCenterData/MSData.m
@@ -63,7 +63,7 @@ static char *const kMSDataDispatchQueue = "com.microsoft.appcenter.DataDispatchQ
 /**
  * Document ID validation pattern.
  */
-static NSString *const kMSDocumentIdValidationPattern = @"^[^/\\\\#\?]+\\z";
+static NSString *const kMSDocumentIdValidationPattern = @"^[^/\\\\#\\s?]+\\z";
 
 /**
  * Singleton.

--- a/AppCenterData/AppCenterData/MSData.m
+++ b/AppCenterData/AppCenterData/MSData.m
@@ -63,7 +63,7 @@ static char *const kMSDataDispatchQueue = "com.microsoft.appcenter.DataDispatchQ
 /**
  * Document ID validation pattern.
  */
-static NSString *const kMSDocumentIdValidationPattern = @"^[^/\\\\#\\s?]+\\z";
+static NSString *const kMSDocumentIdValidationPattern = @"^[^/\\\\#\?]+\\z";
 
 /**
  * Singleton.

--- a/AppCenterData/AppCenterDataTests/MSDataTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDataTests.m
@@ -701,6 +701,25 @@ static NSString *const kMSDocumentIdTest = @"documentId";
   XCTAssertTrue([testResult containsString:kMSDbCollectionNameTest]);
 }
 
+- (void)testDocumentUrlWithTokenResultDocumentIdEncoding {
+
+  // If
+  MSTokenResult *tokenResult = [[MSTokenResult alloc] initWithDictionary:[self prepareMutableDictionary]];
+  NSString *documentId = @"docIdWith\"doubleQuote";
+  NSString *encodedDocumentId = @"docIdWith%22doubleQuote";
+
+  // When
+  NSString *testResult = [MSCosmosDb documentUrlWithTokenResult:tokenResult documentId:documentId];
+
+  // Then
+  XCTAssertNotNil(testResult);
+  XCTAssertFalse([testResult containsString:documentId]);
+  XCTAssertTrue([testResult containsString:kMSDbAccountTest]);
+  XCTAssertTrue([testResult containsString:kMSDbNameTest]);
+  XCTAssertTrue([testResult containsString:kMSDbCollectionNameTest]);
+  XCTAssertTrue([testResult containsString:encodedDocumentId]);
+}
+
 - (void)testGetCosmosDbErrorWithNilEverything {
 
   // If


### PR DESCRIPTION
-fixed the bug with deleting document with double quote in document ID

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
Currently deleting the documents with double quote in the id causes error. the fix is to url encode the document id.