### PR TITLE
Last Update Time Bug + Etag null bug

### DIFF
--- a/AppCenterData/AppCenterData/Internal/LocalStore/MSDBDocumentStore.m
+++ b/AppCenterData/AppCenterData/Internal/LocalStore/MSDBDocumentStore.m
@@ -79,7 +79,7 @@ static const NSUInteger kMSSchemaVersion = 1;
   NSTimeInterval now = NSDate.timeIntervalSinceReferenceDate + NSTimeIntervalSince1970;
   NSString *tableName = [MSDBDocumentStore tableNameForPartition:token.partition];
 
-  // If operation or etag is nil, pass NULL value, else use the atcual value in this format '<ACTUAL_VALUE>' (note the single quotes).
+  // If operation or etag is nil, pass NULL value, else use the actual value in this format '<ACTUAL_VALUE>' (note the single quotes).
   NSString *normalizedOperationString = operation != nil ? [NSString stringWithFormat:@"'%@'", operation] : @"NULL";
   NSString *normalizedEtagString = documentWrapper.eTag != nil ? [NSString stringWithFormat:@"'%@'", documentWrapper.eTag] : @"NULL";
   NSString *insertQuery = [NSString

--- a/AppCenterData/AppCenterDataTests/MSDBDocumentStoreTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDBDocumentStoreTests.m
@@ -371,6 +371,106 @@
   XCTAssertEqual(expirationTime, kMSDataTimeToLiveInfinite);
 }
 
+- (void)testUpsertWontChangeLastUpdatedDate {
+
+  // If
+  long lastUpdateDateLong = (long)[[NSDate date] timeIntervalSince1970];
+  NSDate *lastUpdateDate = [NSDate dateWithTimeIntervalSince1970:lastUpdateDateLong];
+  MSDocumentWrapper *documentWrapper = [[MSDocumentWrapper alloc] initWithDeserializedValue:[MSDictionaryDocument alloc]
+                                                                                  jsonValue:@"{\"key\" : \"value\"}"
+                                                                                  partition:kMSDataAppDocumentsPartition
+                                                                                 documentId:@"documentId"
+                                                                                       eTag:@"myEtag"
+                                                                            lastUpdatedDate:lastUpdateDate
+                                                                           pendingOperation:kMSPendingOperationCreate
+                                                                            fromDeviceCache:YES];
+  // When
+  BOOL result = [self.sut upsertWithToken:self.appToken
+                          documentWrapper:documentWrapper
+                                operation:documentWrapper.pendingOperation
+                         deviceTimeToLive:kMSDataTimeToLiveInfinite];
+  MSDocumentWrapper *expectedDocumentWrapper = [self.sut readWithToken:self.appToken
+                                                            documentId:documentWrapper.documentId
+                                                          documentType:[MSDictionaryDocument class]];
+
+  // Then
+  XCTAssertTrue(result);
+  XCTAssertNil(expectedDocumentWrapper.error);
+  XCTAssertTrue(documentWrapper.fromDeviceCache);
+  XCTAssertNotNil(expectedDocumentWrapper.deserializedValue);
+  XCTAssertNotNil(expectedDocumentWrapper.jsonValue);
+  XCTAssertEqualObjects(expectedDocumentWrapper.documentId, documentWrapper.documentId);
+  XCTAssertEqualObjects(expectedDocumentWrapper.partition, documentWrapper.partition);
+  XCTAssertEqualObjects(expectedDocumentWrapper.eTag, documentWrapper.eTag);
+  XCTAssertEqualObjects(expectedDocumentWrapper.lastUpdatedDate, documentWrapper.lastUpdatedDate);
+}
+
+- (void)testUpsertWithNilLastUpdatedDate {
+
+  // If
+  MSDocumentWrapper *documentWrapper = [[MSDocumentWrapper alloc] initWithDeserializedValue:[MSDictionaryDocument alloc]
+                                                                                  jsonValue:@"{\"key\" : \"value\"}"
+                                                                                  partition:kMSDataAppDocumentsPartition
+                                                                                 documentId:@"documentId"
+                                                                                       eTag:@"myEtag"
+                                                                            lastUpdatedDate:nil
+                                                                           pendingOperation:kMSPendingOperationCreate
+                                                                            fromDeviceCache:YES];
+  // When
+  BOOL result = [self.sut upsertWithToken:self.appToken
+                          documentWrapper:documentWrapper
+                                operation:documentWrapper.pendingOperation
+                         deviceTimeToLive:kMSDataTimeToLiveInfinite];
+  MSDocumentWrapper *expectedDocumentWrapper = [self.sut readWithToken:self.appToken
+                                                            documentId:documentWrapper.documentId
+                                                          documentType:[MSDictionaryDocument class]];
+
+  // Then
+  XCTAssertTrue(result);
+  XCTAssertNil(expectedDocumentWrapper.error);
+  XCTAssertTrue(documentWrapper.fromDeviceCache);
+  XCTAssertNotNil(expectedDocumentWrapper.deserializedValue);
+  XCTAssertNotNil(expectedDocumentWrapper.jsonValue);
+  XCTAssertEqualObjects(expectedDocumentWrapper.documentId, documentWrapper.documentId);
+  XCTAssertEqualObjects(expectedDocumentWrapper.partition, documentWrapper.partition);
+  XCTAssertEqualObjects(expectedDocumentWrapper.eTag, documentWrapper.eTag);
+  XCTAssertNil(expectedDocumentWrapper.lastUpdatedDate);
+}
+
+- (void)testUpsertWithNilEtag {
+
+  // If
+  long lastUpdateDateLong = (long)[[NSDate date] timeIntervalSince1970];
+  NSDate *lastUpdateDate = [NSDate dateWithTimeIntervalSince1970:lastUpdateDateLong];
+  MSDocumentWrapper *documentWrapper = [[MSDocumentWrapper alloc] initWithDeserializedValue:[MSDictionaryDocument alloc]
+                                                                                  jsonValue:@"{\"key\" : \"value\"}"
+                                                                                  partition:kMSDataAppDocumentsPartition
+                                                                                 documentId:@"documentId"
+                                                                                       eTag:nil
+                                                                            lastUpdatedDate:lastUpdateDate
+                                                                           pendingOperation:kMSPendingOperationCreate
+                                                                            fromDeviceCache:YES];
+  // When
+  BOOL result = [self.sut upsertWithToken:self.appToken
+                          documentWrapper:documentWrapper
+                                operation:documentWrapper.pendingOperation
+                         deviceTimeToLive:kMSDataTimeToLiveInfinite];
+  MSDocumentWrapper *expectedDocumentWrapper = [self.sut readWithToken:self.appToken
+                                                            documentId:documentWrapper.documentId
+                                                          documentType:[MSDictionaryDocument class]];
+
+  // Then
+  XCTAssertTrue(result);
+  XCTAssertNil(expectedDocumentWrapper.error);
+  XCTAssertTrue(documentWrapper.fromDeviceCache);
+  XCTAssertNotNil(expectedDocumentWrapper.deserializedValue);
+  XCTAssertNotNil(expectedDocumentWrapper.jsonValue);
+  XCTAssertEqualObjects(expectedDocumentWrapper.documentId, documentWrapper.documentId);
+  XCTAssertEqualObjects(expectedDocumentWrapper.partition, documentWrapper.partition);
+  XCTAssertNil(expectedDocumentWrapper.eTag);
+  XCTAssertEqualObjects(expectedDocumentWrapper.lastUpdatedDate, documentWrapper.lastUpdatedDate);
+}
+
 - (void)testDeleteAppDocumentForNonExistentDocument {
 
   // If, When


### PR DESCRIPTION
-only change the last update time when new value comes from Cosmos and do not change it locally
-fixed the value written to DB when etag is nil

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Before this fix, the value of operation time was updated on every upsert operation. this caused inconsistency between the local value and CosmoDB remote value.
Also, fix the bug where etag is null(to retrieve it as nil value).
