### PR TITLE
Add remoteOperation delegate to data module

### DIFF
--- a/AppCenterData/AppCenterData.xcodeproj/project.pbxproj
+++ b/AppCenterData/AppCenterData.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		046964491F2A5B4D00F9D31F /* AppCenter+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = D3AD5F0B1E5C819A001627AB /* AppCenter+Internal.h */; };
 		0469644E1F2A5D2800F9D31F /* AppCenterData.h in Headers */ = {isa = PBXBuildFile; fileRef = D33A94541E5B11BB003966DB /* AppCenterData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0469644F1F2A5D4A00F9D31F /* MSDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D3AD5EC21E5C4F6A001627AB /* MSDataTests.m */; };
+		048BF75722A6F4110099FF73 /* MSRemoteOperationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AE2E97E229F26DC004BF371 /* MSRemoteOperationDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		048BF75822A6F4270099FF73 /* MSRemoteOperationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AE2E97E229F26DC004BF371 /* MSRemoteOperationDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0496A67B1F3128CE005AE1DB /* MSDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D3AD5EC21E5C4F6A001627AB /* MSDataTests.m */; };
 		049BC84E224EDAEE00AE7FBB /* MSBaseOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 267464DF222F28A200EC1FF3 /* MSBaseOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		049BC84F224EDAF300AE7FBB /* MSBaseOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 267464EA222F28A300EC1FF3 /* MSBaseOptions.m */; };
@@ -718,6 +720,7 @@
 				E820F1A4222767C5009EFA5D /* MSTokenExchange.h in Headers */,
 				049BC850224EDAF600AE7FBB /* MSData.h in Headers */,
 				E8593A19222B91C90001F87E /* MSCosmosDb.h in Headers */,
+				048BF75822A6F4270099FF73 /* MSRemoteOperationDelegate.h in Headers */,
 				E8B79376225EB13700CB3D1D /* MSPendingOperation.h in Headers */,
 				04A0820D1F74BBCF00DC776D /* MSService.h in Headers */,
 				35F515A9225BC6B0001BFFA2 /* MSDocumentWrapperInternal.h in Headers */,
@@ -758,6 +761,7 @@
 				D3AD5F0D1E5C844B001627AB /* MSServiceAbstract.h in Headers */,
 				267464F1222F28A300EC1FF3 /* MSWriteOptions.h in Headers */,
 				267464FB222F28A300EC1FF3 /* MSReadOptions.h in Headers */,
+				048BF75722A6F4110099FF73 /* MSRemoteOperationDelegate.h in Headers */,
 				D3AD5F0C1E5C819A001627AB /* AppCenter+Internal.h in Headers */,
 				E8B79375225EB13600CB3D1D /* MSPendingOperation.h in Headers */,
 				E824A5482225FDAC005B69B5 /* MSDataInternal.h in Headers */,

--- a/AppCenterData/AppCenterData.xcodeproj/project.pbxproj
+++ b/AppCenterData/AppCenterData.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		4A9C4403223B2408008548A7 /* MSTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C4400223B23E3008548A7 /* MSTokenTests.m */; };
 		4ACEAC9E225418B600976AEA /* MSDBDocumentStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4ACEAC9D225418B600976AEA /* MSDBDocumentStoreTests.m */; };
 		4ACEAC9F225418B600976AEA /* MSDBDocumentStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4ACEAC9D225418B600976AEA /* MSDBDocumentStoreTests.m */; };
+		4AE2E97F229F26DC004BF371 /* MSRemoteOperationDelegate.h in Sources */ = {isa = PBXBuildFile; fileRef = 4AE2E97E229F26DC004BF371 /* MSRemoteOperationDelegate.h */; };
+		4AE2E980229F26DC004BF371 /* MSRemoteOperationDelegate.h in Sources */ = {isa = PBXBuildFile; fileRef = 4AE2E97E229F26DC004BF371 /* MSRemoteOperationDelegate.h */; };
 		87FC45D718C70D5B72340A1C /* MSCosmosDbPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 87FA7FB5BC7302D0062016E1 /* MSCosmosDbPrivate.h */; };
 		87FD963F7BF9C9E07DE16D82 /* MSCosmosDbPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 87FA7FB5BC7302D0062016E1 /* MSCosmosDbPrivate.h */; };
 		8F1E76E922652B9D00A6D39F /* MSDataOperationProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F1E76E822652B9D00A6D39F /* MSDataOperationProxyTests.m */; };
@@ -317,6 +319,7 @@
 		4A193735225129B700459E1E /* MSDBDocumentStorePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSDBDocumentStorePrivate.h; sourceTree = "<group>"; };
 		4A9C4400223B23E3008548A7 /* MSTokenTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSTokenTests.m; sourceTree = "<group>"; };
 		4ACEAC9D225418B600976AEA /* MSDBDocumentStoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MSDBDocumentStoreTests.m; sourceTree = "<group>"; };
+		4AE2E97E229F26DC004BF371 /* MSRemoteOperationDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSRemoteOperationDelegate.h; sourceTree = "<group>"; };
 		7FE685B62275432200C2F4BA /* MSPageInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSPageInternal.h; sourceTree = "<group>"; };
 		7FE685B7227546AE00C2F4BA /* MSDataErrorInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSDataErrorInternal.h; sourceTree = "<group>"; };
 		87FA7FB5BC7302D0062016E1 /* MSCosmosDbPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSCosmosDbPrivate.h; sourceTree = "<group>"; };
@@ -550,6 +553,7 @@
 				267464E8222F28A300EC1FF3 /* MSPaginatedDocuments.m */,
 				267464EB222F28A300EC1FF3 /* MSReadOptions.h */,
 				267464E7222F28A300EC1FF3 /* MSReadOptions.m */,
+				4AE2E97E229F26DC004BF371 /* MSRemoteOperationDelegate.h */,
 				E8FE51E9221CBF87005FB52B /* MSSerializableDocument.h */,
 				267464E1222F28A300EC1FF3 /* MSWriteOptions.h */,
 				267464EC222F28A300EC1FF3 /* MSWriteOptions.m */,
@@ -1018,6 +1022,7 @@
 				049BC853224EDB0400AE7FBB /* MSDataError.m in Sources */,
 				049BC858224EDB1100AE7FBB /* MSReadOptions.m in Sources */,
 				049BC859224EDB1100AE7FBB /* MSWriteOptions.m in Sources */,
+				4AE2E980229F26DC004BF371 /* MSRemoteOperationDelegate.h in Sources */,
 				4A19373A225129C400459E1E /* MSDBDocumentStore.m in Sources */,
 				049BC85E224EDBB700AE7FBB /* MSCosmosDb.m in Sources */,
 				049BC84F224EDAF300AE7FBB /* MSBaseOptions.m in Sources */,
@@ -1059,6 +1064,7 @@
 				267464FA222F28A300EC1FF3 /* MSBaseOptions.m in Sources */,
 				2600124222273E94007F4D3A /* MSTokensResponse.m in Sources */,
 				E8B79372225E9E0D00CB3D1D /* MSPendingOperation.m in Sources */,
+				4AE2E97F229F26DC004BF371 /* MSRemoteOperationDelegate.h in Sources */,
 				267464F5222F28A300EC1FF3 /* MSPage.m in Sources */,
 				8F4548E32256D3160021B0BF /* MSDictionaryDocument.m in Sources */,
 				26F4B0EF226A478F006381D0 /* MSDataSerializationHelpers.m in Sources */,

--- a/AppCenterData/AppCenterData/AppCenterData.h
+++ b/AppCenterData/AppCenterData/AppCenterData.h
@@ -12,4 +12,5 @@
 #import "MSPage.h"
 #import "MSPaginatedDocuments.h"
 #import "MSReadOptions.h"
+#import "MSRemoteOperationDelegate.h"
 #import "MSWriteOptions.h"

--- a/AppCenterData/AppCenterData/Internal/MSDataPrivate.h
+++ b/AppCenterData/AppCenterData/Internal/MSDataPrivate.h
@@ -4,6 +4,7 @@
 #import "MSAuthTokenContextDelegate.h"
 #import "MSServiceInternal.h"
 #import "MS_Reachability.h"
+#import "MSRemoteOperationDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,6 +29,11 @@ static NSString *const kMSDefaultApiUrl = @"https://tokens.appcenter.ms/v0.1";
  * Set of outgoing pending operation ids.
  */
 @property(nonatomic, copy) NSMutableSet<NSString *> *outgoingPendingOperations;
+
+/**
+ * Remote operation delegate.
+ */
+@property (nonatomic, weak) id<MSRemoteOperationDelegate> remoteOperationDelegate;
 
 /**
  * Retrieve a paginated list of the documents in a partition.

--- a/AppCenterData/AppCenterData/Internal/MSDataPrivate.h
+++ b/AppCenterData/AppCenterData/Internal/MSDataPrivate.h
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 #import "MSAuthTokenContextDelegate.h"
+#import "MSRemoteOperationDelegate.h"
 #import "MSServiceInternal.h"
 #import "MS_Reachability.h"
-#import "MSRemoteOperationDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -33,7 +33,7 @@ static NSString *const kMSDefaultApiUrl = @"https://tokens.appcenter.ms/v0.1";
 /**
  * Remote operation delegate.
  */
-@property (nonatomic, weak) id<MSRemoteOperationDelegate> remoteOperationDelegate;
+@property(nonatomic, weak) id<MSRemoteOperationDelegate> remoteOperationDelegate;
 
 /**
  * Retrieve a paginated list of the documents in a partition.

--- a/AppCenterData/AppCenterData/MSData.h
+++ b/AppCenterData/AppCenterData/MSData.h
@@ -10,6 +10,8 @@
 @class MSReadOptions;
 @class MSWriteOptions;
 
+@protocol MSRemoteOperationDelegate;
+
 /**
  * App Data service.
  */
@@ -55,6 +57,14 @@ typedef void (^MSPaginatedDocumentsCompletionHandler)(MSPaginatedDocuments *docu
  * @param tokenExchangeUrl The new URL.
  */
 + (void)setTokenExchangeUrl:(NSString *)tokenExchangeUrl;
+
+/**
+ * Set the remote operation delegate which gets called when the device is back online
+ * and the pending operations are processed.
+ *
+ * @param delegate remote operation delegate.
+ */
++ (void)setRemoteOperationDelegate:(nullable id<MSRemoteOperationDelegate>)delegate;
 
 /**
  * Read a document.

--- a/AppCenterData/AppCenterData/MSData.h
+++ b/AppCenterData/AppCenterData/MSData.h
@@ -62,7 +62,7 @@ typedef void (^MSPaginatedDocumentsCompletionHandler)(MSPaginatedDocuments *docu
  * Set the remote operation delegate which gets called when the device is back online
  * and the pending operations are processed.
  *
- * @param delegate remote operation delegate.
+ * @param delegate A remote operation delegate.
  */
 + (void)setRemoteOperationDelegate:(nullable id<MSRemoteOperationDelegate>)delegate;
 

--- a/AppCenterData/AppCenterData/MSData.m
+++ b/AppCenterData/AppCenterData/MSData.m
@@ -925,11 +925,12 @@ static dispatch_once_t onceToken;
   }
 
   // If the Remote operation is set
+  id<MSRemoteOperationDelegate> strongDelegate;
   @synchronized(self) {
-    id<MSRemoteOperationDelegate> strongDelegate = self.remoteOperationDelegate;
-    if (strongDelegate) {
-      [strongDelegate data:self didCompletePendingOperation:pendingOperation forDocument:document withError:documentWrapper.error];
-    }
+    strongDelegate = self.remoteOperationDelegate;
+  }
+  if (strongDelegate) {
+    [strongDelegate data:self didCompletePendingOperation:pendingOperation forDocument:document withError:documentWrapper.error];
   }
 }
 

--- a/AppCenterData/AppCenterData/MSData.m
+++ b/AppCenterData/AppCenterData/MSData.m
@@ -94,9 +94,6 @@ static dispatch_once_t onceToken;
   [[MSData sharedInstance] setTokenExchangeUrl:(NSURL *)[NSURL URLWithString:tokenExchangeUrl]];
 }
 
-/**
- * Set a delegate which will be invoked on network status change to notify pending operations execution status.
- */
 + (void)setRemoteOperationDelegate:(nullable id<MSRemoteOperationDelegate>)delegate {
   @synchronized(self) {
     [[MSData sharedInstance] setRemoteOperationDelegate:delegate];

--- a/AppCenterData/AppCenterData/MSData.m
+++ b/AppCenterData/AppCenterData/MSData.m
@@ -925,9 +925,11 @@ static dispatch_once_t onceToken;
   }
 
   // If the Remote operation is set
-  id<MSRemoteOperationDelegate> strongDelegate = self.remoteOperationDelegate;
-  if (strongDelegate) {
-    [strongDelegate data:self didCompletePendingOperation:pendingOperation forDocument:document withError:documentWrapper.error];
+  @synchronized(self) {
+    id<MSRemoteOperationDelegate> strongDelegate = self.remoteOperationDelegate;
+    if (strongDelegate) {
+      [strongDelegate data:self didCompletePendingOperation:pendingOperation forDocument:document withError:documentWrapper.error];
+    }
   }
 }
 

--- a/AppCenterData/AppCenterData/MSData.m
+++ b/AppCenterData/AppCenterData/MSData.m
@@ -894,15 +894,15 @@ static dispatch_once_t onceToken;
                                    documentWrapper:(MSDocumentWrapper *)documentWrapper
                                   pendingOperation:(NSString *)pendingOperation
                            operationExpirationTime:(NSInteger)operationExpirationTime {
-  
+
   // Check if expired.
   BOOL isExpired = [MSPendingOperation isExpiredWithExpirationTime:operationExpirationTime];
   BOOL shouldDeleteLocalCache = YES;
-  MSDocumentWrapper* document = documentWrapper;
-  
+  MSDocumentWrapper *document = nil;
+
   // Create and Replace operations.
   if (!documentWrapper.error && ![pendingOperation isEqualToString:kMSPendingOperationDelete]) {
-    
+
     // If not expired, update the local cache. otherwise, remove from the local cache.
     // The operation is passes as nil in order to clear the value in `pending_operation` column.
     if (!isExpired) {
@@ -912,25 +912,24 @@ static dispatch_once_t onceToken;
                                               expirationTime:operationExpirationTime];
       shouldDeleteLocalCache = NO;
     }
+    document = documentWrapper;
   } else if (documentWrapper.error.code == MSHTTPCodesNo404NotFound || documentWrapper.error.code == MSHTTPCodesNo409Conflict) {
     MSLogError([MSData logTag], @"Failed to call Cosmos with operation: %@. Remote operation failed with error code: %ld", pendingOperation,
                (long)documentWrapper.error);
     document = nil;
   } else if (documentWrapper.error) {
-    shouldDeleteLocalCache = NO;
     MSLogError([MSData logTag], @"Failed to call Cosmos with operation:%@ API: %@", pendingOperation,
                [documentWrapper.error localizedDescription]);
-    document = nil;
   }
-  
+
   // Delete the document form the local cache.
   if (shouldDeleteLocalCache) {
     [self.dataOperationProxy.documentStore deleteWithToken:token documentId:documentId];
   }
-  
-  //If the Remote operation is set
+
+  // If the Remote operation is set
   id<MSRemoteOperationDelegate> strongDelegate = self.remoteOperationDelegate;
-  if(strongDelegate){
+  if (strongDelegate) {
     [strongDelegate data:self didCompletePendingOperation:pendingOperation forDocument:document withError:documentWrapper.error];
   }
 }

--- a/AppCenterData/AppCenterData/MSData.m
+++ b/AppCenterData/AppCenterData/MSData.m
@@ -94,6 +94,15 @@ static dispatch_once_t onceToken;
   [[MSData sharedInstance] setTokenExchangeUrl:(NSURL *)[NSURL URLWithString:tokenExchangeUrl]];
 }
 
+/**
+ * Set a delegate which will be invoked on network status change to notify pending operations execution status.
+ */
++ (void)setRemoteOperationDelegate:(nullable id<MSRemoteOperationDelegate>)delegate {
+  @synchronized(self) {
+    [[MSData sharedInstance] setRemoteOperationDelegate:delegate];
+  }
+}
+
 + (void)readDocumentWithID:(NSString *)documentID
               documentType:(Class)documentType
                  partition:(NSString *)partition
@@ -885,14 +894,15 @@ static dispatch_once_t onceToken;
                                    documentWrapper:(MSDocumentWrapper *)documentWrapper
                                   pendingOperation:(NSString *)pendingOperation
                            operationExpirationTime:(NSInteger)operationExpirationTime {
-
+  
   // Check if expired.
   BOOL isExpired = [MSPendingOperation isExpiredWithExpirationTime:operationExpirationTime];
   BOOL shouldDeleteLocalCache = YES;
-
+  MSDocumentWrapper* document = documentWrapper;
+  
   // Create and Replace operations.
   if (!documentWrapper.error && ![pendingOperation isEqualToString:kMSPendingOperationDelete]) {
-
+    
     // If not expired, update the local cache. otherwise, remove from the local cache.
     // The operation is passes as nil in order to clear the value in `pending_operation` column.
     if (!isExpired) {
@@ -905,15 +915,23 @@ static dispatch_once_t onceToken;
   } else if (documentWrapper.error.code == MSHTTPCodesNo404NotFound || documentWrapper.error.code == MSHTTPCodesNo409Conflict) {
     MSLogError([MSData logTag], @"Failed to call Cosmos with operation: %@. Remote operation failed with error code: %ld", pendingOperation,
                (long)documentWrapper.error);
+    document = nil;
   } else if (documentWrapper.error) {
     shouldDeleteLocalCache = NO;
     MSLogError([MSData logTag], @"Failed to call Cosmos with operation:%@ API: %@", pendingOperation,
                [documentWrapper.error localizedDescription]);
+    document = nil;
   }
-
+  
   // Delete the document form the local cache.
   if (shouldDeleteLocalCache) {
     [self.dataOperationProxy.documentStore deleteWithToken:token documentId:documentId];
+  }
+  
+  //If the Remote operation is set
+  id<MSRemoteOperationDelegate> strongDelegate = self.remoteOperationDelegate;
+  if(strongDelegate){
+    [strongDelegate data:self didCompletePendingOperation:pendingOperation forDocument:document withError:documentWrapper.error];
   }
 }
 

--- a/AppCenterData/AppCenterData/MSRemoteOperationDelegate.h
+++ b/AppCenterData/AppCenterData/MSRemoteOperationDelegate.h
@@ -14,12 +14,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A callback that is called when the device network status gets changed from offine to online mode.
- * The Data operations are then performed against the cosmosDB
+ * The Data operations are then performed against the cosmosDB.
  *
- * @param data The instance of MSData.
+ * @param data The instance of `MSData`.
  * @param operation Operation ran.
- * @param document Document that was synched. Nil if error encountered
- * @param error Error details or nil when the sync was successful
+ * @param document Document that was synchronized. `nil` if error encountered
+ * @param error Error details or `nil` when the synchronization was successful
  */
 - (void)data:(MSData *)data
     didCompletePendingOperation:(NSString *)operation

--- a/AppCenterData/AppCenterData/MSRemoteOperationDelegate.h
+++ b/AppCenterData/AppCenterData/MSRemoteOperationDelegate.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class MSDocumentWrapper;
+@class MSDataError;
+
+@protocol MSRemoteOperationDelegate <NSObject>
+
+@optional
+
+/**
+ * A callback that is called when the device network status gets changed from offine to online mode.
+ * The Data operations are then performed against the cosmosDB
+ *
+ * @param data The instance of MSData.
+ * @param operation Operation ran.
+ * @param document Document that was synched. Nil if error encountered
+ * @param error Error details or nil when the sync was successful
+ */
+- (void)data:(MSData *)data didCompletePendingOperation:(NSString *)operation forDocument:(MSDocumentWrapper *_Nullable)document withError:(MSDataError *_Nullable)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AppCenterData/AppCenterData/MSRemoteOperationDelegate.h
+++ b/AppCenterData/AppCenterData/MSRemoteOperationDelegate.h
@@ -21,7 +21,10 @@ NS_ASSUME_NONNULL_BEGIN
  * @param document Document that was synched. Nil if error encountered
  * @param error Error details or nil when the sync was successful
  */
-- (void)data:(MSData *)data didCompletePendingOperation:(NSString *)operation forDocument:(MSDocumentWrapper *_Nullable)document withError:(MSDataError *_Nullable)error;
+- (void)data:(MSData *)data
+    didCompletePendingOperation:(NSString *)operation
+                    forDocument:(MSDocumentWrapper *_Nullable)document
+                      withError:(MSDataError *_Nullable)error;
 
 @end
 

--- a/AppCenterData/AppCenterDataTests/MSDataTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDataTests.m
@@ -36,6 +36,7 @@
 @property(nonatomic) id settingsMock;
 @property(nonatomic) id tokenExchangeMock;
 @property(nonatomic) id cosmosDbMock;
+@property(nonatomic) id reachabilityMock;
 @end
 
 @implementation MSDataTests
@@ -53,6 +54,12 @@ static NSString *const kMSDocumentIdTest = @"documentId";
 - (void)setUp {
   [super setUp];
   self.settingsMock = [MSMockUserDefaults new];
+  __block NetworkStatus currentNetworkStatus = ReachableViaWiFi;
+  self.reachabilityMock = OCMClassMock([MS_Reachability class]);
+  OCMStub([self.reachabilityMock reachabilityForInternetConnection]).andReturn(self.reachabilityMock);
+  OCMStub([self.reachabilityMock currentReachabilityStatus]).andDo(^(NSInvocation *invocation) {
+    [invocation setReturnValue:&currentNetworkStatus];
+  });
   self.sut = [MSData sharedInstance];
   self.tokenExchangeMock = OCMClassMock([MSTokenExchange class]);
   self.cosmosDbMock = OCMClassMock([MSCosmosDb class]);
@@ -2151,5 +2158,88 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                      statusCode:statusCode
                                     HTTPVersion:nil
                                    headerFields:nil];
+}
+
+- (void)testRemoteOperationDelegateMethodIsCalled {
+  
+  // Mock remote operation delegate
+  id<MSRemoteOperationDelegate> delegateMock = OCMProtocolMock(@protocol(MSRemoteOperationDelegate));
+  //OCMStub([delegateMock data:OCMOCK_ANY didCompletePendingOperation:OCMOCK_ANY forDocument:OCMOCK_ANY withError:OCMOCK_ANY]);
+  [self.sut setRemoteOperationDelegate:delegateMock];
+  
+  // Simulate being offline.
+  //  __block NetworkStatus currentNetworkStatus = NotReachable;
+  //  [[NSNotificationCenter defaultCenter] postNotificationName:kMSReachabilityChangedNotification
+  //                                                      object:self.reachabilityMock];
+  
+  // Mock cached token result.
+  MSTokenResult *tokenResult = [[MSTokenResult alloc] initWithDictionary:[self prepareMutableDictionary]];
+  MSTokensResponse *testTokensResponse = [[MSTokensResponse alloc] initWithTokens:@[ tokenResult ]];
+  OCMStub([self.tokenExchangeMock performDbTokenAsyncOperationWithHttpClient:OCMOCK_ANY
+                                                            tokenExchangeUrl:OCMOCK_ANY
+                                                                   appSecret:OCMOCK_ANY
+                                                                   partition:kMSPartitionTest
+                                                         includeExpiredToken:YES
+                                                                reachability:self.reachabilityMock
+                                                           completionHandler:OCMOCK_ANY])
+  .andDo(^(NSInvocation *invocation) {
+    MSGetTokenAsyncCompletionHandler getTokenCallback;
+    [invocation getArgument:&getTokenCallback atIndex:8];
+    getTokenCallback(testTokensResponse, nil);
+  });
+  
+  OCMStub([self.tokenExchangeMock retrieveCachedTokenForPartition:kMSPartitionTest includeExpiredToken:NO]).andReturn(tokenResult);
+  
+  // Mock local storage.
+  id<MSDocumentStore> localStorageMock = OCMProtocolMock(@protocol(MSDocumentStore));
+  self.sut.dataOperationProxy.documentStore = localStorageMock;
+  NSData *jsonFixture = [self jsonFixture:@"validTestUserDocument"];
+  NSString *documentId = @"standalonedocument1";
+  MSDocumentWrapper *localStorageDocument = OCMPartialMock([MSDocumentUtils documentWrapperFromData:jsonFixture
+                                                                                       documentType:[MSDictionaryDocument class]
+                                                                                          partition:kMSPartitionTest documentId:documentId
+                                                                                    fromDeviceCache:NO]);
+  OCMStub([localStorageMock readWithToken:tokenResult documentId:OCMOCK_ANY documentType:OCMOCK_ANY]).andReturn(localStorageDocument);
+  
+  // Mock CosmosDB requests.
+  OCMStub([self.cosmosDbMock performCosmosDbAsyncOperationWithHttpClient:OCMOCK_ANY
+                                                             tokenResult:tokenResult
+                                                              documentId:documentId
+                                                              httpMethod:kMSHttpMethodPost
+                                                                document:OCMOCK_ANY
+                                                       additionalHeaders:OCMOCK_ANY
+                                                       additionalUrlPath:OCMOCK_ANY
+                                                       completionHandler:OCMOCK_ANY])
+  .andDo(^(NSInvocation *invocation) {
+    MSHttpRequestCompletionHandler cosmosdbOperationCallback;
+    [invocation getArgument:&cosmosdbOperationCallback atIndex:9];
+    cosmosdbOperationCallback(jsonFixture, [self generateResponseWithStatusCode:MSHTTPCodesNo200OK], nil);
+  });
+  
+  // Mock pending operation.
+  NSError *error;
+  NSDictionary *document = [NSJSONSerialization JSONObjectWithData:jsonFixture options:0 error:&error];
+  MSPendingOperation *mockPendingOperation =
+  [[MSPendingOperation alloc] initWithOperation:kMSPendingOperationCreate
+                                      partition:kMSPartitionTest
+                                     documentId:documentId
+                                       document:document
+                                           etag:@"1234"
+                                 expirationTime:[[NSDate dateWithTimeIntervalSinceNow:1000000] timeIntervalSince1970]];
+  OCMStub([localStorageMock pendingOperationsWithToken:OCMOCK_ANY]).andReturn(@[ mockPendingOperation ]);
+  
+  // Simulate being online.
+  //  currentNetworkStatus = ReachableViaWiFi;
+  //  [[NSNotificationCenter defaultCenter] postNotificationName:kMSReachabilityChangedNotification
+  //                                                      object:self.reachabilityMock];
+  
+  [self.sut processPendingOperations];
+  
+  // Then
+  id<MSRemoteOperationDelegate> strongDelegate = [MSData sharedInstance].remoteOperationDelegate;
+  XCTAssertNotNil(strongDelegate);
+  XCTAssertEqual(strongDelegate, delegateMock);
+  
+  OCMVerify([delegateMock data:self.sut didCompletePendingOperation:kMSPendingOperationCreate forDocument:localStorageDocument withError:nil]);
 }
 @end

--- a/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -38,7 +38,7 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
 #if GCC_PREPROCESSOR_MACRO_PUPPET
     MSAnalyticsDelegate,
 #endif
-    MSCrashesDelegate, MSDistributeDelegate, MSPushDelegate, UNUserNotificationCenterDelegate, CLLocationManagerDelegate>
+    MSCrashesDelegate, MSDistributeDelegate, MSPushDelegate, MSRemoteOperationDelegate, UNUserNotificationCenterDelegate, CLLocationManagerDelegate>
 
 @property(nonatomic) MSAnalyticsResult *analyticsResult;
 @property(nonatomic) API_AVAILABLE(ios(10.0)) void (^notificationPresentationCompletionHandler)(UNNotificationPresentationOptions options);
@@ -76,7 +76,8 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
 #pragma clang diagnostic pop
   [MSPush setDelegate:self];
   [MSDistribute setDelegate:self];
-
+  [MSData setRemoteOperationDelegate:self];
+  
   // Set max storage size.
   NSNumber *storageMaxSize = [[NSUserDefaults standardUserDefaults] objectForKey:kMSStorageMaxSizeKey];
   if (storageMaxSize) {
@@ -254,6 +255,19 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
   [NSNotificationCenter.defaultCenter postNotificationName:kUpdateAnalyticsResultNotification object:self.analyticsResult];
 }
 #endif
+
+#pragma mark - MSRemoteOperationDelegate
+
+- (void)data:(MSData *)data didCompletePendingOperation:(NSString *)operation forDocument:(MSDocumentWrapper *_Nullable)document withError:(MSDataError *_Nullable)error
+{
+  NSLog(@"Operation processed: %@ ", operation);
+  if(document){
+    NSLog(@"Document: Partition : %@, document id : %@, eTag : %@ ", document.partition, document.documentId, document.eTag);
+  }
+  if(error){
+     NSLog(@"Error: %@ ", error);
+  }
+}
 
 #pragma mark - MSCrashesDelegate
 

--- a/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -38,7 +38,8 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
 #if GCC_PREPROCESSOR_MACRO_PUPPET
     MSAnalyticsDelegate,
 #endif
-    MSCrashesDelegate, MSDistributeDelegate, MSPushDelegate, MSRemoteOperationDelegate, UNUserNotificationCenterDelegate, CLLocationManagerDelegate>
+    MSCrashesDelegate, MSDistributeDelegate, MSPushDelegate, MSRemoteOperationDelegate, UNUserNotificationCenterDelegate,
+    CLLocationManagerDelegate>
 
 @property(nonatomic) MSAnalyticsResult *analyticsResult;
 @property(nonatomic) API_AVAILABLE(ios(10.0)) void (^notificationPresentationCompletionHandler)(UNNotificationPresentationOptions options);
@@ -77,7 +78,7 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
   [MSPush setDelegate:self];
   [MSDistribute setDelegate:self];
   [MSData setRemoteOperationDelegate:self];
-  
+
   // Set max storage size.
   NSNumber *storageMaxSize = [[NSUserDefaults standardUserDefaults] objectForKey:kMSStorageMaxSizeKey];
   if (storageMaxSize) {
@@ -258,14 +259,16 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
 
 #pragma mark - MSRemoteOperationDelegate
 
-- (void)data:(MSData *)data didCompletePendingOperation:(NSString *)operation forDocument:(MSDocumentWrapper *_Nullable)document withError:(MSDataError *_Nullable)error
-{
+- (void)data:(MSData *)data
+    didCompletePendingOperation:(NSString *)operation
+                    forDocument:(MSDocumentWrapper *_Nullable)document
+                      withError:(MSDataError *_Nullable)error {
   NSLog(@"Operation processed: %@ ", operation);
-  if(document){
+  if (document) {
     NSLog(@"Document: Partition : %@, document id : %@, eTag : %@ ", document.partition, document.documentId, document.eTag);
   }
-  if(error){
-     NSLog(@"Error: %@ ", error);
+  if (error) {
+    NSLog(@"Error: %@ ", error);
   }
 }
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

We need to enable a delegate which will get triggered when the pending operations get processed after the device goes back online

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
