### PR TITLE
Refresh token fix

### DIFF
--- a/AppCenterAuth/AppCenterAuth/MSAuth.m
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.m
@@ -515,6 +515,10 @@ static dispatch_once_t onceToken;
       self.homeAccountIdToRefresh = accountId;
       return;
     }
+    if (!self.clientApplication) {
+      MSLogWarning([MSAuth logTag], @"MSAL client is not configured yet.");
+      return;
+    }
     MSALAccount *account = [self retrieveAccountWithAccountId:accountId];
     if (account) {
       __weak typeof(self) weakSelf = self;

--- a/AppCenterAuth/AppCenterAuth/MSAuth.m
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.m
@@ -516,7 +516,7 @@ static dispatch_once_t onceToken;
       return;
     }
     if (!self.clientApplication) {
-      MSLogWarning([MSAuth logTag], @"MSAL client is not configured yet.");
+      MSLogWarning([MSAuth logTag], @"MSAL client is not configured yet. The token will be refreshed on the next re-try.");
       return;
     }
     MSALAccount *account = [self retrieveAccountWithAccountId:accountId];

--- a/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
+++ b/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
@@ -1205,6 +1205,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   OCMStub([authTokenContextMock sharedInstance]).andReturn(authTokenContextMock);
 
   // When
+  OCMExpect([authTokenContextMock setAuthToken:nil withAccountId:nil expiresOn:nil]);
   [authMock startWithChannelGroup:OCMProtocolMock(@protocol(MSChannelGroupProtocol))
                         appSecret:kMSTestAppSecret
           transmissionTargetToken:nil
@@ -1212,7 +1213,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   [[MSAuthTokenContext sharedInstance] checkIfTokenNeedsToBeRefreshed:fakeValidityInfo];
 
   // Then
-  OCMVerify([authTokenContextMock setAuthToken:nil withAccountId:nil expiresOn:nil]);
+  OCMVerifyAll(authTokenContextMock);
 
   // Clear
   [authMock stopMocking];

--- a/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
+++ b/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
@@ -1168,13 +1168,6 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   MSALAccount *accountMock = OCMClassMock([MSALAccount class]);
   OCMStub([authMock retrieveAccountWithAccountId:fakeAccountId]).andReturn(accountMock);
 
-  // OCMVerify turned out to be unreliable in this case.
-  __block int count = 0;
-  OCMStub([self.clientApplicationMock acquireTokenSilentForScopes:OCMOCK_ANY account:OCMOCK_ANY completionBlock:OCMOCK_ANY])
-      .andDo(^(NSInvocation *__unused invocation) {
-        count++;
-      });
-
   // When
   [authMock startWithChannelGroup:OCMProtocolMock(@protocol(MSChannelGroupProtocol))
                         appSecret:kMSTestAppSecret
@@ -1183,7 +1176,7 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   [[MSAuthTokenContext sharedInstance] checkIfTokenNeedsToBeRefreshed:fakeValidityInfo];
 
   // Then
-  assertThatInt(count, equalToInt(1));
+  OCMVerify([self.clientApplicationMock acquireTokenSilentForScopes:OCMOCK_ANY account:OCMOCK_ANY completionBlock:OCMOCK_ANY]);
   [authMock stopMocking];
 }
 

--- a/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
+++ b/AppCenterAuth/AppCenterAuthTests/MSAuthTests.m
@@ -1241,12 +1241,13 @@ static NSString *const kMSTestAppSecret = @"TestAppSecret";
   self.sut.clientApplication = nil;
 
   // Shouldn't call MSAL client while it is not configured.
-  OCMReject([self.sut.clientApplication accountForHomeAccountId:OCMOCK_ANY error:[OCMArg anyObjectRef]]);
+  OCMReject([authMock retrieveAccountWithAccountId:OCMOCK_ANY]);
 
   // When
   [[MSAuthTokenContext sharedInstance] checkIfTokenNeedsToBeRefreshed:fakeValidityInfo];
 
   // Then
+  OCMVerifyAll(authMock);
   [authMock stopMocking];
   [authTokenContextMock stopMocking];
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * **[Feature]** Expose the ID Token and Access Token JWTs in the `MSUserInformation` object passed to the sign in callback.
 * **[Fix]** Fix changing signing status may cause logs (e.g., events) to be delayed.
+* **[Fix]** Fix rare condition where a user is prompted again for their credentials instead of refreshing the token silently.
 
 ### AppCenterData
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fixes a race condition in the following scenario:

1. App starts with expired token.
2. App going to send «startSession» log, but it should update token first.
3. Auth service begins to start.
4. refreshTokenForAccountId called in another thread.
5. RetrieveAccountWithAccountId called while MSALPublicClientApplication is nil.

## Related PRs or issues

[AB#62552](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/62552)
