### PR TITLE
Fix testLogsNotFlushedImmediatelyWhenIntervalIsCustom

### DIFF
--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -295,7 +295,10 @@ static NSString *const kMSTestGroupId = @"GroupId";
   for (NSUInteger i = 0; i < itemsToAdd; i++) {
     [self.sut enqueueItem:[self getValidMockLog] flags:MSFlagsDefault];
   }
-  [self enqueueChannelEndJobExpectation];
+  // Then
+  dispatch_async(self.logsDispatchQueue, ^{
+    [self enqueueChannelEndJobExpectation];
+  });
 
   // Then
   [self waitForExpectationsWithTimeout:kMSTestTimeout

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -294,13 +294,13 @@ static NSString *const kMSTestGroupId = @"GroupId";
 
   // When
   for (NSUInteger i = 0; i < itemsToAdd; i++) {
-    [channelmock enqueueItem:[channelmock getValidMockLog] flags:MSFlagsDefault];
+    [channelmock enqueueItem:[self getValidMockLog] flags:MSFlagsDefault];
   }
   // Then
-  [channelmock enqueueChannelEndJobExpectation];
+  [self enqueueChannelEndJobExpectation];
 
   // Then
-  [channelmock waitForExpectationsWithTimeout:kMSTestTimeout
+  [self waitForExpectationsWithTimeout:kMSTestTimeout
                                handler:^(NSError *error) {
                                  OCMVerify([channelmock startTimer:OCMOCK_ANY]);
                                  assertThatUnsignedLong(self.sut.itemsCount, equalToInt(itemsToAdd));

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -107,15 +107,15 @@ static NSString *const kMSTestGroupId = @"GroupId";
 
   // If
   [self initChannelEndJobExpectation];
-  id dateMock = OCMClassMock([NSDate class]);
   NSObject *object = [NSObject new];
   NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:3000];
+  id dateMock = OCMStrictClassMock([NSDate class]);
   OCMStub([dateMock date]).andReturn(date);
 
   // Configure channel with custom interval.
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
-                                                                 flushInterval:60
+                                                                 flushInterval:INT_MAX
                                                                 batchSizeLimit:50
                                                            pendingBatchesLimit:3];
 
@@ -147,7 +147,6 @@ static NSString *const kMSTestGroupId = @"GroupId";
   NSUInteger flushInterval = 600;
   NSUInteger batchSizeLimit = 50;
   __block int currentBatchId = 1;
-  id dateMock = OCMClassMock([NSDate class]);
   NSDate *date = [NSDate dateWithTimeIntervalSince1970:0];
   NSDate *date2 = [NSDate dateWithTimeIntervalSince1970:flushInterval + 100];
   __block id responseMock = [MSHttpTestUtil createMockResponseForStatusCode:200 headers:nil];
@@ -198,6 +197,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   [self.settingsMock setObject:date forKey:self.sut.oldestPendingLogTimestampKey];
 
   // Change time. Simulate time has passed.
+  id dateMock = OCMStrictClassMock([NSDate class]);
   OCMStub([dateMock date]).andReturn(date2);
 
   // Trigger checkPengingLogs. Should flush 3 batches now.
@@ -241,7 +241,6 @@ static NSString *const kMSTestGroupId = @"GroupId";
 
   // If
   [self initChannelEndJobExpectation];
-  id dateMock = OCMClassMock([NSDate class]);
   self.sut.itemsCount = 5;
 
   // Configure channel.
@@ -251,8 +250,9 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                                                 batchSizeLimit:1
                                                            pendingBatchesLimit:3];
   NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:3000];
-  OCMStub([dateMock date]).andReturn(date);
   [self.settingsMock setObject:[[NSDate alloc] initWithTimeIntervalSince1970:500] forKey:self.sut.oldestPendingLogTimestampKey];
+  id dateMock = OCMStrictClassMock([NSDate class]);
+  OCMStub([dateMock date]).andReturn(date);
   id channelUnitMock = OCMPartialMock(self.sut);
   OCMReject([channelUnitMock startTimer:OCMOCK_ANY]);
 
@@ -282,10 +282,11 @@ static NSString *const kMSTestGroupId = @"GroupId";
   [self initChannelEndJobExpectation];
   NSUInteger batchSizeLimit = 4;
   int itemsToAdd = 8;
-  NSUInteger flushInterval = 600;
+
+  // Configure channel.
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
-                                                                 flushInterval:flushInterval
+                                                                 flushInterval:600
                                                                 batchSizeLimit:batchSizeLimit
                                                            pendingBatchesLimit:3];
 
@@ -299,7 +300,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   [self waitForExpectationsWithTimeout:kMSTestTimeout
                                handler:^(NSError *error) {
                                  OCMVerify([self.sut startTimer:OCMOCK_ANY]);
-                                 // assertThatUnsignedLong(self.sut.itemsCount, equalToInt(itemsToAdd));
+                                 assertThatUnsignedLong(self.sut.itemsCount, equalToInt(itemsToAdd));
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }
@@ -309,7 +310,6 @@ static NSString *const kMSTestGroupId = @"GroupId";
 - (void)testResolveFlushIntervalTimestampNotSet {
 
   // If
-  id dateMock = OCMClassMock([NSDate class]);
   NSUInteger flushInterval = 2000;
 
   // Configure channel.
@@ -319,6 +319,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                                                 batchSizeLimit:50
                                                            pendingBatchesLimit:1];
   NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:1000];
+  id dateMock = OCMStrictClassMock([NSDate class]);
   OCMStub([dateMock date]).andReturn(date);
 
   // When
@@ -334,7 +335,6 @@ static NSString *const kMSTestGroupId = @"GroupId";
 - (void)testResolveFlushIntervalTimeIsOut {
 
   // If
-  id dateMock = OCMClassMock([NSDate class]);
   NSUInteger flushInterval = 2000;
 
   // Configure channel.
@@ -343,9 +343,10 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                                                  flushInterval:flushInterval
                                                                 batchSizeLimit:50
                                                            pendingBatchesLimit:1];
-  NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:3000];
-  OCMStub([dateMock date]).andReturn(date);
   [self.settingsMock setObject:[[NSDate alloc] initWithTimeIntervalSince1970:500] forKey:self.sut.oldestPendingLogTimestampKey];
+  NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:3000];
+  id dateMock = OCMStrictClassMock([NSDate class]);
+  OCMStub([dateMock date]).andReturn(date);
 
   // When
   NSUInteger resultFlushInterval = [self.sut resolveFlushInterval];
@@ -360,7 +361,6 @@ static NSString *const kMSTestGroupId = @"GroupId";
 - (void)testResolveFlushIntervalTimestampLaterThanNow {
 
   // If
-  id dateMock = OCMClassMock([NSDate class]);
   NSUInteger flushInterval = 2000;
 
   // Configure channel.
@@ -370,8 +370,9 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                                                 batchSizeLimit:50
                                                            pendingBatchesLimit:1];
   NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:1000];
-  OCMStub([dateMock date]).andReturn(date);
   [self.settingsMock setObject:[[NSDate alloc] initWithTimeIntervalSince1970:2000] forKey:self.sut.oldestPendingLogTimestampKey];
+  id dateMock = OCMStrictClassMock([NSDate class]);
+  OCMStub([dateMock date]).andReturn(date);
 
   // When
   NSUInteger resultFlushInterval = [self.sut resolveFlushInterval];
@@ -386,17 +387,15 @@ static NSString *const kMSTestGroupId = @"GroupId";
 - (void)testResolveFlushIntervalNow {
 
   // If
-  id dateMock = OCMClassMock([NSDate class]);
-
-  // Configure channel.
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
                                                                  flushInterval:2000
                                                                 batchSizeLimit:50
                                                            pendingBatchesLimit:1];
   NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:4000];
-  OCMStub([dateMock date]).andReturn(date);
   [self.settingsMock setObject:[[NSDate alloc] initWithTimeIntervalSince1970:2000] forKey:self.sut.oldestPendingLogTimestampKey];
+  id dateMock = OCMStrictClassMock([NSDate class]);
+  OCMStub([dateMock date]).andReturn(date);
 
   // When
   NSUInteger resultFlushInterval = [self.sut resolveFlushInterval];
@@ -411,17 +410,15 @@ static NSString *const kMSTestGroupId = @"GroupId";
 - (void)testResolveFlushInterval {
 
   // If
-  id dateMock = OCMClassMock([NSDate class]);
-
-  // Configure channel.
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
                                                                  flushInterval:2000
                                                                 batchSizeLimit:50
                                                            pendingBatchesLimit:1];
   NSDate *date = [[NSDate alloc] initWithTimeIntervalSince1970:1000];
-  OCMStub([dateMock date]).andReturn(date);
   [self.settingsMock setObject:[[NSDate alloc] initWithTimeIntervalSince1970:500] forKey:self.sut.oldestPendingLogTimestampKey];
+  id dateMock = OCMStrictClassMock([NSDate class]);
+  OCMStub([dateMock date]).andReturn(date);
 
   // When
   NSUInteger resultFlushInterval = [self.sut resolveFlushInterval];
@@ -486,7 +483,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   // Configure channel.
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
-                                                                 flushInterval:0.0
+                                                                 flushInterval:0
                                                                 batchSizeLimit:batchSizeLimit
                                                            pendingBatchesLimit:1];
 
@@ -577,7 +574,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   // Configure channel.
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
-                                                                 flushInterval:0.0
+                                                                 flushInterval:0
                                                                 batchSizeLimit:batchSizeLimit
                                                            pendingBatchesLimit:1];
   [self.sut addDelegate:delegateMock];
@@ -628,12 +625,11 @@ static NSString *const kMSTestGroupId = @"GroupId";
 
   // If
   [self initChannelEndJobExpectation];
-  MSChannelUnitConfiguration *config = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
-                                                                                  priority:MSPriorityDefault
-                                                                             flushInterval:5
-                                                                            batchSizeLimit:10
-                                                                       pendingBatchesLimit:3];
-  self.sut.configuration = config;
+  self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
+                                                                      priority:MSPriorityDefault
+                                                                 flushInterval:INT_MAX
+                                                                batchSizeLimit:10
+                                                           pendingBatchesLimit:3];
   int itemsToAdd = 3;
 
   // When
@@ -658,7 +654,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   [self initChannelEndJobExpectation];
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
-                                                                 flushInterval:5
+                                                                 flushInterval:INT_MAX
                                                                 batchSizeLimit:10
                                                            pendingBatchesLimit:3];
   self.sut.storage = self.storageMock = OCMProtocolMock(@protocol(MSStorage));
@@ -750,7 +746,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   [self initChannelEndJobExpectation];
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
-                                                                 flushInterval:0.0
+                                                                 flushInterval:0
                                                                 batchSizeLimit:3
                                                            pendingBatchesLimit:3];
   int itemsToAdd = 3;
@@ -821,7 +817,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
       });
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
-                                                                 flushInterval:0.0
+                                                                 flushInterval:0
                                                                 batchSizeLimit:batchSizeLimit
                                                            pendingBatchesLimit:expectedMaxPendingBatched];
 
@@ -895,7 +891,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   // Configure channel.
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
-                                                                 flushInterval:0.0
+                                                                 flushInterval:0
                                                                 batchSizeLimit:batchSizeLimit
                                                            pendingBatchesLimit:1];
 
@@ -951,7 +947,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                               completionHandler:([OCMArg invokeBlockWithArgs:((NSArray<id<MSLog>> *)@[ mockLog ]), @"1", nil])]);
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
-                                                                 flushInterval:0.0
+                                                                 flushInterval:0
                                                                 batchSizeLimit:batchSizeLimit
                                                            pendingBatchesLimit:10];
 
@@ -984,7 +980,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                               completionHandler:([OCMArg invokeBlockWithArgs:((NSArray<id<MSLog>> *)@[ mockLog ]), @"1", nil])]);
   self.sut.configuration = [[MSChannelUnitConfiguration alloc] initWithGroupId:kMSTestGroupId
                                                                       priority:MSPriorityDefault
-                                                                 flushInterval:0.0
+                                                                 flushInterval:0
                                                                 batchSizeLimit:batchSizeLimit
                                                            pendingBatchesLimit:10];
 

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -301,7 +301,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
   // Then
   [self waitForExpectationsWithTimeout:kMSTestTimeout
                                handler:^(NSError *error) {
-                                 OCMVerify([self.sut startTimer:OCMOCK_ANY]);
+                                 // OCMVerify([self.sut startTimer:OCMOCK_ANY]);
                                  assertThatUnsignedLong(self.sut.itemsCount, equalToInt(itemsToAdd));
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -277,7 +277,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
 }
 
 - (void)testLogsNotFlushedImmediatelyWhenIntervalIsCustom {
-  
+
   // If
   [self initChannelEndJobExpectation];
   NSUInteger batchSizeLimit = 4;
@@ -288,7 +288,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                                                  flushInterval:flushInterval
                                                                 batchSizeLimit:batchSizeLimit
                                                            pendingBatchesLimit:3];
-  
+
   // When
   dispatch_async(self.logsDispatchQueue, ^{
     for (NSUInteger i = 0; i < itemsToAdd; i++) {
@@ -296,7 +296,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
     }
     [self enqueueChannelEndJobExpectation];
   });
-  
+
   // Then
   [self waitForExpectationsWithTimeout:kMSTestTimeout
                                handler:^(NSError *error) {
@@ -1636,13 +1636,12 @@ static NSString *const kMSTestGroupId = @"GroupId";
   NSMutableArray<MSAuthTokenValidityInfo *> *tokenValidityArray = [NSMutableArray<MSAuthTokenValidityInfo *> new];
   for (NSUInteger i = 0; i < dates.count - 1; i++) {
     NSString *token = [NSString stringWithFormat:@"token%tu", i];
-    [tokenValidityArray addObject:[[MSAuthTokenValidityInfo alloc] initWithAuthToken:token startTime:dates[i] endTime:dates[i+1]]];
+    [tokenValidityArray addObject:[[MSAuthTokenValidityInfo alloc] initWithAuthToken:token startTime:dates[i] endTime:dates[i + 1]]];
   }
 
   // Configure ingestion mock.
   NSMutableDictionary<NSString *, MSSendAsyncCompletionHandler> *sendingBatches = [NSMutableDictionary new];
-  OCMStub([self.ingestionMock sendAsync:OCMOCK_ANY authToken:OCMOCK_ANY completionHandler:OCMOCK_ANY])
-  .andDo(^(NSInvocation *invocation) {
+  OCMStub([self.ingestionMock sendAsync:OCMOCK_ANY authToken:OCMOCK_ANY completionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
     [invocation retainArguments];
     MSLogContainer *logContainer;
     [invocation getArgument:&logContainer atIndex:2];
@@ -1711,8 +1710,12 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }
-                                 OCMVerify([self.ingestionMock sendAsync:hasProperty(@"batchId", @"batch4") authToken:@"token1" completionHandler:OCMOCK_ANY]);
-                                 OCMVerify([self.ingestionMock sendAsync:hasProperty(@"batchId", @"batch6") authToken:@"token3" completionHandler:OCMOCK_ANY]);
+                                 OCMVerify([self.ingestionMock sendAsync:hasProperty(@"batchId", @"batch4")
+                                                               authToken:@"token1"
+                                                       completionHandler:OCMOCK_ANY]);
+                                 OCMVerify([self.ingestionMock sendAsync:hasProperty(@"batchId", @"batch6")
+                                                               authToken:@"token3"
+                                                       completionHandler:OCMOCK_ANY]);
                                  OCMVerifyAll(self.authTokenContextMock);
                                }];
   [response stopMocking];

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -296,9 +296,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
     [self.sut enqueueItem:[self getValidMockLog] flags:MSFlagsDefault];
   }
   // Then
-  dispatch_async(self.logsDispatchQueue, ^{
-    [self enqueueChannelEndJobExpectation];
-  });
+  [self enqueueChannelEndJobExpectation];
 
   // Then
   [self waitForExpectationsWithTimeout:kMSTestTimeout

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -308,6 +308,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }
                                }];
+  [channelmock stopMocking];
 }
 
 - (void)testResolveFlushIntervalTimestampNotSet {

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -290,18 +290,16 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                                            pendingBatchesLimit:3];
 
   // When
-  dispatch_async(self.logsDispatchQueue, ^{
-    for (NSUInteger i = 0; i < itemsToAdd; i++) {
-      [self.sut enqueueItem:[self getValidMockLog] flags:MSFlagsDefault];
-    }
-    [self enqueueChannelEndJobExpectation];
-  });
+  for (NSUInteger i = 0; i < itemsToAdd; i++) {
+    [self.sut enqueueItem:[self getValidMockLog] flags:MSFlagsDefault];
+  }
+  [self enqueueChannelEndJobExpectation];
 
   // Then
   [self waitForExpectationsWithTimeout:kMSTestTimeout
                                handler:^(NSError *error) {
                                  OCMVerify([self.sut startTimer:OCMOCK_ANY]);
-                                 assertThatUnsignedLong(self.sut.itemsCount, equalToInt(itemsToAdd));
+                                 // assertThatUnsignedLong(self.sut.itemsCount, equalToInt(itemsToAdd));
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }

--- a/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelUnitDefaultTests.m
@@ -280,6 +280,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
 
   // If
   [self initChannelEndJobExpectation];
+  id channelmock = OCMPartialMock(self.sut);
   NSUInteger batchSizeLimit = 4;
   int itemsToAdd = 8;
   NSUInteger flushInterval = 600;
@@ -293,15 +294,15 @@ static NSString *const kMSTestGroupId = @"GroupId";
 
   // When
   for (NSUInteger i = 0; i < itemsToAdd; i++) {
-    [self.sut enqueueItem:[self getValidMockLog] flags:MSFlagsDefault];
+    [channelmock enqueueItem:[channelmock getValidMockLog] flags:MSFlagsDefault];
   }
   // Then
-  [self enqueueChannelEndJobExpectation];
+  [channelmock enqueueChannelEndJobExpectation];
 
   // Then
-  [self waitForExpectationsWithTimeout:kMSTestTimeout
+  [channelmock waitForExpectationsWithTimeout:kMSTestTimeout
                                handler:^(NSError *error) {
-                                 // OCMVerify([self.sut startTimer:OCMOCK_ANY]);
+                                 OCMVerify([channelmock startTimer:OCMOCK_ANY]);
                                  assertThatUnsignedLong(self.sut.itemsCount, equalToInt(itemsToAdd));
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

testLogsNotFlushedImmediatelyWhenIntervalIsCustom is continuously failing in merge build but couldn't reproduce on local machine. Please investigate the failure and fix it.

## Related PRs or issues

[AB#62895](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/62895)