### PR TITLE
Add Authentication status unknown for Auth default status on iOS test apps

### DIFF
--- a/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
@@ -46,6 +46,7 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
   private var dbFileSource: DispatchSourceProtocol?  
   let startUpModeForCurrentSession: NSInteger = (UserDefaults.standard.object(forKey: kMSStartTargetKey) ?? 0) as! NSInteger
   var userInformation: MSUserInformation?
+  var userDefaultStatus: Bool = true
   
   deinit {
     self.dbFileSource?.cancel()
@@ -120,6 +121,7 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
 
   @IBAction func authSignIn(_ sender: UIButton) {
     appCenter.signIn { (userInformation, error) in
+      self.userDefaultStatus = false
       self.userInformation = userInformation
       DispatchQueue.main.async {
         self.updateViewState()
@@ -129,6 +131,7 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
 
   @IBAction func authSignOut(_ sender: UIButton) {
     appCenter.signOut()
+    self.userDefaultStatus = false
     self.userInformation = nil
     updateViewState()
   }
@@ -137,7 +140,11 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
     self.appCenterEnabledSwitch.isOn = appCenter.isAppCenterEnabled()
     self.pushEnabledSwitch.isOn = appCenter.isPushEnabled()
     self.authSwitch.isOn = appCenter.isAuthEnabled()
-    if (self.userInformation == nil) {
+    if (self.userDefaultStatus) {
+      authInfoCell.isUserInteractionEnabled = false
+      authInfoLabel.text = "Authentication status unknown"
+      authInfoLabel.isEnabled = false
+    } else if (self.userInformation == nil) {
       authInfoCell.isUserInteractionEnabled = false
       authInfoLabel.text = "User is not authenticated"
       authInfoLabel.isEnabled = false


### PR DESCRIPTION
The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
Display "Authentication status unknown" as default status until user sign-in or sign-out and the app knows an exact state of authentication.

## Related PRs or issues

[#63194](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/63194)

