### PR TITLE
Fix call to setUserId from UI (one collector)

### DIFF
--- a/Sasquatch/Sasquatch/ViewControllers/Sections/CommonSchemaPropertiesTableSection.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/Sections/CommonSchemaPropertiesTableSection.swift
@@ -94,7 +94,9 @@ class CommonSchemaPropertiesTableSection : SimplePropertiesTableSection {
       target.propertyConfigurator.setAppLocale(sender.text!)
       break
     case .UserId:
-      target.propertyConfigurator.setUserId(sender.text!)
+      let text = sender.text ?? ""
+      let userId = !text.isEmpty ? text : nil
+      target.propertyConfigurator.setUserId(userId)
       break
     }
     sender.resignFirstResponder()


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [X] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The runtime Target UserInfo.Id of event still exists after deleting User ID

## Related PRs or issues
AB#63198