### PR TITLE
Fix SasquatchSwift openURL forwarding to MSAuth

### DIFF
--- a/Sasquatch/SasquatchSwift/AppDelegate.swift
+++ b/Sasquatch/SasquatchSwift/AppDelegate.swift
@@ -161,7 +161,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MSCrashesDelegate, MSDist
    */
   func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     // Forward the URL.
-    return MSDistribute.open(url) && MSAuth.open(url)
+    return MSDistribute.open(url) || MSAuth.open(url)
   }
 
   func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {

--- a/Sasquatch/SasquatchSwift/AppDelegate.swift
+++ b/Sasquatch/SasquatchSwift/AppDelegate.swift
@@ -161,7 +161,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MSCrashesDelegate, MSDist
    */
   func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
     // Forward the URL.
-    return MSDistribute.open(url) || MSAuth.open(url)
+    return MSDistribute.open(url) || MSAuth.open(url, options: options);
   }
 
   func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Are the files formatted correctly?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
Auth sign-in was failing on iOS 10 for SasquatchSwift app because the openURL call wasn't forwarded correctly to MSAuth.