### PR TITLE
Fix/reset crash confirmation

### DIFF
--- a/Sasquatch/Sasquatch/Base.lproj/Main.storyboard
+++ b/Sasquatch/Sasquatch/Base.lproj/Main.storyboard
@@ -1286,6 +1286,24 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="88S-X5-7Nh">
+                                        <rect key="frame" x="0.0" y="1412.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="88S-X5-7Nh" id="phR-gY-BqC">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WUg-SA-npz">
+                                                    <rect key="frame" x="86" y="7" width="203" height="30"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <state key="normal" title="Clear crash user confirmation"/>
+                                                    <connections>
+                                                        <action selector="clearCrashUserConfirmation:" destination="9Ck-4D-Ozb" eventType="touchUpInside" id="QaU-xI-9f7"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Data" id="6Vf-WW-jGy">
@@ -1329,6 +1347,7 @@
                         <outlet property="authInfoCell" destination="dRI-LI-6Sl" id="Tl5-QH-UWJ"/>
                         <outlet property="authInfoLabel" destination="Qym-oN-3dV" id="ljN-W8-7cS"/>
                         <outlet property="authSwitch" destination="iXu-ht-std" id="Sea-q6-3hw"/>
+                        <outlet property="clearCrashUserConfirmationButton" destination="WUg-SA-npz" id="hJw-aC-Puf"/>
                         <outlet property="deviceIdLabel" destination="eS2-cR-m6j" id="UsE-g6-FF0"/>
                         <outlet property="installId" destination="NtN-Tm-B6i" id="99C-gY-7Q8"/>
                         <outlet property="logFilterSwitch" destination="Noo-Uo-Lot" id="joI-f2-5vY"/>

--- a/Sasquatch/Sasquatch/Constants.h
+++ b/Sasquatch/Sasquatch/Constants.h
@@ -41,6 +41,7 @@ static NSString *const kMSUserIdKey = @"userId";
 static NSString *const kMSLogUrl = @"logUrl";
 static NSString *const kMSAppSecret = @"appSecret";
 static NSString *const kMSUserIdentity = @"userIdentity";
+static NSString *const kMSUserConfirmationKey = @"MSUserConfirmation";
 
 #ifdef SQLITE_DEFAULT_PAGE_SIZE
 static int const kMSStoragePageSize = SQLITE_DEFAULT_PAGE_SIZE;

--- a/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
@@ -38,6 +38,7 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
   @IBOutlet weak var overrideCountryCodeButton: UIButton!
   @IBOutlet weak var authInfoCell: UITableViewCell!
   @IBOutlet weak var authInfoLabel: UILabel!
+  @IBOutlet weak var clearCrashUserConfirmationButton: UIButton!
 
   var appCenter: AppCenterDelegate!
   private var startupModePicker: MSEnumPicker<StartupMode>?
@@ -181,6 +182,10 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
   @IBAction func overrideCountryCode(_ sender: UIButton) {
     let appDelegate: AppDelegate? = UIApplication.shared.delegate as? AppDelegate
     appDelegate?.requestLocation()
+  }
+
+  @IBAction func clearCrashUserConfirmation(_ sender: UIButton) {
+   UserDefaults.standard.removeObject(forKey: kMSUserConfirmationKey)
   }
 
   @IBAction func logFilterSwitchChanged(_ sender: UISwitch) {

--- a/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
@@ -185,7 +185,17 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
   }
 
   @IBAction func clearCrashUserConfirmation(_ sender: UIButton) {
-   UserDefaults.standard.removeObject(forKey: kMSUserConfirmationKey)
+    let alertController = UIAlertController(title: "Clear crash user confirmation?",
+                                            message: nil,
+                                            preferredStyle:.alert)
+    let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
+    let clearAction = UIAlertAction(title: "Clear", style: .default, handler: {
+      (_ action : UIAlertAction) -> Void in
+      UserDefaults.standard.removeObject(forKey: kMSUserConfirmationKey)
+    })
+    alertController.addAction(cancelAction)
+    alertController.addAction(clearAction)
+    self.present(alertController, animated: true, completion: nil)
   }
 
   @IBAction func logFilterSwitchChanged(_ sender: UISwitch) {

--- a/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
@@ -189,7 +189,7 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
                                             message: nil,
                                             preferredStyle:.alert)
     let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
-    let clearAction = UIAlertAction(title: "Clear", style: .default, handler: {
+    let clearAction = UIAlertAction(title: "OK", style: .default, handler: {
       (_ action : UIAlertAction) -> Void in
       UserDefaults.standard.removeObject(forKey: kMSUserConfirmationKey)
     })

--- a/SasquatchMac/SasquatchMac/Base.lproj/SasquatchMac.storyboard
+++ b/SasquatchMac/SasquatchMac/Base.lproj/SasquatchMac.storyboard
@@ -944,19 +944,6 @@
                                     <action selector="overrideCountryCode:" target="O3Z-WH-pbf" id="drU-lc-OEp"/>
                                 </connections>
                             </button>
-                            <button translatesAutoresizingMaskIntoConstraints="NO" id="rUG-7Y-zgX">
-                                <rect key="frame" x="181" y="194" width="95" height="21"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="17" id="9JU-vO-k6n"/>
-                                </constraints>
-                                <buttonCell key="cell" type="check" title="Set Enabled" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ztl-av-U9H">
-                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="setEnabledWithSender:" target="O3Z-WH-pbf" id="qX4-X9-cfB"/>
-                                </connections>
-                            </button>
                             <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AaW-HC-ZSx">
                                 <rect key="frame" x="14" y="217" width="116" height="32"/>
                                 <buttonCell key="cell" type="push" title="Set Log URL" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="EQ8-1j-3Hb">
@@ -977,21 +964,42 @@
                                     <action selector="setAppSecret:" target="O3Z-WH-pbf" id="PD0-ug-7We"/>
                                 </connections>
                             </button>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aOC-Nn-pfW">
+                                <rect key="frame" x="14" y="178" width="219" height="32"/>
+                                <buttonCell key="cell" type="push" title="Clear crash user confirmation" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="yLF-Fh-ZyT">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="clearCrashUserConfirmation:" target="O3Z-WH-pbf" id="PlH-YO-dfc"/>
+                                </connections>
+                            </button>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="rUG-7Y-zgX">
+                                <rect key="frame" x="217" y="126" width="95" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="17" id="ynP-mb-eXC"/>
+                                </constraints>
+                                <buttonCell key="cell" type="check" title="Set Enabled" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ztl-av-U9H">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="setEnabledWithSender:" target="O3Z-WH-pbf" id="qX4-X9-cfB"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
                             <constraint firstItem="N1B-nD-gUu" firstAttribute="leading" secondItem="M7z-d7-GnN" secondAttribute="leading" id="1aT-zh-uRs"/>
                             <constraint firstItem="Ih6-MC-nUR" firstAttribute="leading" secondItem="XCk-4w-Cy6" secondAttribute="leading" id="2FJ-yt-Gai"/>
+                            <constraint firstItem="aOC-Nn-pfW" firstAttribute="leading" secondItem="EJZ-Wn-7Tz" secondAttribute="leading" id="4nc-Xa-AyH"/>
                             <constraint firstItem="4qO-Fe-RWA" firstAttribute="leading" secondItem="t5v-V3-aso" secondAttribute="trailing" constant="8" symbolic="YES" id="6Ya-oi-Qh3"/>
-                            <constraint firstItem="R4D-X9-Nms" firstAttribute="centerX" secondItem="rUG-7Y-zgX" secondAttribute="centerX" id="7E3-Ff-1te"/>
                             <constraint firstItem="QHt-Sf-WnZ" firstAttribute="leading" secondItem="t5v-V3-aso" secondAttribute="leading" id="84C-u9-9mT"/>
                             <constraint firstItem="XCk-4w-Cy6" firstAttribute="leading" secondItem="ktO-VZ-RCE" secondAttribute="leading" id="8ZI-zq-krX"/>
                             <constraint firstItem="qCJ-IQ-Xx3" firstAttribute="top" secondItem="rm3-tN-rQO" secondAttribute="bottom" constant="12" symbolic="YES" id="8bp-k8-Yyo"/>
-                            <constraint firstItem="rUG-7Y-zgX" firstAttribute="top" secondItem="qCJ-IQ-Xx3" secondAttribute="bottom" constant="11" id="A1x-Si-Kj4"/>
+                            <constraint firstItem="rUG-7Y-zgX" firstAttribute="trailing" secondItem="qDp-Yr-DOK" secondAttribute="trailing" id="9mq-D1-9J1"/>
                             <constraint firstItem="VA4-N7-8nZ" firstAttribute="trailing" secondItem="7dF-GM-Y0D" secondAttribute="trailing" id="BkF-l8-ZS6"/>
-                            <constraint firstItem="R4D-X9-Nms" firstAttribute="top" secondItem="k9u-4S-Pzy" secondAttribute="top" constant="20" symbolic="YES" id="DDy-XL-azc"/>
                             <constraint firstItem="RsK-dO-vcR" firstAttribute="leading" secondItem="AaW-HC-ZSx" secondAttribute="trailing" constant="228" id="EPW-Jd-T2Y"/>
                             <constraint firstItem="qCJ-IQ-Xx3" firstAttribute="leading" secondItem="AaW-HC-ZSx" secondAttribute="trailing" constant="30" id="FOK-uE-8g9"/>
-                            <constraint firstItem="AaW-HC-ZSx" firstAttribute="leading" secondItem="k9u-4S-Pzy" secondAttribute="leading" constant="50" id="HSq-JQ-Q1F"/>
                             <constraint firstItem="rm3-tN-rQO" firstAttribute="baseline" secondItem="9qE-Q3-fww" secondAttribute="baseline" id="HvG-Rz-JaY"/>
                             <constraint firstItem="VA4-N7-8nZ" firstAttribute="leading" secondItem="FL1-7e-JUq" secondAttribute="trailing" constant="8" symbolic="YES" id="IZi-cZ-g0R"/>
                             <constraint firstItem="ufS-r3-0uH" firstAttribute="top" secondItem="t5v-V3-aso" secondAttribute="bottom" constant="5" id="Iq0-2t-MoK"/>
@@ -1000,7 +1008,6 @@
                             <constraint firstItem="6ga-1T-9ly" firstAttribute="top" secondItem="AJ3-cu-c5f" secondAttribute="bottom" constant="8" symbolic="YES" id="Lfi-TU-De6"/>
                             <constraint firstItem="UAF-Zh-FC1" firstAttribute="top" secondItem="FL1-7e-JUq" secondAttribute="bottom" constant="10" id="Ll5-Z6-pEQ"/>
                             <constraint firstItem="M7z-d7-GnN" firstAttribute="baseline" secondItem="4qO-Fe-RWA" secondAttribute="firstBaseline" id="MV7-rf-BDw"/>
-                            <constraint firstItem="R4D-X9-Nms" firstAttribute="centerX" secondItem="k9u-4S-Pzy" secondAttribute="centerX" id="MhE-ZY-1g0"/>
                             <constraint firstItem="AJ3-cu-c5f" firstAttribute="top" secondItem="mid-Fe-HHm" secondAttribute="bottom" constant="8" symbolic="YES" id="NtC-64-IfV"/>
                             <constraint firstItem="ktO-VZ-RCE" firstAttribute="trailing" secondItem="VA4-N7-8nZ" secondAttribute="trailing" id="PEi-27-TzQ"/>
                             <constraint firstItem="7dF-GM-Y0D" firstAttribute="leading" secondItem="UAF-Zh-FC1" secondAttribute="trailing" id="Pt1-mW-dWT"/>
@@ -1008,13 +1015,14 @@
                             <constraint firstItem="VA4-N7-8nZ" firstAttribute="leading" secondItem="7dF-GM-Y0D" secondAttribute="leading" id="Q7C-s8-raX"/>
                             <constraint firstItem="qCJ-IQ-Xx3" firstAttribute="centerY" secondItem="AaW-HC-ZSx" secondAttribute="centerY" id="QCk-AN-Jec"/>
                             <constraint firstItem="4qO-Fe-RWA" firstAttribute="leading" secondItem="qDp-Yr-DOK" secondAttribute="leading" id="QjJ-Ha-orS"/>
-                            <constraint firstItem="mid-Fe-HHm" firstAttribute="leading" secondItem="k9u-4S-Pzy" secondAttribute="leading" constant="20" symbolic="YES" id="S4D-Sj-AY9"/>
+                            <constraint firstItem="aOC-Nn-pfW" firstAttribute="leading" secondItem="k9u-4S-Pzy" secondAttribute="leading" constant="20" symbolic="YES" id="SKB-Rx-K1B"/>
                             <constraint firstItem="qDp-Yr-DOK" firstAttribute="leading" secondItem="ufS-r3-0uH" secondAttribute="trailing" constant="8" symbolic="YES" id="TAZ-iM-tDb"/>
                             <constraint firstItem="mid-Fe-HHm" firstAttribute="top" secondItem="Ih6-MC-nUR" secondAttribute="top" id="UDP-Xg-kjv"/>
                             <constraint firstItem="7dF-GM-Y0D" firstAttribute="top" secondItem="VA4-N7-8nZ" secondAttribute="bottom" constant="4" id="UpW-tS-2Zy"/>
                             <constraint firstItem="Ih6-MC-nUR" firstAttribute="leading" secondItem="mid-Fe-HHm" secondAttribute="trailing" constant="8" symbolic="YES" id="WhF-yN-VuX"/>
                             <constraint firstItem="rm3-tN-rQO" firstAttribute="leading" secondItem="EJZ-Wn-7Tz" secondAttribute="trailing" constant="40" id="XqK-v9-hlP"/>
                             <constraint firstItem="ufS-r3-0uH" firstAttribute="baseline" secondItem="SFI-Qh-n2D" secondAttribute="firstBaseline" id="Xv0-rp-0hp"/>
+                            <constraint firstItem="aOC-Nn-pfW" firstAttribute="leading" secondItem="AaW-HC-ZSx" secondAttribute="leading" id="YSu-cM-Tyr"/>
                             <constraint firstItem="Ih6-MC-nUR" firstAttribute="trailing" secondItem="XCk-4w-Cy6" secondAttribute="trailing" id="ZWN-7Z-q11"/>
                             <constraint firstItem="M7z-d7-GnN" firstAttribute="baseline" secondItem="4qO-Fe-RWA" secondAttribute="baseline" id="Znb-re-3Uz"/>
                             <constraint firstItem="6ga-1T-9ly" firstAttribute="leading" secondItem="FL1-7e-JUq" secondAttribute="leading" id="bu7-ct-veh"/>
@@ -1026,6 +1034,7 @@
                             <constraint firstItem="rm3-tN-rQO" firstAttribute="top" secondItem="ufS-r3-0uH" secondAttribute="bottom" constant="13" id="f9p-hz-cuK"/>
                             <constraint firstItem="EJZ-Wn-7Tz" firstAttribute="baseline" secondItem="9qE-Q3-fww" secondAttribute="firstBaseline" id="fHE-6o-Bvt"/>
                             <constraint firstItem="FL1-7e-JUq" firstAttribute="top" secondItem="6ga-1T-9ly" secondAttribute="bottom" constant="8" symbolic="YES" id="foN-rj-5CO"/>
+                            <constraint firstItem="rUG-7Y-zgX" firstAttribute="top" secondItem="aOC-Nn-pfW" secondAttribute="bottom" constant="40" id="gZT-ES-yd1"/>
                             <constraint firstItem="N1B-nD-gUu" firstAttribute="top" secondItem="QHt-Sf-WnZ" secondAttribute="top" id="hMn-v1-dx9"/>
                             <constraint firstItem="AJ3-cu-c5f" firstAttribute="leading" secondItem="6ga-1T-9ly" secondAttribute="leading" id="iij-X8-ux5"/>
                             <constraint firstItem="RsK-dO-vcR" firstAttribute="centerY" secondItem="AaW-HC-ZSx" secondAttribute="centerY" id="iro-dK-HVr"/>
@@ -1042,6 +1051,8 @@
                             <constraint firstItem="9qE-Q3-fww" firstAttribute="leading" secondItem="rm3-tN-rQO" secondAttribute="trailing" constant="33" id="vTS-gr-U9s"/>
                             <constraint firstItem="Ih6-MC-nUR" firstAttribute="top" secondItem="R4D-X9-Nms" secondAttribute="bottom" constant="8" symbolic="YES" id="vbg-xR-VDY"/>
                             <constraint firstItem="ufS-r3-0uH" firstAttribute="baseline" secondItem="qDp-Yr-DOK" secondAttribute="baseline" id="w1f-RX-iwS"/>
+                            <constraint firstItem="aOC-Nn-pfW" firstAttribute="top" secondItem="qCJ-IQ-Xx3" secondAttribute="bottom" constant="18" id="wJm-bd-VCz"/>
+                            <constraint firstAttribute="bottom" secondItem="aOC-Nn-pfW" secondAttribute="bottom" constant="185" id="wsY-xR-Ser"/>
                             <constraint firstItem="t5v-V3-aso" firstAttribute="leading" secondItem="ufS-r3-0uH" secondAttribute="leading" id="xwD-xr-Mhg"/>
                             <constraint firstItem="mid-Fe-HHm" firstAttribute="leading" secondItem="AJ3-cu-c5f" secondAttribute="leading" id="yKl-i2-2sp"/>
                             <constraint firstItem="EJZ-Wn-7Tz" firstAttribute="centerY" secondItem="9qE-Q3-fww" secondAttribute="centerY" id="ymh-La-Nor"/>
@@ -1051,6 +1062,7 @@
                     </view>
                     <connections>
                         <outlet property="appSecretLabel" destination="XCk-4w-Cy6" id="VD8-WX-Sho"/>
+                        <outlet property="clearCrashUserConfirmationButton" destination="aOC-Nn-pfW" id="ZOn-qk-5cy"/>
                         <outlet property="deviceIdField" destination="7dF-GM-Y0D" id="FEY-bl-hqc"/>
                         <outlet property="installIdLabel" destination="Ih6-MC-nUR" id="X6a-Ru-i1f"/>
                         <outlet property="logURLLabel" destination="ktO-VZ-RCE" id="FrS-qE-UaM"/>

--- a/SasquatchMac/SasquatchMac/Base.lproj/SasquatchMac.storyboard
+++ b/SasquatchMac/SasquatchMac/Base.lproj/SasquatchMac.storyboard
@@ -991,15 +991,17 @@
                         <constraints>
                             <constraint firstItem="N1B-nD-gUu" firstAttribute="leading" secondItem="M7z-d7-GnN" secondAttribute="leading" id="1aT-zh-uRs"/>
                             <constraint firstItem="Ih6-MC-nUR" firstAttribute="leading" secondItem="XCk-4w-Cy6" secondAttribute="leading" id="2FJ-yt-Gai"/>
-                            <constraint firstItem="aOC-Nn-pfW" firstAttribute="leading" secondItem="EJZ-Wn-7Tz" secondAttribute="leading" id="4nc-Xa-AyH"/>
                             <constraint firstItem="4qO-Fe-RWA" firstAttribute="leading" secondItem="t5v-V3-aso" secondAttribute="trailing" constant="8" symbolic="YES" id="6Ya-oi-Qh3"/>
+                            <constraint firstItem="R4D-X9-Nms" firstAttribute="centerX" secondItem="rUG-7Y-zgX" secondAttribute="centerX" constant="11.5" id="7E3-Ff-1te"/>
                             <constraint firstItem="QHt-Sf-WnZ" firstAttribute="leading" secondItem="t5v-V3-aso" secondAttribute="leading" id="84C-u9-9mT"/>
                             <constraint firstItem="XCk-4w-Cy6" firstAttribute="leading" secondItem="ktO-VZ-RCE" secondAttribute="leading" id="8ZI-zq-krX"/>
                             <constraint firstItem="qCJ-IQ-Xx3" firstAttribute="top" secondItem="rm3-tN-rQO" secondAttribute="bottom" constant="12" symbolic="YES" id="8bp-k8-Yyo"/>
-                            <constraint firstItem="rUG-7Y-zgX" firstAttribute="trailing" secondItem="qDp-Yr-DOK" secondAttribute="trailing" id="9mq-D1-9J1"/>
+                            <constraint firstItem="rUG-7Y-zgX" firstAttribute="top" secondItem="qCJ-IQ-Xx3" secondAttribute="bottom" constant="59" id="A1x-Si-Kj4"/>
                             <constraint firstItem="VA4-N7-8nZ" firstAttribute="trailing" secondItem="7dF-GM-Y0D" secondAttribute="trailing" id="BkF-l8-ZS6"/>
+                            <constraint firstItem="R4D-X9-Nms" firstAttribute="top" secondItem="k9u-4S-Pzy" secondAttribute="top" constant="20" symbolic="YES" id="DDy-XL-azc"/>
                             <constraint firstItem="RsK-dO-vcR" firstAttribute="leading" secondItem="AaW-HC-ZSx" secondAttribute="trailing" constant="228" id="EPW-Jd-T2Y"/>
                             <constraint firstItem="qCJ-IQ-Xx3" firstAttribute="leading" secondItem="AaW-HC-ZSx" secondAttribute="trailing" constant="30" id="FOK-uE-8g9"/>
+                            <constraint firstItem="AaW-HC-ZSx" firstAttribute="leading" secondItem="k9u-4S-Pzy" secondAttribute="leading" constant="50" id="HSq-JQ-Q1F"/>
                             <constraint firstItem="rm3-tN-rQO" firstAttribute="baseline" secondItem="9qE-Q3-fww" secondAttribute="baseline" id="HvG-Rz-JaY"/>
                             <constraint firstItem="VA4-N7-8nZ" firstAttribute="leading" secondItem="FL1-7e-JUq" secondAttribute="trailing" constant="8" symbolic="YES" id="IZi-cZ-g0R"/>
                             <constraint firstItem="ufS-r3-0uH" firstAttribute="top" secondItem="t5v-V3-aso" secondAttribute="bottom" constant="5" id="Iq0-2t-MoK"/>
@@ -1008,6 +1010,7 @@
                             <constraint firstItem="6ga-1T-9ly" firstAttribute="top" secondItem="AJ3-cu-c5f" secondAttribute="bottom" constant="8" symbolic="YES" id="Lfi-TU-De6"/>
                             <constraint firstItem="UAF-Zh-FC1" firstAttribute="top" secondItem="FL1-7e-JUq" secondAttribute="bottom" constant="10" id="Ll5-Z6-pEQ"/>
                             <constraint firstItem="M7z-d7-GnN" firstAttribute="baseline" secondItem="4qO-Fe-RWA" secondAttribute="firstBaseline" id="MV7-rf-BDw"/>
+                            <constraint firstItem="R4D-X9-Nms" firstAttribute="centerX" secondItem="k9u-4S-Pzy" secondAttribute="centerX" id="MhE-ZY-1g0"/>
                             <constraint firstItem="AJ3-cu-c5f" firstAttribute="top" secondItem="mid-Fe-HHm" secondAttribute="bottom" constant="8" symbolic="YES" id="NtC-64-IfV"/>
                             <constraint firstItem="ktO-VZ-RCE" firstAttribute="trailing" secondItem="VA4-N7-8nZ" secondAttribute="trailing" id="PEi-27-TzQ"/>
                             <constraint firstItem="7dF-GM-Y0D" firstAttribute="leading" secondItem="UAF-Zh-FC1" secondAttribute="trailing" id="Pt1-mW-dWT"/>
@@ -1015,14 +1018,13 @@
                             <constraint firstItem="VA4-N7-8nZ" firstAttribute="leading" secondItem="7dF-GM-Y0D" secondAttribute="leading" id="Q7C-s8-raX"/>
                             <constraint firstItem="qCJ-IQ-Xx3" firstAttribute="centerY" secondItem="AaW-HC-ZSx" secondAttribute="centerY" id="QCk-AN-Jec"/>
                             <constraint firstItem="4qO-Fe-RWA" firstAttribute="leading" secondItem="qDp-Yr-DOK" secondAttribute="leading" id="QjJ-Ha-orS"/>
-                            <constraint firstItem="aOC-Nn-pfW" firstAttribute="leading" secondItem="k9u-4S-Pzy" secondAttribute="leading" constant="20" symbolic="YES" id="SKB-Rx-K1B"/>
+                            <constraint firstItem="mid-Fe-HHm" firstAttribute="leading" secondItem="k9u-4S-Pzy" secondAttribute="leading" constant="20" symbolic="YES" id="S4D-Sj-AY9"/>
                             <constraint firstItem="qDp-Yr-DOK" firstAttribute="leading" secondItem="ufS-r3-0uH" secondAttribute="trailing" constant="8" symbolic="YES" id="TAZ-iM-tDb"/>
                             <constraint firstItem="mid-Fe-HHm" firstAttribute="top" secondItem="Ih6-MC-nUR" secondAttribute="top" id="UDP-Xg-kjv"/>
                             <constraint firstItem="7dF-GM-Y0D" firstAttribute="top" secondItem="VA4-N7-8nZ" secondAttribute="bottom" constant="4" id="UpW-tS-2Zy"/>
                             <constraint firstItem="Ih6-MC-nUR" firstAttribute="leading" secondItem="mid-Fe-HHm" secondAttribute="trailing" constant="8" symbolic="YES" id="WhF-yN-VuX"/>
                             <constraint firstItem="rm3-tN-rQO" firstAttribute="leading" secondItem="EJZ-Wn-7Tz" secondAttribute="trailing" constant="40" id="XqK-v9-hlP"/>
                             <constraint firstItem="ufS-r3-0uH" firstAttribute="baseline" secondItem="SFI-Qh-n2D" secondAttribute="firstBaseline" id="Xv0-rp-0hp"/>
-                            <constraint firstItem="aOC-Nn-pfW" firstAttribute="leading" secondItem="AaW-HC-ZSx" secondAttribute="leading" id="YSu-cM-Tyr"/>
                             <constraint firstItem="Ih6-MC-nUR" firstAttribute="trailing" secondItem="XCk-4w-Cy6" secondAttribute="trailing" id="ZWN-7Z-q11"/>
                             <constraint firstItem="M7z-d7-GnN" firstAttribute="baseline" secondItem="4qO-Fe-RWA" secondAttribute="baseline" id="Znb-re-3Uz"/>
                             <constraint firstItem="6ga-1T-9ly" firstAttribute="leading" secondItem="FL1-7e-JUq" secondAttribute="leading" id="bu7-ct-veh"/>
@@ -1034,7 +1036,6 @@
                             <constraint firstItem="rm3-tN-rQO" firstAttribute="top" secondItem="ufS-r3-0uH" secondAttribute="bottom" constant="13" id="f9p-hz-cuK"/>
                             <constraint firstItem="EJZ-Wn-7Tz" firstAttribute="baseline" secondItem="9qE-Q3-fww" secondAttribute="firstBaseline" id="fHE-6o-Bvt"/>
                             <constraint firstItem="FL1-7e-JUq" firstAttribute="top" secondItem="6ga-1T-9ly" secondAttribute="bottom" constant="8" symbolic="YES" id="foN-rj-5CO"/>
-                            <constraint firstItem="rUG-7Y-zgX" firstAttribute="top" secondItem="aOC-Nn-pfW" secondAttribute="bottom" constant="40" id="gZT-ES-yd1"/>
                             <constraint firstItem="N1B-nD-gUu" firstAttribute="top" secondItem="QHt-Sf-WnZ" secondAttribute="top" id="hMn-v1-dx9"/>
                             <constraint firstItem="AJ3-cu-c5f" firstAttribute="leading" secondItem="6ga-1T-9ly" secondAttribute="leading" id="iij-X8-ux5"/>
                             <constraint firstItem="RsK-dO-vcR" firstAttribute="centerY" secondItem="AaW-HC-ZSx" secondAttribute="centerY" id="iro-dK-HVr"/>
@@ -1051,8 +1052,6 @@
                             <constraint firstItem="9qE-Q3-fww" firstAttribute="leading" secondItem="rm3-tN-rQO" secondAttribute="trailing" constant="33" id="vTS-gr-U9s"/>
                             <constraint firstItem="Ih6-MC-nUR" firstAttribute="top" secondItem="R4D-X9-Nms" secondAttribute="bottom" constant="8" symbolic="YES" id="vbg-xR-VDY"/>
                             <constraint firstItem="ufS-r3-0uH" firstAttribute="baseline" secondItem="qDp-Yr-DOK" secondAttribute="baseline" id="w1f-RX-iwS"/>
-                            <constraint firstItem="aOC-Nn-pfW" firstAttribute="top" secondItem="qCJ-IQ-Xx3" secondAttribute="bottom" constant="18" id="wJm-bd-VCz"/>
-                            <constraint firstAttribute="bottom" secondItem="aOC-Nn-pfW" secondAttribute="bottom" constant="185" id="wsY-xR-Ser"/>
                             <constraint firstItem="t5v-V3-aso" firstAttribute="leading" secondItem="ufS-r3-0uH" secondAttribute="leading" id="xwD-xr-Mhg"/>
                             <constraint firstItem="mid-Fe-HHm" firstAttribute="leading" secondItem="AJ3-cu-c5f" secondAttribute="leading" id="yKl-i2-2sp"/>
                             <constraint firstItem="EJZ-Wn-7Tz" firstAttribute="centerY" secondItem="9qE-Q3-fww" secondAttribute="centerY" id="ymh-La-Nor"/>

--- a/SasquatchMac/SasquatchMac/Constants.h
+++ b/SasquatchMac/SasquatchMac/Constants.h
@@ -8,6 +8,7 @@ static NSString *const kMSUserIdKey = @"userId";
 static NSString *const kMSLogUrl = @"logUrl";
 static NSString *const kMSAppSecret = @"appSecret";
 static NSString *const kMSLogTag = @"[SasquatchMac]";
+static NSString *const kMSUserConfirmationKey = @"MSUserConfirmation";
 
 static NSString *const kSASCustomizedUpdateAlertKey = @"kSASCustomizedUpdateAlertKey";
 static NSString *const kMSChildTransmissionTargetTokenKey = @"kMSChildTransmissionTargetToken";

--- a/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
@@ -234,8 +234,6 @@ class AppCenterViewController : NSViewController, NSTextFieldDelegate, NSTextVie
     case NSAlertFirstButtonReturn:
         UserDefaults.standard.removeObject(forKey: kMSUserConfirmationKey)
         break
-    case NSAlertSecondButtonReturn:
-        break
     default:
         break
     }

--- a/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
@@ -225,13 +225,16 @@ class AppCenterViewController : NSViewController, NSTextFieldDelegate, NSTextVie
   }
 
   @IBAction func clearCrashUserConfirmation(_ sender: Any) {
-    UserDefaults.standard.removeObject(forKey: kMSUserConfirmationKey)
     let alert: NSAlert = NSAlert()
-    alert.messageText = "Crash user confirmation has been reset!"
+    alert.messageText = "Clear crash user confirmation?"
     alert.addButton(withTitle: "OK")
+    alert.addButton(withTitle: "Cancel")
     alert.alertStyle = NSWarningAlertStyle
     switch(alert.runModal()) {
-    case NSAlertThirdButtonReturn:
+    case NSAlertFirstButtonReturn:
+        UserDefaults.standard.removeObject(forKey: kMSUserConfirmationKey)
+        break
+    case NSAlertSecondButtonReturn:
         break
     default:
         break

--- a/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
@@ -226,6 +226,16 @@ class AppCenterViewController : NSViewController, NSTextFieldDelegate, NSTextVie
 
   @IBAction func clearCrashUserConfirmation(_ sender: Any) {
     UserDefaults.standard.removeObject(forKey: kMSUserConfirmationKey)
+    let alert: NSAlert = NSAlert()
+    alert.messageText = "Crash user confirmation has been reset!"
+    alert.addButton(withTitle: "OK")
+    alert.alertStyle = NSWarningAlertStyle
+    switch(alert.runModal()) {
+    case NSAlertThirdButtonReturn:
+        break
+    default:
+        break
+    }
   }
 
   private func prodLogUrl() -> String {

--- a/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
@@ -39,7 +39,8 @@ class AppCenterViewController : NSViewController, NSTextFieldDelegate, NSTextVie
 
   @IBOutlet weak var setLogURLButton: NSButton!
   @IBOutlet weak var setAppSecretButton: NSButton!
-  
+  @IBOutlet var clearCrashUserConfirmationButton: NSButton!
+
   private var dbFileDescriptor: CInt = 0
   private var dbFileSource: DispatchSourceProtocol?
 
@@ -221,6 +222,10 @@ class AppCenterViewController : NSViewController, NSTextFieldDelegate, NSTextVie
       break
     }
     appSecretLabel?.stringValue = (UserDefaults.standard.object(forKey: kMSAppSecret) ?? appCenter.appSecret()) as! String
+  }
+
+  @IBAction func clearCrashUserConfirmation(_ sender: Any) {
+    UserDefaults.standard.removeObject(forKey: kMSUserConfirmationKey)
   }
 
   private func prodLogUrl() -> String {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Add reset crash confirmation feature on iOS and macOS test app.

iOS after:
<img width="354" alt="Screen Shot 2019-06-24 at 16 23 40" src="https://user-images.githubusercontent.com/46912152/60003254-e30f3500-969c-11e9-9130-90e7f0eb07fb.png">


macOS after:
![Screen Shot 2019-06-21 at 11 18 09 AM](https://user-images.githubusercontent.com/46912152/59895243-5b17f980-9416-11e9-9ad5-0732d58ecacf.png)




## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
