### PR TITLE
GetNextPage when offline

### DIFF
--- a/AppCenterData/AppCenterData/Internal/Client/MSDataOperationProxy.m
+++ b/AppCenterData/AppCenterData/Internal/Client/MSDataOperationProxy.m
@@ -192,7 +192,8 @@
       MSDataError *dataError = [[MSDataError alloc] initWithErrorCode:MSACDataErrorCachedToken innerError:nil message:message];
       MSPaginatedDocuments *documents = [[MSPaginatedDocuments alloc] initWithError:dataError
                                                                           partition:partition
-                                                                       documentType:documentType];
+                                                                       documentType:documentType
+                                                                  continuationToken:nil];
       completionHandler(documents);
       return;
     }

--- a/AppCenterData/AppCenterData/Internal/Model/MSPaginatedDocumentsInternal.h
+++ b/AppCenterData/AppCenterData/Internal/Model/MSPaginatedDocumentsInternal.h
@@ -44,10 +44,15 @@ NS_ASSUME_NONNULL_BEGIN
  * @param error Error to initialize with.
  * @param partition The partition for the documents.
  * @param documentType The type of the documents in the partition.
+ * @param continuationToken The continuation token, if any.
  *
  * @return The paginated documents.
  */
-- (instancetype)initWithError:(MSDataError *)error partition:(NSString *)partition documentType:(Class)documentType;
+- (instancetype)initWithError:(MSDataError *)error
+                    partition:(NSString *)partition
+                 documentType:(Class)documentType
+            continuationToken:(NSString *_Nullable)continuationToken;
+;
 
 @end
 

--- a/AppCenterData/AppCenterData/MSData.m
+++ b/AppCenterData/AppCenterData/MSData.m
@@ -403,9 +403,10 @@ static dispatch_once_t onceToken;
       dataError = [self generateDisabledError:@"list" documentId:nil];
     } else if (![MSDocumentUtils isSerializableDocument:documentType]) {
       dataError = [self generateInvalidClassError];
-    } else if ([self.reachability currentReachabilityStatus] == NotReachable) {
+    } else if (continuationToken && [self.reachability currentReachabilityStatus] == NotReachable) {
 
-      // If offline, return an error.
+      // For offline scenario, if continuation token is provided, then return an error since next page can't be retrieved.
+      // Otherwise, (if continuationToken is nil), return the first page.
       dataError = [[MSDataError alloc] initWithErrorCode:MSACDataErrorNextDocumentPageUnavailable
                                               innerError:nil
                                                  message:(NSString *)kMSACDataErrorNextDocumentPageUnavailableDesc];

--- a/AppCenterData/AppCenterData/MSData.m
+++ b/AppCenterData/AppCenterData/MSData.m
@@ -403,9 +403,18 @@ static dispatch_once_t onceToken;
       dataError = [self generateDisabledError:@"list" documentId:nil];
     } else if (![MSDocumentUtils isSerializableDocument:documentType]) {
       dataError = [self generateInvalidClassError];
+    } else if ([self.reachability currentReachabilityStatus] == NotReachable) {
+
+      // If offline, return an error.
+      dataError = [[MSDataError alloc] initWithErrorCode:MSACDataErrorNextDocumentPageUnavailable
+                                              innerError:nil
+                                                 message:(NSString *)kMSACDataErrorNextDocumentPageUnavailableDesc];
     }
     if (dataError) {
-      completionHandler([[MSPaginatedDocuments alloc] initWithError:dataError partition:partition documentType:documentType]);
+      completionHandler([[MSPaginatedDocuments alloc] initWithError:dataError
+                                                          partition:partition
+                                                       documentType:documentType
+                                                  continuationToken:continuationToken]);
       return;
     }
 
@@ -594,7 +603,8 @@ static dispatch_once_t onceToken;
                                            [actualDataError localizedDescription], (long)response.statusCode, (long)MSHTTPCodesNo200OK);
                                 MSPaginatedDocuments *documents = [[MSPaginatedDocuments alloc] initWithError:actualDataError
                                                                                                     partition:partition
-                                                                                                 documentType:documentType];
+                                                                                                 documentType:documentType
+                                                                                            continuationToken:nil];
                                 completionHandler(documents);
                                 return;
                               }
@@ -612,7 +622,8 @@ static dispatch_once_t onceToken;
                                 if (deserializeDataError) {
                                   MSPaginatedDocuments *documents = [[MSPaginatedDocuments alloc] initWithError:deserializeDataError
                                                                                                       partition:partition
-                                                                                                   documentType:documentType];
+                                                                                                   documentType:documentType
+                                                                                              continuationToken:nil];
                                   completionHandler(documents);
                                   return;
                                 }

--- a/AppCenterData/AppCenterData/MSDataErrors.h
+++ b/AppCenterData/AppCenterData/MSDataErrors.h
@@ -39,6 +39,6 @@ static NSString const *kMSACDataInvalidClassDesc = @"Provided class does not con
 static NSString const *kMSACDataCosmosDbErrorResponseDesc = @"Unexpected error while talking to CosmosDB.";
 static NSString const *kMSACDocumentCreationDesc = @"Can't create document.";
 static NSString const *kMSACDataErrorDocumentIdInvalidDesc = @"Invalid document ID.";
-static NSString const *kMSACDataErrorNextDocumentPageUnavailableDesc = @"Can't detect next page when the device is offline.";
+static NSString const *kMSACDataErrorNextDocumentPageUnavailableDesc = @"Can't retrieve the next page when the device is offline.";
 
 NS_ASSUME_NONNULL_END

--- a/AppCenterData/AppCenterData/MSPaginatedDocuments.h
+++ b/AppCenterData/AppCenterData/MSPaginatedDocuments.h
@@ -13,11 +13,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Boolean indicating if an extra page is available.
  *
- * @param error Error indicating an error in retrieving the next page.
- *
  * @return True if there is another page of documents, false otherwise.
  */
-- (BOOL)hasNextPageWithError:(MSDataError *__autoreleasing *)error;
+- (BOOL)hasNextPage;
 
 /**
  * Return the current page.

--- a/AppCenterData/AppCenterData/MSPaginatedDocuments.m
+++ b/AppCenterData/AppCenterData/MSPaginatedDocuments.m
@@ -38,28 +38,24 @@
   return self;
 }
 
-- (instancetype)initWithError:(MSDataError *)error partition:(NSString *)partition documentType:(Class)documentType {
+- (instancetype)initWithError:(MSDataError *)error
+                    partition:(NSString *)partition
+                 documentType:(Class)documentType
+            continuationToken:(NSString *_Nullable)continuationToken {
   return [self initWithPage:[[MSPage alloc] initWithError:error]
                   partition:partition
                documentType:documentType
                reachability:self.reachability
            deviceTimeToLive:kMSDataTimeToLiveNoCache
-          continuationToken:nil];
+          continuationToken:continuationToken];
 }
 
-- (BOOL)hasNextPageWithError:(MSDataError *__autoreleasing *)error {
-  if (self.reachability && [self.reachability currentReachabilityStatus] == NotReachable) {
-    *error = [[MSDataError alloc] initWithErrorCode:MSACDataErrorNextDocumentPageUnavailable
-                                         innerError:nil
-                                            message:(NSString *)kMSACDataErrorNextDocumentPageUnavailableDesc];
-    return NO;
-  }
+- (BOOL)hasNextPage {
   return [self.continuationToken length] != 0;
 }
 
 - (void)nextPageWithCompletionHandler:(void (^)(MSPage *page))completionHandler {
-  MSDataError *nextPageError;
-  if ([self hasNextPageWithError:&nextPageError]) {
+  if ([self hasNextPage]) {
     [MSData listDocumentsWithType:self.documentType
                         partition:self.partition
                       readOptions:[[MSReadOptions alloc] initWithDeviceTimeToLive:self.deviceTimeToLive]
@@ -72,8 +68,6 @@
                   // Notify completion handler.
                   completionHandler(documents.currentPage);
                 }];
-  } else if (nextPageError) {
-    completionHandler([[MSPage alloc] initWithError:nextPageError]);
   } else {
     completionHandler(nil);
   }

--- a/Sasquatch/Sasquatch/ViewControllers/MSDataViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSDataViewController.swift
@@ -89,7 +89,7 @@ class MSDataViewController: UIViewController, UITableViewDelegate, UITableViewDa
   }
   
   func loadMore() {
-    if (!loadMoreStatus && self.allDocuments.hasNextPageWithError(nil)){
+    if (!loadMoreStatus && self.allDocuments.hasNextPage){
       self.loadMoreStatus = true
       DispatchQueue.global().async() {
         self.allDocuments.nextPage(completionHandler: { page in

--- a/Sasquatch/Sasquatch/ViewControllers/MSDataViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSDataViewController.swift
@@ -89,7 +89,7 @@ class MSDataViewController: UIViewController, UITableViewDelegate, UITableViewDa
   }
   
   func loadMore() {
-    if (!loadMoreStatus && self.allDocuments.hasNextPage){
+    if (!loadMoreStatus && self.allDocuments.hasNextPage()){
       self.loadMoreStatus = true
       DispatchQueue.global().async() {
         self.allDocuments.nextPage(completionHandler: { page in


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
There are 2 APIs related to this change.
1- `- (BOOL)hasNextPage;`
the implementation of this API remains the same and as long as continuation token exists, it return true. this change reverts this API.

2- `- (void)nextPageWithCompletionHandler:(void (^)(MSPage *page))completionHandler;`
for this API when device is offline, it returns a Page containing an error that indicates next page is not available cause device is offline. Also, we keep the continuation token around (won't clean it up when called network offline)
