### PR TITLE
Yochaude/sqlite query invalid table

### DIFF
--- a/AppCenterData/AppCenterData/Internal/Client/MSDataOperationProxy.m
+++ b/AppCenterData/AppCenterData/Internal/Client/MSDataOperationProxy.m
@@ -202,7 +202,7 @@
     MSTokenResult *token = tokensResponse.tokens.firstObject;
 
     // Retrieve from cache when offline and when there are pending operations.
-    if (![self shouldAttemptRemoteOperationForPartition:partition]) {
+    if (![self shouldAttemptRemoteOperationForPartition:[token partition]]) {
       MSPaginatedDocuments *cachedDocumentsList = [self.documentStore listWithToken:token
                                                                           partition:partition
                                                                        documentType:documentType
@@ -220,7 +220,7 @@
     }
 
     // Execute remote operation online and does not have any pending operations.
-    else if ([self shouldAttemptRemoteOperationForPartition:partition]) {
+    else {
       MSLogInfo([MSData logTag], @"Performing remote operation");
       [self performRemoteOperationWithToken:token
                                 baseOptions:baseOptions

--- a/AppCenterData/AppCenterData/Internal/LocalStore/MSDBDocumentStore.m
+++ b/AppCenterData/AppCenterData/Internal/LocalStore/MSDBDocumentStore.m
@@ -231,7 +231,7 @@ static const NSUInteger kMSSchemaVersion = 1;
       // Delete the local document when found to be expired.
       [self deleteWithToken:token documentId:documentId];
     } else {
-        
+
       // Deserialize document.
       NSString *jsonString = documentRow[self.documentColumnIndex];
       NSData *jsonData = [jsonString dataUsingEncoding:NSUTF8StringEncoding];

--- a/AppCenterData/AppCenterDataTests/MSDataTests.m
+++ b/AppCenterData/AppCenterDataTests/MSDataTests.m
@@ -785,7 +785,7 @@ static NSString *const kMSDocumentIdTest = @"documentId";
                                                                              reachability:self.sut.reachability
                                                                          deviceTimeToLive:kMSDataTimeToLiveDefault
                                                                         continuationToken:nil];
-  OCMStub([localStorageMock hasPendingOperationsForPartition:kMSPartitionTest]).andReturn(true);
+  OCMStub([localStorageMock hasPendingOperationsForPartition:[testToken partition]]).andReturn(true);
   OCMStub([localStorageMock listWithToken:testToken partition:OCMOCK_ANY documentType:OCMOCK_ANY baseOptions:OCMOCK_ANY])
       .andReturn(expectedDocumentList);
 


### PR DESCRIPTION
A document storage query was using the partition passed to the Data module instead of the internal partition representation (coming from tokens).

This was causing this kind of potential errors:

```
2019-07-10 15:11:26.513572-0700 SasquatchPuppet[19182:468691] [AppCenter] ERROR: +[MSDBStorage executeSelectionQuery:inOpenedDatabase:result:]/356 Query "SELECT COUNT(*) FROM "(null)" WHERE "pending_operation" IS NOT NULL" failed with error: 1 - no such table: (null)
```

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

A few sentences describing the overall goals of the pull request.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
