### PR TITLE
SDK is logging appSecret in verbose logs in clear text when enabling in-app updates

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -504,7 +504,8 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
 
   // Check URL validity so far.
   if (!components) {
-    MSLogError([MSDistribute logTag], kMSUpdateTokenURLInvalidErrorDescFormat, urlString);
+    NSString *hideUrl = [urlString stringByReplacingOccurrencesOfString:appSecret withString:[MSHttpUtil hideSecret:urlString]];
+    MSLogError([MSDistribute logTag], kMSUpdateTokenURLInvalidErrorDescFormat, hideUrl);
     return nil;
   }
 
@@ -561,7 +562,8 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
 }
 
 - (void)openURLInAuthenticationSessionWith:(NSURL *)url fromClass:(Class)sessionClazz {
-  MSLogDebug([MSDistribute logTag], @"Using SFAuthenticationSession to open URL: %@", url);
+  NSString *hideUrl = [url.absoluteString stringByReplacingOccurrencesOfString:self.appSecret withString:[MSHttpUtil hideSecret:url.absoluteString]];
+  MSLogDebug([MSDistribute logTag], @"Using SFAuthenticationSession to open URL: %@", hideUrl);
   NSString *callbackUrlScheme = [NSString stringWithFormat:kMSDefaultCustomSchemeFormat, self.appSecret];
 
   // Check once more if we have the correct class.

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -2537,9 +2537,6 @@ static NSURL *sfURL;
 -(void)testHideAppSecret {
   
   // If
-  NSString *scheme = [NSString stringWithFormat:kMSDefaultCustomSchemeFormat, kMSTestAppSecret];
-  NSString *requestId = @"FIRST-REQUEST";
-  NSString *updateSetupFailureMessage = @"in-app updates setup failed";
   NSString *urlPath = [NSString stringWithFormat:kMSUpdateTokenApiPathFormat, kMSTestAppSecret];
   NSURLComponents *components = [NSURLComponents componentsWithString:urlPath];
   id authClass = nil;
@@ -2557,18 +2554,20 @@ static NSURL *sfURL;
   // When
   NSMutableArray *items = [NSMutableArray array];
   components.queryItems = items;
-  
-  // Then
-  [distributeMock openURLInAuthenticationSessionWith:components.URL fromClass:authClass];
   OCMReject([[mockLog ignoringNonObjectArgs] logMessage:OCMOCK_ANY
-                                                  level:OCMOCK_ANY
+                                                  level:0
                                                     tag:containsSubstring(kMSTestAppSecret)
                                                    file:0
                                                function:0
                                                    line:0]);
+  
+  // Then
+  [distributeMock openURLInAuthenticationSessionWith:components.URL fromClass:authClass];
  
   // Clear
   [mockLog stopMocking];
+  [appCenterMock stopMocking];
+  [distributeMock stopMocking];
 }
 
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Distribute
 
-* **[Fix]** Fix the logging appSecret in verbose logs.
+* **[Fix]** Obfuscate app secret value that appears as URI part in verbose logs for in-app updates.
 
 ## Version 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # App Center SDK for iOS, macOS and tvOS Change Log
 
+## Version 2.2.1
+
+### App Center Distribute
+
+* **[Fix]** Fix the logging appSecret in verbose logs.
+
 ## Version 2.2.0
 
 ### App Center


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Hide app secret in logs

## Related PRs or issues

[AB#64628](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/64628)