### PR TITLE
Fix warnings in publc headers caused by missing lifetime attributes f…

### DIFF
--- a/AppCenter/AppCenter/MSLog.h
+++ b/AppCenter/AppCenter/MSLog.h
@@ -15,7 +15,7 @@
 /**
  * Log timestamp.
  */
-@property(nonatomic) NSDate *timestamp;
+@property(nonatomic, strong) NSDate *timestamp;
 
 /**
  * A session identifier is used to correlate logs together. A session is an abstract concept in the API and is not necessarily an analytics
@@ -36,13 +36,13 @@
 /**
  * Device properties associated to this log.
  */
-@property(nonatomic) MSDevice *device;
+@property(nonatomic, strong) MSDevice *device;
 
 /**
  * Transient object tag. For example, a log can be tagged with a transmission target. We do this currently to prevent properties being
  * applied retroactively to previous logs by comparing their tags.
  */
-@property(nonatomic) NSObject *tag;
+@property(nonatomic, strong) NSObject *tag;
 
 /**
  * Checks if the object's values are valid.

--- a/AppCenter/AppCenter/Model/MSLogWithProperties.h
+++ b/AppCenter/AppCenter/Model/MSLogWithProperties.h
@@ -10,6 +10,6 @@
 /**
  * Additional key/value pair parameters. [optional]
  */
-@property(nonatomic, copy) NSDictionary<NSString *, NSString *> *properties;
+@property(nonatomic, strong) NSDictionary<NSString *, NSString *> *properties;
 
 @end

--- a/AppCenter/AppCenter/Model/MSLogWithProperties.h
+++ b/AppCenter/AppCenter/Model/MSLogWithProperties.h
@@ -10,6 +10,6 @@
 /**
  * Additional key/value pair parameters. [optional]
  */
-@property(nonatomic) NSDictionary<NSString *, NSString *> *properties;
+@property(nonatomic, copy) NSDictionary<NSString *, NSString *> *properties;
 
 @end

--- a/AppCenterAnalytics/AppCenterAnalytics/Model/MSEventLog.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/Model/MSEventLog.h
@@ -16,6 +16,6 @@
 /**
  * Event properties.
  */
-@property(nonatomic) MSEventProperties *typedProperties;
+@property(nonatomic, strong) MSEventProperties *typedProperties;
 
 @end


### PR DESCRIPTION
…or object properties

## Description

This pull requests fixes warnings in public headers so clients including the AppCenter, AppCenterAnalytics, and AppCenterCrashes frameworks on Mac do not get warnings while compiling.

The warnings were caused by the use of `@property(nonatomic)`, without specifying a lifetime attribute, for object properties. Objective-C defaults to `assign` when there is no lifetime attribute, which is not appropriate for Objective-C objects.

## Related PRs or issues

There are no related PRs or issues that I could find.

## Misc

Because I wanted to keep this pull request small, I only updated the public headers. There are lots of internal headers and implementation files which also use `@property(nonatomic)` in this way. If you would like me to update those as well, I would be happy to.

This is my first pull request to this project, and although I attempted to run the local tests, I was unable to get them to build due to various linking errors in Xcode 10.3. I may be missing a step. Is there a script or other command I should be using to run the tests? If not, I can file issues on the linker errors I get when trying to run the tests in Xcode.

Thank you for your consideration.