### PR TITLE
Allow Mac apps to name their Application Support directory

### DIFF
--- a/AppCenter/AppCenter/Internals/Util/MSUtility+File.m
+++ b/AppCenter/AppCenter/Internals/Util/MSUtility+File.m
@@ -17,6 +17,11 @@ NSString *MSUtilityFileCategory;
  */
 static NSString *const kMSAppCenterBundleIdentifier = @"com.microsoft.appcenter";
 
+/**
+ * Info.plist key to use instead of app bundle ID for Application Support directory
+ */
+static NSString *const kMSAppCenterAppSupportDirectoryName = @"MSAppCenterAppSupportDirectoryName";
+
 @implementation MSUtility (File)
 
 + (NSURL *)createFileAtPathComponent:(NSString *)filePathComponent
@@ -162,9 +167,13 @@ static NSString *const kMSAppCenterBundleIdentifier = @"com.microsoft.appcenter"
 
 #if TARGET_OS_OSX
 
-    // Use the application's bundle identifier for macOS to make sure to use separate directories for each app.
-    NSString *bundleIdentifier = [NSString stringWithFormat:@"%@/", [MS_APP_MAIN_BUNDLE bundleIdentifier]];
-    dirURL = [[baseDirUrl URLByAppendingPathComponent:bundleIdentifier] URLByAppendingPathComponent:kMSAppCenterBundleIdentifier];
+    NSString *dirName = [MS_APP_MAIN_BUNDLE objectForInfoDictionaryKey:kMSAppCenterAppSupportDirectoryName];
+    if (dirName == nil) {
+        // Use the application's bundle identifier for macOS to make sure to use separate directories for each app.
+        dirName = [NSString stringWithFormat:@"%@/", [MS_APP_MAIN_BUNDLE bundleIdentifier]];
+    }
+
+    dirURL = [[baseDirUrl URLByAppendingPathComponent:dirName] URLByAppendingPathComponent:kMSAppCenterBundleIdentifier];
 #else
     dirURL = [baseDirUrl URLByAppendingPathComponent:kMSAppCenterBundleIdentifier];
 #endif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 2.2.1
 
+### App Center
+
+* **[Feature]** Add the ability for Mac apps to specify the name of their directory in Application Support.
+
 ### App Center Distribute
 
 * **[Fix]** Obfuscate app secret value that appears as URI part in verbose logs for in-app updates.


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [:(] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Hello again.

This change allows Mac applications to specify the name of the directory inside Application Support to be used by App Center.

In our shipping app, we store our files in `Application Support/Transmit`, but AppCenter creates a directory based on our bundle ID, `Application Support/com.panic.transmit`. We've had some queries from users about this, and would like to combine everything into a single directory. (We'll take care of moving the AppCenter directory before initializing the framework.)

## Related PRs or issues

N/A

## Misc

Sadly, I was unable to add unit tests for this, since the changed code takes place within a `dispatch_once` block. I could either test this or the default behavior, but not both.