### PR TITLE
Disable “Set App Secret' for "None" and "Skip" startup mode

### DIFF
--- a/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
@@ -104,7 +104,7 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
     self.sdkVersion.text = appCenter.sdkVersion()
     self.deviceIdLabel.text = UIDevice.current.identifierForVendor?.uuidString
     self.userId.text = self.showUserId()
-    self.setAppSecretButton.isEnabled = StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.AppCenter || StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.Both ? true : false
+    self.setAppSecretButton.isEnabled = StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.AppCenter || StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.Both
 
     // Make sure the UITabBarController does not cut off the last cell.
     self.edgesForExtendedLayout = []

--- a/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
@@ -104,7 +104,7 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
     self.sdkVersion.text = appCenter.sdkVersion()
     self.deviceIdLabel.text = UIDevice.current.identifierForVendor?.uuidString
     self.userId.text = self.showUserId()
-    self.setAppSecretButton.isEnabled = StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.OneCollector ? false : true
+    self.setAppSecretButton.isEnabled = StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.AppCenter || StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.Both ? true : false
 
     // Make sure the UITabBarController does not cut off the last cell.
     self.edgesForExtendedLayout = []

--- a/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
@@ -52,7 +52,7 @@ class AppCenterViewController : NSViewController, NSTextFieldDelegate, NSTextVie
 
   override func viewWillAppear() {
     setEnabledButton?.state = appCenter.isAppCenterEnabled() ? NSControlStateValueOn : NSControlStateValueOff
-    setAppSecretButton?.isEnabled = startUpModeForCurrentSession == StartupMode.AppCenter.rawValue || startUpModeForCurrentSession == StartupMode.Both.rawValue ? true : false
+    setAppSecretButton?.isEnabled = startUpModeForCurrentSession == StartupMode.AppCenter.rawValue || startUpModeForCurrentSession == StartupMode.Both.rawValue
   }
 
   override func viewDidLoad() {

--- a/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
@@ -52,7 +52,7 @@ class AppCenterViewController : NSViewController, NSTextFieldDelegate, NSTextVie
 
   override func viewWillAppear() {
     setEnabledButton?.state = appCenter.isAppCenterEnabled() ? NSControlStateValueOn : NSControlStateValueOff
-    setAppSecretButton?.isEnabled = startUpModeForCurrentSession == StartupMode.OneCollector.rawValue ? false : true
+    setAppSecretButton?.isEnabled = startUpModeForCurrentSession == StartupMode.AppCenter.rawValue || startUpModeForCurrentSession == StartupMode.Both.rawValue ? true : false
   }
 
   override func viewDidLoad() {


### PR DESCRIPTION

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Disable “Set App Secret" when startup mode is "None" or "Skip", like "One Collector" startup mode behavior.

## Related PRs or issues

[#66828](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/66828)
