### PR TITLE
add app secrets to info.plist to enable auth on production and int apps

### DIFF
--- a/Sasquatch/SasquatchPuppet/Info.plist
+++ b/Sasquatch/SasquatchPuppet/Info.plist
@@ -26,6 +26,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>appcenter-65dc3680-7325-4000-a0e7-dbd2276eafd1</string>
+				<string>appcenter-66957d63-b484-43e6-bb8d-b89bf37a1c08</string>
 			</array>
 		</dict>
 		<dict>
@@ -36,6 +37,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>msal65dc3680-7325-4000-a0e7-dbd2276eafd1</string>
+				<string>msal66957d63-b484-43e6-bb8d-b89bf37a1c08</string>
 			</array>
 		</dict>
 	</array>
@@ -43,8 +45,8 @@
 	<string>${BUILD_NUMBER}</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-        <key>NSLocationWhenInUseUsageDescription</key>
-        <string>The app needs to know your location to override the country code.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>The app needs to know your location to override the country code.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Select photo for attachment</string>
 	<key>UIBackgroundModes</key>

--- a/Sasquatch/SasquatchSwift/Info.plist
+++ b/Sasquatch/SasquatchSwift/Info.plist
@@ -32,6 +32,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>appcenter-0dbca56b-b9ae-4d53-856a-7c2856137d85</string>
+				<string>appcenter-f9854e3a-0c8a-4774-9bf1-68f6dff8eb98</string>
 			</array>
 		</dict>
 		<dict>
@@ -42,6 +43,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>msal0dbca56b-b9ae-4d53-856a-7c2856137d85</string>
+				<string>msalf9854e3a-0c8a-4774-9bf1-68f6dff8eb98</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

To enable auth urls schemes should match. I have added new url schemes for Puppet and Swift Apps. 

## Related PRs or issues
#1774  

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
