### PR TITLE
change B2C authentication to MSAuthentication and change error message

### DIFF
--- a/AppCenterAuth/AppCenterAuth/MSAuth.m
+++ b/AppCenterAuth/AppCenterAuth/MSAuth.m
@@ -259,9 +259,8 @@ static dispatch_once_t onceToken;
                 withErrorCode:(NSInteger)errorCode
                       message:(NSString *)errorMessage {
   if (completionHandler) {
-    NSError *error = [[NSError alloc] initWithDomain:kMSACAuthErrorDomain
-                                                code:errorCode
-                                            userInfo:@{NSLocalizedDescriptionKey : errorMessage}];
+    NSError *error =
+        [[NSError alloc] initWithDomain:kMSACAuthErrorDomain code:errorCode userInfo:@{NSLocalizedDescriptionKey : errorMessage}];
     completionHandler(nil, error);
   }
 }
@@ -352,10 +351,8 @@ static dispatch_once_t onceToken;
               } else if (response.statusCode == MSHTTPCodesNo200OK) {
                 config = [self deserializeData:data];
                 if ([config isValid]) {
-                  NSURL *configUrl = [MSUtility createFileAtPathComponent:[self authConfigFilePath]
-                                                                 withData:data
-                                                               atomically:YES
-                                                           forceOverwrite:YES];
+                  NSURL *configUrl =
+                      [MSUtility createFileAtPathComponent:[self authConfigFilePath] withData:data atomically:YES forceOverwrite:YES];
 
                   // Store eTag only when the configuration file is created successfully.
                   if (configUrl) {
@@ -394,13 +391,13 @@ static dispatch_once_t onceToken;
 
   // Init MSAL client application.
   NSError *error;
-  MSALB2CAuthority *auth = [[MSALB2CAuthority alloc] initWithURL:(NSURL * __nonnull) self.authConfig.authorities[0].authorityUrl error:nil];
+  MSALAuthority *auth = [MSALAuthority authorityWithURL:(NSURL * __nonnull)self.authConfig.authorities[0].authorityUrl error:nil];
   MSALPublicClientApplicationConfig *config =
-      [[MSALPublicClientApplicationConfig alloc] initWithClientId:(NSString * __nonnull) self.authConfig.clientId
+      [[MSALPublicClientApplicationConfig alloc] initWithClientId:(NSString * __nonnull)self.authConfig.clientId
                                                       redirectUri:self.authConfig.redirectUri
                                                         authority:auth];
   if (!auth) {
-    MSLogError([MSAuth logTag], @"Auth config doesn't contain a valid default B2C authority.");
+    MSLogError([MSAuth logTag], @"Auth config doesn't contain a valid default %@ authority.", self.authConfig.authorities[0].type);
     return;
   }
   config.knownAuthorities = @[ auth ];
@@ -465,7 +462,7 @@ static dispatch_once_t onceToken;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [self.clientApplication
-      acquireTokenSilentForScopes:@[ (NSString * __nonnull) self.authConfig.authScope ]
+      acquireTokenSilentForScopes:@[ (NSString * __nonnull)self.authConfig.authScope ]
                           account:account
                   completionBlock:^(MSALResult *result, NSError *error) {
                     typeof(self) strongSelf = weakSelf;
@@ -510,7 +507,7 @@ static dispatch_once_t onceToken;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [self.clientApplication
-      acquireTokenForScopes:@[ (NSString * __nonnull) self.authConfig.authScope ]
+      acquireTokenForScopes:@[ (NSString * __nonnull)self.authConfig.authScope ]
                   loginHint:nil
                  promptType:MSALPromptTypeSelectAccount
        extraQueryParameters:nil


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

In MSAuth.m we were initializing MSB2CAuthority through this line of code

```
MSALB2CAuthority *auth = [[MSALB2CAuthority alloc] initWithURL:(NSURL * __nonnull) self.authConfig.authorities[0].authorityUrl error:nil]
```

Since we are also initializing AAd Authority now depending on the app I changed it to another method from MSAL which automatically decides which authority object to create based on authority url

```
MSALAuthority *auth = [MSALAuthority authorityWithURL:(NSURL * __nonnull)self.authConfig.authorities[0].authorityUrl error:nil];
```

I also changed error message in next line. Earlier it read

```
Auth config doesn't contain a valid default B2C authority.
```

Now it will give message specific to Authority

```
Auth config doesn't contain a valid default %@ authority.", self.authConfig.authorities[0].type)
```

## Related PRs or issues

#1764 

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
