### PR TITLE
Create separate targets for Apps, containing extensions

### DIFF
--- a/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
+++ b/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
@@ -232,16 +232,114 @@
 		C2F156F62338C34500798480 /* CrashLibIOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156AA2338C26A00798480 /* CrashLibIOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C2F156F92338C34B00798480 /* CrashLibIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156AA2338C26A00798480 /* CrashLibIOS.framework */; };
 		C2F156FA2338C34B00798480 /* CrashLibIOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156AA2338C26A00798480 /* CrashLibIOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C90574F1233B76DF00F69C92 /* MSDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBF2CC224C71FF002DB884 /* MSDataViewController.swift */; };
+		C90574F2233B76DF00F69C92 /* MSAnalyticsChildTransmissionTargetTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B203FF4B20E57A5B002AD536 /* MSAnalyticsChildTransmissionTargetTableViewController.swift */; };
+		C90574F3233B76DF00F69C92 /* AppCenterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A3E711E8A9922008711CB /* AppCenterProtocol.swift */; };
+		C90574F4233B76DF00F69C92 /* MSCrashesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A0FF651E8A87B4000E7A28 /* MSCrashesViewController.swift */; };
+		C90574F5233B76DF00F69C92 /* MSAnalyticsTypedPropertyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AA9F322164F994009104E3 /* MSAnalyticsTypedPropertyTableViewCell.swift */; };
+		C90574F6233B76DF00F69C92 /* EventPropertiesTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352A3E7320F801A900D09CF0 /* EventPropertiesTableSection.swift */; };
+		C90574F7233B76DF00F69C92 /* MSTableViewCellExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CAA1F92143229300A8BED2 /* MSTableViewCellExtension.swift */; };
+		C90574F8233B76DF00F69C92 /* MSAnalyticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A0FF681E8A87C9000E7A28 /* MSAnalyticsViewController.swift */; };
+		C90574F9233B76DF00F69C92 /* MSSignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807DB551212164E000F35E03 /* MSSignInViewController.swift */; };
+		C90574FA233B76DF00F69C92 /* MSTransmissionTargetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35396A7720F95A9C00A091E0 /* MSTransmissionTargetsViewController.swift */; };
+		C90574FB233B76DF00F69C92 /* MSAnalyticsTransmissionTargetSelectorViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E011EC21091EF1003F4A5B /* MSAnalyticsTransmissionTargetSelectorViewCell.swift */; };
+		C90574FC233B76DF00F69C92 /* AppCenterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84226D3A1E8937FF00798417 /* AppCenterDelegate.swift */; };
+		C90574FD233B76DF00F69C92 /* MSCustomPropertyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E011ED21091EF1003F4A5B /* MSCustomPropertyTableViewCell.swift */; };
+		C90574FE233B76DF00F69C92 /* MSAnalyticsPropertyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E011F021091EF2003F4A5B /* MSAnalyticsPropertyTableViewCell.swift */; };
+		C90574FF233B76DF00F69C92 /* CommonSchemaPropertiesTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2586C80210A478500664A43 /* CommonSchemaPropertiesTableSection.swift */; };
+		C9057500233B76DF00F69C92 /* MSCustomPropertiesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B36CE11EEF49B700230341 /* MSCustomPropertiesViewController.swift */; };
+		C9057501233B76DF00F69C92 /* MSTransmissionTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FBE78020FD095200F7B05C /* MSTransmissionTargets.swift */; };
+		C9057502233B76DF00F69C92 /* MSAnalyticsResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2586C88210A485300664A43 /* MSAnalyticsResultViewController.swift */; };
+		C9057503233B76DF00F69C92 /* MSDocumentDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBF312224CB053002DB884 /* MSDocumentDetailsViewController.swift */; };
+		C9057504233B76DF00F69C92 /* MSAuthInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F077A422A6A27B007B4B31 /* MSAuthInfoViewController.swift */; };
+		C9057505233B76DF00F69C92 /* MSMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845964AC1E8A7E9700BABA51 /* MSMainViewController.swift */; };
+		C9057506233B76DF00F69C92 /* PropertiesTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359171F620F7F80800F3DDE6 /* PropertiesTableSection.swift */; };
+		C9057507233B76DF00F69C92 /* AppCenterDelegateSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84226D3E1E8939B700798417 /* AppCenterDelegateSwift.swift */; };
+		C9057508233B76DF00F69C92 /* TargetPropertiesTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359171F920F8001A00F3DDE6 /* TargetPropertiesTableSection.swift */; };
+		C9057509233B76DF00F69C92 /* MSAuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B3CAD9211B2686007C332E /* MSAuthenticationViewController.swift */; };
+		C905750A233B76DF00F69C92 /* MSAnalyticsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2586C84210A47A800664A43 /* MSAnalyticsResult.swift */; };
+		C905750B233B76DF00F69C92 /* MSDistributeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A0FF6B1E8A87E1000E7A28 /* MSDistributeViewController.swift */; };
+		C905750C233B76DF00F69C92 /* MSDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AA9F3C2164FD1C009104E3 /* MSDatePicker.swift */; };
+		C905750D233B76DF00F69C92 /* MSEnumPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A502252149339100872B3B /* MSEnumPicker.swift */; };
+		C905750E233B76DF00F69C92 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84226C821E8908CA00798417 /* AppDelegate.swift */; };
+		C905750F233B76DF00F69C92 /* SimplePropertiesTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AA9F4821650C04009104E3 /* SimplePropertiesTableSection.swift */; };
+		C9057511233B76DF00F69C92 /* AppCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D2E1E89301A00798417 /* AppCenter.framework */; };
+		C9057512233B76DF00F69C92 /* AppCenterAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0459920E21F0042300BD3F82 /* AppCenterAuth.framework */; };
+		C9057513233B76DF00F69C92 /* AppCenterAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D2F1E89301B00798417 /* AppCenterAnalytics.framework */; };
+		C9057514233B76DF00F69C92 /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D301E89301B00798417 /* AppCenterCrashes.framework */; };
+		C9057515233B76DF00F69C92 /* AppCenterData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25DAE3B22280B150073B86A /* AppCenterData.framework */; };
+		C9057516233B76DF00F69C92 /* AppCenterDistribute.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D311E89301B00798417 /* AppCenterDistribute.framework */; };
+		C9057517233B76DF00F69C92 /* AppCenterPush.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 046790411E8DA7D80033FDEC /* AppCenterPush.framework */; };
+		C9057518233B76DF00F69C92 /* CrashLibIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156AA2338C26A00798480 /* CrashLibIOS.framework */; };
+		C905751A233B76DF00F69C92 /* AppCenterDistributeResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = F8EE93532331212D0023C682 /* AppCenterDistributeResources.bundle */; };
+		C905751B233B76DF00F69C92 /* Sasquatch.strings in Resources */ = {isa = PBXBuildFile; fileRef = 041A4BAF1F8C28A3009E1B6C /* Sasquatch.strings */; };
+		C905751C233B76DF00F69C92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84226C891E8908CA00798417 /* Assets.xcassets */; };
+		C905751D233B76DF00F69C92 /* MSAnalyticsTransmissionTargetSelectorViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B2E011EE21091EF1003F4A5B /* MSAnalyticsTransmissionTargetSelectorViewCell.xib */; };
+		C905751E233B76DF00F69C92 /* MSAnalyticsTypedPropertyTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = F8AA9F052164F91B009104E3 /* MSAnalyticsTypedPropertyTableViewCell.xib */; };
+		C905751F233B76DF00F69C92 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F809D5021FC6DA2B005E0F83 /* LaunchScreen.storyboard */; };
+		C9057520233B76DF00F69C92 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 845964A91E8A7E6600BABA51 /* Main.storyboard */; };
+		C9057521233B76DF00F69C92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84226C1C1E88FEFC00798417 /* Assets.xcassets */; };
+		C9057522233B76DF00F69C92 /* MSAnalyticsPropertyTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B2E011EF21091EF2003F4A5B /* MSAnalyticsPropertyTableViewCell.xib */; };
+		C9057524233B76DF00F69C92 /* CrashLibIOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156AA2338C26A00798480 /* CrashLibIOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C9057526233B76DF00F69C92 /* SasquatchWatchSwift.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = D31EF9541E9517C500450162 /* SasquatchWatchSwift.app */; };
+		C9057529233B76DF00F69C92 /* SasquatchSwift Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = C9E7E4E5231E9A5D007D96DC /* SasquatchSwift Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		C9057538233B772500F69C92 /* MSDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBF2CC224C71FF002DB884 /* MSDataViewController.swift */; };
+		C9057539233B772500F69C92 /* MSAnalyticsChildTransmissionTargetTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B203FF4B20E57A5B002AD536 /* MSAnalyticsChildTransmissionTargetTableViewController.swift */; };
+		C905753A233B772500F69C92 /* AppCenterProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849A3E711E8A9922008711CB /* AppCenterProtocol.swift */; };
+		C905753B233B772500F69C92 /* MSCrashesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A0FF651E8A87B4000E7A28 /* MSCrashesViewController.swift */; };
+		C905753C233B772500F69C92 /* MSAnalyticsTypedPropertyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AA9F322164F994009104E3 /* MSAnalyticsTypedPropertyTableViewCell.swift */; };
+		C905753D233B772500F69C92 /* EventPropertiesTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 352A3E7320F801A900D09CF0 /* EventPropertiesTableSection.swift */; };
+		C905753E233B772500F69C92 /* MSTableViewCellExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CAA1F92143229300A8BED2 /* MSTableViewCellExtension.swift */; };
+		C905753F233B772500F69C92 /* MSAnalyticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A0FF681E8A87C9000E7A28 /* MSAnalyticsViewController.swift */; };
+		C9057540233B772500F69C92 /* MSSignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807DB551212164E000F35E03 /* MSSignInViewController.swift */; };
+		C9057541233B772500F69C92 /* MSTransmissionTargetsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35396A7720F95A9C00A091E0 /* MSTransmissionTargetsViewController.swift */; };
+		C9057542233B772500F69C92 /* MSAnalyticsTransmissionTargetSelectorViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E011EC21091EF1003F4A5B /* MSAnalyticsTransmissionTargetSelectorViewCell.swift */; };
+		C9057543233B772500F69C92 /* AppCenterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84226D3A1E8937FF00798417 /* AppCenterDelegate.swift */; };
+		C9057544233B772500F69C92 /* MSCustomPropertyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E011ED21091EF1003F4A5B /* MSCustomPropertyTableViewCell.swift */; };
+		C9057545233B772500F69C92 /* MSAnalyticsPropertyTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E011F021091EF2003F4A5B /* MSAnalyticsPropertyTableViewCell.swift */; };
+		C9057546233B772500F69C92 /* CommonSchemaPropertiesTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2586C80210A478500664A43 /* CommonSchemaPropertiesTableSection.swift */; };
+		C9057547233B772500F69C92 /* MSCustomPropertiesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B36CE11EEF49B700230341 /* MSCustomPropertiesViewController.swift */; };
+		C9057548233B772500F69C92 /* MSTransmissionTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35FBE78020FD095200F7B05C /* MSTransmissionTargets.swift */; };
+		C9057549233B772500F69C92 /* MSAnalyticsResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2586C88210A485300664A43 /* MSAnalyticsResultViewController.swift */; };
+		C905754A233B772500F69C92 /* MSDocumentDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBF312224CB053002DB884 /* MSDocumentDetailsViewController.swift */; };
+		C905754B233B772500F69C92 /* MSAuthInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F077A422A6A27B007B4B31 /* MSAuthInfoViewController.swift */; };
+		C905754C233B772500F69C92 /* MSMainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845964AC1E8A7E9700BABA51 /* MSMainViewController.swift */; };
+		C905754D233B772500F69C92 /* PropertiesTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359171F620F7F80800F3DDE6 /* PropertiesTableSection.swift */; };
+		C905754E233B772500F69C92 /* AppCenterDelegateSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84226D3E1E8939B700798417 /* AppCenterDelegateSwift.swift */; };
+		C905754F233B772500F69C92 /* TargetPropertiesTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359171F920F8001A00F3DDE6 /* TargetPropertiesTableSection.swift */; };
+		C9057550233B772500F69C92 /* MSAuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B3CAD9211B2686007C332E /* MSAuthenticationViewController.swift */; };
+		C9057551233B772500F69C92 /* MSAnalyticsResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2586C84210A47A800664A43 /* MSAnalyticsResult.swift */; };
+		C9057552233B772500F69C92 /* MSDistributeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A0FF6B1E8A87E1000E7A28 /* MSDistributeViewController.swift */; };
+		C9057553233B772500F69C92 /* MSDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AA9F3C2164FD1C009104E3 /* MSDatePicker.swift */; };
+		C9057554233B772500F69C92 /* MSEnumPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8A502252149339100872B3B /* MSEnumPicker.swift */; };
+		C9057555233B772500F69C92 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84226C821E8908CA00798417 /* AppDelegate.swift */; };
+		C9057556233B772500F69C92 /* SimplePropertiesTableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8AA9F4821650C04009104E3 /* SimplePropertiesTableSection.swift */; };
+		C9057558233B772500F69C92 /* AppCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D2E1E89301A00798417 /* AppCenter.framework */; };
+		C9057559233B772500F69C92 /* AppCenterAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0459920E21F0042300BD3F82 /* AppCenterAuth.framework */; };
+		C905755A233B772500F69C92 /* AppCenterAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D2F1E89301B00798417 /* AppCenterAnalytics.framework */; };
+		C905755B233B772500F69C92 /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D301E89301B00798417 /* AppCenterCrashes.framework */; };
+		C905755C233B772500F69C92 /* AppCenterData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C25DAE3B22280B150073B86A /* AppCenterData.framework */; };
+		C905755D233B772500F69C92 /* AppCenterDistribute.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D311E89301B00798417 /* AppCenterDistribute.framework */; };
+		C905755E233B772500F69C92 /* AppCenterPush.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 046790411E8DA7D80033FDEC /* AppCenterPush.framework */; };
+		C905755F233B772500F69C92 /* CrashLibIOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156AA2338C26A00798480 /* CrashLibIOS.framework */; };
+		C9057561233B772500F69C92 /* Sasquatch.strings in Resources */ = {isa = PBXBuildFile; fileRef = 041A4BAF1F8C28A3009E1B6C /* Sasquatch.strings */; };
+		C9057562233B772500F69C92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84226C891E8908CA00798417 /* Assets.xcassets */; };
+		C9057563233B772500F69C92 /* MSAnalyticsTransmissionTargetSelectorViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B2E011EE21091EF1003F4A5B /* MSAnalyticsTransmissionTargetSelectorViewCell.xib */; };
+		C9057564233B772500F69C92 /* MSAnalyticsTypedPropertyTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = F8AA9F052164F91B009104E3 /* MSAnalyticsTypedPropertyTableViewCell.xib */; };
+		C9057565233B772500F69C92 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F809D5021FC6DA2B005E0F83 /* LaunchScreen.storyboard */; };
+		C9057566233B772500F69C92 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 845964A91E8A7E6600BABA51 /* Main.storyboard */; };
+		C9057567233B772500F69C92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84226C1C1E88FEFC00798417 /* Assets.xcassets */; };
+		C9057568233B772500F69C92 /* MSAnalyticsPropertyTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B2E011EF21091EF2003F4A5B /* MSAnalyticsPropertyTableViewCell.xib */; };
+		C905756A233B772500F69C92 /* CrashLibIOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156AA2338C26A00798480 /* CrashLibIOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C905756D233B772500F69C92 /* SasquatchSwift-Preview Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = C9E7E482231E99E9007D96DC /* SasquatchSwift-Preview Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		C90789BE2327CEB200999F08 /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D301E89301B00798417 /* AppCenterCrashes.framework */; };
 		C90789BF2327CEB200999F08 /* AppCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D2E1E89301A00798417 /* AppCenter.framework */; };
 		C90789C02327DF7600999F08 /* AppCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D2E1E89301A00798417 /* AppCenter.framework */; };
 		C90789C12327DF7600999F08 /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84226D301E89301B00798417 /* AppCenterCrashes.framework */; };
 		C9E7E484231E99E9007D96DC /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9E7E483231E99E9007D96DC /* NotificationCenter.framework */; };
-		C9E7E48E231E99E9007D96DC /* SasquatchSwift-Preview Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = C9E7E482231E99E9007D96DC /* SasquatchSwift-Preview Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		C9E7E4E6231E9A5D007D96DC /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9E7E483231E99E9007D96DC /* NotificationCenter.framework */; };
 		C9E7E4E9231E9A5E007D96DC /* ExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E7E4E8231E9A5E007D96DC /* ExtensionViewController.swift */; };
 		C9E7E4EC231E9A5E007D96DC /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C9E7E4EA231E9A5E007D96DC /* MainInterface.storyboard */; };
-		C9E7E4F0231E9A5E007D96DC /* SasquatchSwift Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = C9E7E4E5231E9A5D007D96DC /* SasquatchSwift Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		C9FA99BA232111CB007E276C /* ExtensionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E7E4E8231E9A5E007D96DC /* ExtensionViewController.swift */; };
 		C9FA9A3C23224DE1007E276C /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C9E7E4EA231E9A5E007D96DC /* MainInterface.storyboard */; };
 		D31EF92D1E9517B600450162 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D31EF92B1E9517B600450162 /* Interface.storyboard */; };
@@ -783,6 +881,55 @@
 			remoteGlobalIDString = B21A71DA1DD2A38C0044BB1C;
 			remoteInfo = CrashLibIOS;
 		};
+		C90574E7233B76DF00F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = B21A71DA1DD2A38C0044BB1C;
+			remoteInfo = CrashLibIOS;
+		};
+		C90574E9233B76DF00F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84226C0A1E88FEFC00798417 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D31EF9531E9517C500450162;
+			remoteInfo = SasquatchWatchSwift;
+		};
+		C90574EB233B76DF00F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84226C0A1E88FEFC00798417 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C9E7E4E4231E9A5D007D96DC;
+			remoteInfo = "SasquatchSwift-Extension";
+		};
+		C90574ED233B76DF00F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = B21A71DA1DD2A38C0044BB1C;
+			remoteInfo = CrashLibIOS;
+		};
+		C9057531233B772500F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = B21A71DA1DD2A38C0044BB1C;
+			remoteInfo = CrashLibIOS;
+		};
+		C9057533233B772500F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 84226C0A1E88FEFC00798417 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C9E7E481231E99E9007D96DC;
+			remoteInfo = "SasquatchSwift-Preview-Extension";
+		};
+		C9057535233B772500F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = B21A71DA1DD2A38C0044BB1C;
+			remoteInfo = CrashLibIOS;
+		};
 		C9E7E48C231E99E9007D96DC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 84226C0A1E88FEFC00798417 /* Project object */;
@@ -941,13 +1088,85 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C9057523233B76DF00F69C92 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				C9057524233B76DF00F69C92 /* CrashLibIOS.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C9057525233B76DF00F69C92 /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				C9057526233B76DF00F69C92 /* SasquatchWatchSwift.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C9057527233B76DF00F69C92 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C9057528233B76DF00F69C92 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				C9057529233B76DF00F69C92 /* SasquatchSwift Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C9057569233B772500F69C92 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				C905756A233B772500F69C92 /* CrashLibIOS.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C905756B233B772500F69C92 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C905756C233B772500F69C92 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				C905756D233B772500F69C92 /* SasquatchSwift-Preview Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C9E7E4D2231E99E9007D96DC /* Embed App Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				C9E7E48E231E99E9007D96DC /* SasquatchSwift-Preview Extension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -958,7 +1177,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				C9E7E4F0231E9A5E007D96DC /* SasquatchSwift Extension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1127,6 +1345,8 @@
 		C25DAE2522280A590073B86A /* AppCenterData.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AppCenterData.xcodeproj; path = ../AppCenterData/AppCenterData.xcodeproj; sourceTree = "<group>"; };
 		C25DAE3B22280B150073B86A /* AppCenterData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppCenterData.framework; path = "../AppCenter-SDK-Apple/iOS/AppCenterData.framework"; sourceTree = "<group>"; };
 		C2F156A32338C26A00798480 /* CrashLib.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CrashLib.xcodeproj; path = ../../CrashLib/CrashLib.xcodeproj; sourceTree = "<group>"; };
+		C905752D233B76DF00F69C92 /* SasquatchSwift-ContainingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SasquatchSwift-ContainingApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C9057571233B772500F69C92 /* SasquatchSwift-Preview-ContainingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SasquatchSwift-Preview-ContainingApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9E7E482231E99E9007D96DC /* SasquatchSwift-Preview Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "SasquatchSwift-Preview Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9E7E483231E99E9007D96DC /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
 		C9E7E4E5231E9A5D007D96DC /* SasquatchSwift Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "SasquatchSwift Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1287,6 +1507,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C9057510233B76DF00F69C92 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C9057511233B76DF00F69C92 /* AppCenter.framework in Frameworks */,
+				C9057512233B76DF00F69C92 /* AppCenterAuth.framework in Frameworks */,
+				C9057513233B76DF00F69C92 /* AppCenterAnalytics.framework in Frameworks */,
+				C9057514233B76DF00F69C92 /* AppCenterCrashes.framework in Frameworks */,
+				C9057515233B76DF00F69C92 /* AppCenterData.framework in Frameworks */,
+				C9057516233B76DF00F69C92 /* AppCenterDistribute.framework in Frameworks */,
+				C9057517233B76DF00F69C92 /* AppCenterPush.framework in Frameworks */,
+				C9057518233B76DF00F69C92 /* CrashLibIOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C9057557233B772500F69C92 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C9057558233B772500F69C92 /* AppCenter.framework in Frameworks */,
+				C9057559233B772500F69C92 /* AppCenterAuth.framework in Frameworks */,
+				C905755A233B772500F69C92 /* AppCenterAnalytics.framework in Frameworks */,
+				C905755B233B772500F69C92 /* AppCenterCrashes.framework in Frameworks */,
+				C905755C233B772500F69C92 /* AppCenterData.framework in Frameworks */,
+				C905755D233B772500F69C92 /* AppCenterDistribute.framework in Frameworks */,
+				C905755E233B772500F69C92 /* AppCenterPush.framework in Frameworks */,
+				C905755F233B772500F69C92 /* CrashLibIOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C9E7E47F231E99E9007D96DC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1410,6 +1660,8 @@
 				B2A4CFB6210A6E6900199B4F /* SasquatchSwift-Preview.app */,
 				C9E7E482231E99E9007D96DC /* SasquatchSwift-Preview Extension.appex */,
 				C9E7E4E5231E9A5D007D96DC /* SasquatchSwift Extension.appex */,
+				C905752D233B76DF00F69C92 /* SasquatchSwift-ContainingApp.app */,
+				C9057571233B772500F69C92 /* SasquatchSwift-Preview-ContainingApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1956,6 +2208,57 @@
 			productReference = B2A888B52102B1E7001ACFDF /* SasquatchPuppetUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		C90574E5233B76DF00F69C92 /* SasquatchSwift-ContainingApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C905752A233B76DF00F69C92 /* Build configuration list for PBXNativeTarget "SasquatchSwift-ContainingApp" */;
+			buildPhases = (
+				C90574EE233B76DF00F69C92 /* Verify No Build Settings */,
+				C90574EF233B76DF00F69C92 /* Remove the wrong framework */,
+				C90574F0233B76DF00F69C92 /* Sources */,
+				C9057510233B76DF00F69C92 /* Frameworks */,
+				C9057519233B76DF00F69C92 /* Resources */,
+				C9057523233B76DF00F69C92 /* Embed Frameworks */,
+				C9057525233B76DF00F69C92 /* Embed Watch Content */,
+				C9057527233B76DF00F69C92 /* CopyFiles */,
+				C9057528233B76DF00F69C92 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C90574E6233B76DF00F69C92 /* PBXTargetDependency */,
+				C90574E8233B76DF00F69C92 /* PBXTargetDependency */,
+				C90574EA233B76DF00F69C92 /* PBXTargetDependency */,
+				C90574EC233B76DF00F69C92 /* PBXTargetDependency */,
+			);
+			name = "SasquatchSwift-ContainingApp";
+			productName = SasquatchSwift;
+			productReference = C905752D233B76DF00F69C92 /* SasquatchSwift-ContainingApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		C905752F233B772500F69C92 /* SasquatchSwift-Preview-ContainingApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C905756E233B772500F69C92 /* Build configuration list for PBXNativeTarget "SasquatchSwift-Preview-ContainingApp" */;
+			buildPhases = (
+				C9057536233B772500F69C92 /* Verify No Build Settings */,
+				C9057537233B772500F69C92 /* Sources */,
+				C9057557233B772500F69C92 /* Frameworks */,
+				C9057560233B772500F69C92 /* Resources */,
+				C9057569233B772500F69C92 /* Embed Frameworks */,
+				C905756B233B772500F69C92 /* CopyFiles */,
+				C905756C233B772500F69C92 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C9057530233B772500F69C92 /* PBXTargetDependency */,
+				C9057532233B772500F69C92 /* PBXTargetDependency */,
+				C9057534233B772500F69C92 /* PBXTargetDependency */,
+			);
+			name = "SasquatchSwift-Preview-ContainingApp";
+			productName = SasquatchSwift;
+			productReference = C9057571233B772500F69C92 /* SasquatchSwift-Preview-ContainingApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 		C9E7E481231E99E9007D96DC /* SasquatchSwift-Preview Extension */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C9E7E4D1231E99E9007D96DC /* Build configuration list for PBXNativeTarget "SasquatchSwift-Preview Extension" */;
@@ -2155,6 +2458,13 @@
 						ProvisioningStyle = Automatic;
 						TestTargetID = B20AE37C21027D6200A1A195;
 					};
+					C90574E5233B76DF00F69C92 = {
+						ProvisioningStyle = Automatic;
+					};
+					C905752F233B772500F69C92 = {
+						DevelopmentTeam = 5Z97G9NZQ6;
+						ProvisioningStyle = Manual;
+					};
 					C9E7E481231E99E9007D96DC = {
 						CreatedOnToolsVersion = 10.2.1;
 						DevelopmentTeam = 5Z97G9NZQ6;
@@ -2263,8 +2573,10 @@
 				D31EF9281E9517B500450162 /* SasquatchWatchObjC */,
 				D31EF9341E9517B600450162 /* SasquatchWatchObjC Extension */,
 				B2A4CF85210A6E6900199B4F /* SasquatchSwift-Preview */,
+				C905752F233B772500F69C92 /* SasquatchSwift-Preview-ContainingApp */,
 				C9E7E481231E99E9007D96DC /* SasquatchSwift-Preview Extension */,
 				84226C7F1E8908C900798417 /* SasquatchSwift */,
+				C90574E5233B76DF00F69C92 /* SasquatchSwift-ContainingApp */,
 				C9E7E4E4231E9A5D007D96DC /* SasquatchSwift Extension */,
 				D31EF9531E9517C500450162 /* SasquatchWatchSwift */,
 				D31EF95F1E9517C600450162 /* SasquatchWatchSwift Extension */,
@@ -2631,6 +2943,37 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C9057519233B76DF00F69C92 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C905751A233B76DF00F69C92 /* AppCenterDistributeResources.bundle in Resources */,
+				C905751B233B76DF00F69C92 /* Sasquatch.strings in Resources */,
+				C905751C233B76DF00F69C92 /* Assets.xcassets in Resources */,
+				C905751D233B76DF00F69C92 /* MSAnalyticsTransmissionTargetSelectorViewCell.xib in Resources */,
+				C905751E233B76DF00F69C92 /* MSAnalyticsTypedPropertyTableViewCell.xib in Resources */,
+				C905751F233B76DF00F69C92 /* LaunchScreen.storyboard in Resources */,
+				C9057520233B76DF00F69C92 /* Main.storyboard in Resources */,
+				C9057521233B76DF00F69C92 /* Assets.xcassets in Resources */,
+				C9057522233B76DF00F69C92 /* MSAnalyticsPropertyTableViewCell.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C9057560233B772500F69C92 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C9057561233B772500F69C92 /* Sasquatch.strings in Resources */,
+				C9057562233B772500F69C92 /* Assets.xcassets in Resources */,
+				C9057563233B772500F69C92 /* MSAnalyticsTransmissionTargetSelectorViewCell.xib in Resources */,
+				C9057564233B772500F69C92 /* MSAnalyticsTypedPropertyTableViewCell.xib in Resources */,
+				C9057565233B772500F69C92 /* LaunchScreen.storyboard in Resources */,
+				C9057566233B772500F69C92 /* Main.storyboard in Resources */,
+				C9057567233B772500F69C92 /* Assets.xcassets in Resources */,
+				C9057568233B772500F69C92 /* MSAnalyticsPropertyTableViewCell.xib in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C9E7E480231E99E9007D96DC /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2712,6 +3055,55 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+			showEnvVarsInLog = 0;
+		};
+		C90574EE233B76DF00F69C92 /* Verify No Build Settings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Verify No Build Settings";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+			showEnvVarsInLog = 0;
+		};
+		C90574EF233B76DF00F69C92 /* Remove the wrong framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Remove the wrong framework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# We test the app on the fat fake framework produced by our script. \n# In order for linker to not pick up the simple static framework\n# (which it does by default), we need to remove it.\nrm -rf \"${BUILT_PRODUCTS_DIR}\"/AppCenter*.framework\n";
+			showEnvVarsInLog = 0;
+		};
+		C9057536233B772500F69C92 /* Verify No Build Settings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Verify No Build Settings";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
 		C9FA992323200B9E007E276C /* Verify No Build Settings */ = {
@@ -3099,6 +3491,82 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C90574F0233B76DF00F69C92 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C90574F1233B76DF00F69C92 /* MSDataViewController.swift in Sources */,
+				C90574F2233B76DF00F69C92 /* MSAnalyticsChildTransmissionTargetTableViewController.swift in Sources */,
+				C90574F3233B76DF00F69C92 /* AppCenterProtocol.swift in Sources */,
+				C90574F4233B76DF00F69C92 /* MSCrashesViewController.swift in Sources */,
+				C90574F5233B76DF00F69C92 /* MSAnalyticsTypedPropertyTableViewCell.swift in Sources */,
+				C90574F6233B76DF00F69C92 /* EventPropertiesTableSection.swift in Sources */,
+				C90574F7233B76DF00F69C92 /* MSTableViewCellExtension.swift in Sources */,
+				C90574F8233B76DF00F69C92 /* MSAnalyticsViewController.swift in Sources */,
+				C90574F9233B76DF00F69C92 /* MSSignInViewController.swift in Sources */,
+				C90574FA233B76DF00F69C92 /* MSTransmissionTargetsViewController.swift in Sources */,
+				C90574FB233B76DF00F69C92 /* MSAnalyticsTransmissionTargetSelectorViewCell.swift in Sources */,
+				C90574FC233B76DF00F69C92 /* AppCenterDelegate.swift in Sources */,
+				C90574FD233B76DF00F69C92 /* MSCustomPropertyTableViewCell.swift in Sources */,
+				C90574FE233B76DF00F69C92 /* MSAnalyticsPropertyTableViewCell.swift in Sources */,
+				C90574FF233B76DF00F69C92 /* CommonSchemaPropertiesTableSection.swift in Sources */,
+				C9057500233B76DF00F69C92 /* MSCustomPropertiesViewController.swift in Sources */,
+				C9057501233B76DF00F69C92 /* MSTransmissionTargets.swift in Sources */,
+				C9057502233B76DF00F69C92 /* MSAnalyticsResultViewController.swift in Sources */,
+				C9057503233B76DF00F69C92 /* MSDocumentDetailsViewController.swift in Sources */,
+				C9057504233B76DF00F69C92 /* MSAuthInfoViewController.swift in Sources */,
+				C9057505233B76DF00F69C92 /* MSMainViewController.swift in Sources */,
+				C9057506233B76DF00F69C92 /* PropertiesTableSection.swift in Sources */,
+				C9057507233B76DF00F69C92 /* AppCenterDelegateSwift.swift in Sources */,
+				C9057508233B76DF00F69C92 /* TargetPropertiesTableSection.swift in Sources */,
+				C9057509233B76DF00F69C92 /* MSAuthenticationViewController.swift in Sources */,
+				C905750A233B76DF00F69C92 /* MSAnalyticsResult.swift in Sources */,
+				C905750B233B76DF00F69C92 /* MSDistributeViewController.swift in Sources */,
+				C905750C233B76DF00F69C92 /* MSDatePicker.swift in Sources */,
+				C905750D233B76DF00F69C92 /* MSEnumPicker.swift in Sources */,
+				C905750E233B76DF00F69C92 /* AppDelegate.swift in Sources */,
+				C905750F233B76DF00F69C92 /* SimplePropertiesTableSection.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C9057537233B772500F69C92 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C9057538233B772500F69C92 /* MSDataViewController.swift in Sources */,
+				C9057539233B772500F69C92 /* MSAnalyticsChildTransmissionTargetTableViewController.swift in Sources */,
+				C905753A233B772500F69C92 /* AppCenterProtocol.swift in Sources */,
+				C905753B233B772500F69C92 /* MSCrashesViewController.swift in Sources */,
+				C905753C233B772500F69C92 /* MSAnalyticsTypedPropertyTableViewCell.swift in Sources */,
+				C905753D233B772500F69C92 /* EventPropertiesTableSection.swift in Sources */,
+				C905753E233B772500F69C92 /* MSTableViewCellExtension.swift in Sources */,
+				C905753F233B772500F69C92 /* MSAnalyticsViewController.swift in Sources */,
+				C9057540233B772500F69C92 /* MSSignInViewController.swift in Sources */,
+				C9057541233B772500F69C92 /* MSTransmissionTargetsViewController.swift in Sources */,
+				C9057542233B772500F69C92 /* MSAnalyticsTransmissionTargetSelectorViewCell.swift in Sources */,
+				C9057543233B772500F69C92 /* AppCenterDelegate.swift in Sources */,
+				C9057544233B772500F69C92 /* MSCustomPropertyTableViewCell.swift in Sources */,
+				C9057545233B772500F69C92 /* MSAnalyticsPropertyTableViewCell.swift in Sources */,
+				C9057546233B772500F69C92 /* CommonSchemaPropertiesTableSection.swift in Sources */,
+				C9057547233B772500F69C92 /* MSCustomPropertiesViewController.swift in Sources */,
+				C9057548233B772500F69C92 /* MSTransmissionTargets.swift in Sources */,
+				C9057549233B772500F69C92 /* MSAnalyticsResultViewController.swift in Sources */,
+				C905754A233B772500F69C92 /* MSDocumentDetailsViewController.swift in Sources */,
+				C905754B233B772500F69C92 /* MSAuthInfoViewController.swift in Sources */,
+				C905754C233B772500F69C92 /* MSMainViewController.swift in Sources */,
+				C905754D233B772500F69C92 /* PropertiesTableSection.swift in Sources */,
+				C905754E233B772500F69C92 /* AppCenterDelegateSwift.swift in Sources */,
+				C905754F233B772500F69C92 /* TargetPropertiesTableSection.swift in Sources */,
+				C9057550233B772500F69C92 /* MSAuthenticationViewController.swift in Sources */,
+				C9057551233B772500F69C92 /* MSAnalyticsResult.swift in Sources */,
+				C9057552233B772500F69C92 /* MSDistributeViewController.swift in Sources */,
+				C9057553233B772500F69C92 /* MSDatePicker.swift in Sources */,
+				C9057554233B772500F69C92 /* MSEnumPicker.swift in Sources */,
+				C9057555233B772500F69C92 /* AppDelegate.swift in Sources */,
+				C9057556233B772500F69C92 /* SimplePropertiesTableSection.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C9E7E47E231E99E9007D96DC /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3292,6 +3760,41 @@
 			isa = PBXTargetDependency;
 			name = CrashLibIOS;
 			targetProxy = C2F156FB2338C34B00798480 /* PBXContainerItemProxy */;
+		};
+		C90574E6233B76DF00F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibIOS;
+			targetProxy = C90574E7233B76DF00F69C92 /* PBXContainerItemProxy */;
+		};
+		C90574E8233B76DF00F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D31EF9531E9517C500450162 /* SasquatchWatchSwift */;
+			targetProxy = C90574E9233B76DF00F69C92 /* PBXContainerItemProxy */;
+		};
+		C90574EA233B76DF00F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C9E7E4E4231E9A5D007D96DC /* SasquatchSwift Extension */;
+			targetProxy = C90574EB233B76DF00F69C92 /* PBXContainerItemProxy */;
+		};
+		C90574EC233B76DF00F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibIOS;
+			targetProxy = C90574ED233B76DF00F69C92 /* PBXContainerItemProxy */;
+		};
+		C9057530233B772500F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibIOS;
+			targetProxy = C9057531233B772500F69C92 /* PBXContainerItemProxy */;
+		};
+		C9057532233B772500F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C9E7E481231E99E9007D96DC /* SasquatchSwift-Preview Extension */;
+			targetProxy = C9057533233B772500F69C92 /* PBXContainerItemProxy */;
+		};
+		C9057534233B772500F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibIOS;
+			targetProxy = C9057535233B772500F69C92 /* PBXContainerItemProxy */;
 		};
 		C9E7E48D231E99E9007D96DC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3600,6 +4103,64 @@
 			};
 			name = Release;
 		};
+		C905752B233B76DF00F69C92 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SasquatchSwift/SasquatchSwift.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "$(SRCROOT)/SasquatchSwift/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+			};
+			name = Debug;
+		};
+		C905752C233B76DF00F69C92 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SasquatchSwift/SasquatchSwift.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "$(SRCROOT)/SasquatchSwift/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+			};
+			name = Release;
+		};
+		C905756F233B772500F69C92 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SasquatchSwift/SasquatchSwift.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = 5Z97G9NZQ6;
+				INFOPLIST_FILE = "$(SRCROOT)/SasquatchSwift/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "13aa81a6-41a9-436b-bf26-b9910cfbee17";
+				PROVISIONING_PROFILE_SPECIFIER = "AppCenter SDK Sasquatch Swift Debug";
+			};
+			name = Debug;
+		};
+		C9057570233B772500F69C92 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SasquatchSwift/SasquatchSwift.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = 5Z97G9NZQ6;
+				INFOPLIST_FILE = "$(SRCROOT)/SasquatchSwift/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "a4aa0a1a-5369-411d-9c93-1493db2dc33e";
+				PROVISIONING_PROFILE_SPECIFIER = "AppCenter SDK SasquatchSwift Release In-house";
+			};
+			name = Release;
+		};
 		C9E7E48F231E99E9007D96DC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C237A695232BACB50081153F /* Sasquatch Extension.xcconfig */;
@@ -3807,6 +4368,24 @@
 			buildConfigurations = (
 				B2A888BC2102B1E7001ACFDF /* Debug */,
 				B2A888BD2102B1E7001ACFDF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C905752A233B76DF00F69C92 /* Build configuration list for PBXNativeTarget "SasquatchSwift-ContainingApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C905752B233B76DF00F69C92 /* Debug */,
+				C905752C233B76DF00F69C92 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C905756E233B772500F69C92 /* Build configuration list for PBXNativeTarget "SasquatchSwift-Preview-ContainingApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C905756F233B772500F69C92 /* Debug */,
+				C9057570233B772500F69C92 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
+++ b/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
@@ -4112,7 +4112,6 @@
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/SasquatchSwift/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
@@ -4126,7 +4125,6 @@
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/SasquatchSwift/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
@@ -4140,7 +4138,6 @@
 				DEVELOPMENT_TEAM = 5Z97G9NZQ6;
 				INFOPLIST_FILE = "$(SRCROOT)/SasquatchSwift/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "13aa81a6-41a9-436b-bf26-b9910cfbee17";
 				PROVISIONING_PROFILE_SPECIFIER = "AppCenter SDK Sasquatch Swift Debug";
 			};
@@ -4155,7 +4152,6 @@
 				DEVELOPMENT_TEAM = 5Z97G9NZQ6;
 				INFOPLIST_FILE = "$(SRCROOT)/SasquatchSwift/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "a4aa0a1a-5369-411d-9c93-1493db2dc33e";
 				PROVISIONING_PROFILE_SPECIFIER = "AppCenter SDK SasquatchSwift Release In-house";
 			};

--- a/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
+++ b/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
@@ -95,59 +95,46 @@
 		D3C31C671E8E763600B288CE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C661E8E763600B288CE /* Assets.xcassets */; };
 		D3C31C801E8E7BD200B288CE /* SasquatchMac.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C151E8E757300B288CE /* SasquatchMac.storyboard */; };
 		D3C31C811E8E7BEE00B288CE /* SasquatchMac.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C151E8E757300B288CE /* SasquatchMac.storyboard */; };
+		F8B8DCC12321205100BF7DAA /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE645F231E6F8E0007A52E /* TodayViewController.swift */; };
+		F8B8DCC22321205400BF7DAA /* TodayViewController.xib in Sources */ = {isa = PBXBuildFile; fileRef = F8EE6461231E6F8E0007A52E /* TodayViewController.xib */; };
+		F8B8DCC42321210600BF7DAA /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
+		F8B8DCC52321210600BF7DAA /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
+		F8B8DCCA232121C800BF7DAA /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
+		F8B8DCCB232121C900BF7DAA /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
+		F8B8DCCC232121D200BF7DAA /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; };
+		F8B8DCCD232121D900BF7DAA /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; };
+		F8B8DCCE2321815900BF7DAA /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
+		F8B8DCCF2321815A00BF7DAA /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
 		F8B8EC731FD853E800445BD4 /* CustomPropertiesViewControler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8EC721FD853E800445BD4 /* CustomPropertiesViewControler.swift */; };
 		F8B8EC741FD853E800445BD4 /* CustomPropertiesViewControler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8EC721FD853E800445BD4 /* CustomPropertiesViewControler.swift */; };
+		F8EE645D231E6F8E0007A52E /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8EE645C231E6F8E0007A52E /* NotificationCenter.framework */; };
+		F8EE6463231E6F8E0007A52E /* TodayViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = F8EE6461231E6F8E0007A52E /* TodayViewController.xib */; };
+		F8EE6467231E6F8E0007A52E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F8EE6465231E6F8E0007A52E /* InfoPlist.strings */; };
+		F8EE646B231E6F8E0007A52E /* SasquatchMacSwift-Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F8EE645B231E6F8E0007A52E /* SasquatchMacSwift-Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		F8EE6470231E6FF50007A52E /* AppCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04ED31D41EAAC7510033BAAE /* AppCenter.framework */; };
+		F8EE6471231E6FF50007A52E /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042319CC1EAAD720008FACA0 /* AppCenterCrashes.framework */; };
+		F8EE647A231E71060007A52E /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8EE645C231E6F8E0007A52E /* NotificationCenter.framework */; };
+		F8EE6484231E71060007A52E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F8EE6482231E71060007A52E /* InfoPlist.strings */; };
+		F8EE6488231E71060007A52E /* SasquatchMacSwift-Preview-Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F8EE6479231E71060007A52E /* SasquatchMacSwift-Preview-Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		F8EE648D231E711D0007A52E /* AppCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04ED31D41EAAC7510033BAAE /* AppCenter.framework */; };
+		F8EE648E231E711E0007A52E /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042319CC1EAAD720008FACA0 /* AppCenterCrashes.framework */; };
+		F8EE6490231E71CD0007A52E /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE645F231E6F8E0007A52E /* TodayViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		C22AA71E2334F5AB003D6D05 /* PBXContainerItemProxy */ = {
+		F8EE6469231E6F8E0007A52E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = C2AB5BA72334F48800654274 /* CrashLib.xcodeproj */;
+			containerPortal = D3C31C041E8E757300B288CE /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
-			remoteInfo = CrashLibMac;
+			remoteGlobalIDString = F8EE645A231E6F8E0007A52E;
+			remoteInfo = "SasquatchMacSwift-Extension";
 		};
-		C2AB5BAD2334F48800654274 /* PBXContainerItemProxy */ = {
+		F8EE6486231E71060007A52E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = C2AB5BA72334F48800654274 /* CrashLib.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = B21A71DB1DD2A38C0044BB1C;
-			remoteInfo = CrashLibIOS;
-		};
-		C2AB5BAF2334F48800654274 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C2AB5BA72334F48800654274 /* CrashLib.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 80F991211F0265070040FAD7;
-			remoteInfo = CrashLibTV;
-		};
-		C2AB5BB12334F48800654274 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C2AB5BA72334F48800654274 /* CrashLib.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 8065B5781F4C3FF4004FF622;
-			remoteInfo = CrashLibMac;
-		};
-		C2AB5BB32334F49B00654274 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C2AB5BA72334F48800654274 /* CrashLib.xcodeproj */;
+			containerPortal = D3C31C041E8E757300B288CE /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
-			remoteInfo = CrashLibMac;
-		};
-		C2AB5BB52334F4A100654274 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C2AB5BA72334F48800654274 /* CrashLib.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
-			remoteInfo = CrashLibMac;
-		};
-		C2AB5BB72334F4AB00654274 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C2AB5BA72334F48800654274 /* CrashLib.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
-			remoteInfo = CrashLibMac;
+			remoteGlobalIDString = F8EE6478231E71060007A52E;
+			remoteInfo = "SasquatchMacSwift-Preview-Extension";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -196,6 +183,28 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F8EE646F231E6F8F0007A52E /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				F8EE646B231E6F8E0007A52E /* SasquatchMacSwift-Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8EE648C231E71060007A52E /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				F8EE6488231E71060007A52E /* SasquatchMacSwift-Preview-Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -226,7 +235,6 @@
 		B2A4CFD4210A716E00199B4F /* SasquatchMacObjC-Preview.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SasquatchMacObjC-Preview.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2A4CFF1210A77D400199B4F /* SasquatchMacSwift-Preview.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SasquatchMacSwift-Preview.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2CD74CF1F22C3150070E7DF /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
-		C2AB5BA72334F48800654274 /* CrashLib.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CrashLib.xcodeproj; path = ../../CrashLib/CrashLib.xcodeproj; sourceTree = "<group>"; };
 		D3C31C161E8E757300B288CE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/SasquatchMac.storyboard; sourceTree = "<group>"; };
 		D3C31C221E8E75B300B288CE /* SasquatchMacObjC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SasquatchMacObjC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3C31C241E8E75B300B288CE /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -240,7 +248,18 @@
 		D3C31C6B1E8E763600B288CE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F84BA0B721133A740020F13B /* Sasquatch Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Sasquatch Debug.xcconfig"; sourceTree = "<group>"; };
 		F84BA0B821133A740020F13B /* Sasquatch.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Sasquatch.xcconfig; sourceTree = "<group>"; };
+		F8B8DCC32321210600BF7DAA /* CrashLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLoader.swift; sourceTree = "<group>"; };
 		F8B8EC721FD853E800445BD4 /* CustomPropertiesViewControler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPropertiesViewControler.swift; sourceTree = "<group>"; };
+		F8EE645B231E6F8E0007A52E /* SasquatchMacSwift-Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "SasquatchMacSwift-Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8EE645C231E6F8E0007A52E /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
+		F8EE645F231E6F8E0007A52E /* TodayViewController.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = TodayViewController.swift; sourceTree = "<group>"; };
+		F8EE6462231E6F8E0007A52E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/TodayViewController.xib; sourceTree = "<group>"; };
+		F8EE6464231E6F8E0007A52E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F8EE6466231E6F8E0007A52E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F8EE6468231E6F8E0007A52E /* SasquatchMacSwift_Today_Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SasquatchMacSwift_Today_Extension.entitlements; sourceTree = "<group>"; };
+		F8EE6479231E71060007A52E /* SasquatchMacSwift-Preview-Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "SasquatchMacSwift-Preview-Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8EE6483231E71060007A52E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		F8EE6485231E71060007A52E /* SasquatchMacSwift_Preview_Today_Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SasquatchMacSwift_Preview_Today_Extension.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -292,6 +311,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F8EE6458231E6F8E0007A52E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8B8DCCC232121D200BF7DAA /* CrashLibMac.framework in Frameworks */,
+				F8EE6470231E6FF50007A52E /* AppCenter.framework in Frameworks */,
+				F8EE6471231E6FF50007A52E /* AppCenterCrashes.framework in Frameworks */,
+				F8EE645D231E6F8E0007A52E /* NotificationCenter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8EE6476231E71060007A52E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8B8DCCD232121D900BF7DAA /* CrashLibMac.framework in Frameworks */,
+				F8EE648D231E711D0007A52E /* AppCenter.framework in Frameworks */,
+				F8EE648E231E711E0007A52E /* AppCenterCrashes.framework in Frameworks */,
+				F8EE647A231E71060007A52E /* NotificationCenter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -304,32 +345,15 @@
 			path = EventFilter;
 			sourceTree = "<group>";
 		};
-		C2AB5BA52334F2EA00654274 /* CrashLib */ = {
-			isa = PBXGroup;
-			children = (
-				C2AB5BA72334F48800654274 /* CrashLib.xcodeproj */,
-			);
-			path = CrashLib;
-			sourceTree = "<group>";
-		};
-		C2AB5BA82334F48800654274 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				C2AB5BAE2334F48800654274 /* CrashLibIOS.framework */,
-				C2AB5BB02334F48800654274 /* CrashLibTV.framework */,
-				C2AB5BB22334F48800654274 /* CrashLibMac.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		D3C31C031E8E757300B288CE = {
 			isa = PBXGroup;
 			children = (
-				C2AB5BA52334F2EA00654274 /* CrashLib */,
 				F84BA0B621133A740020F13B /* Config */,
 				D3C31C0E1E8E757300B288CE /* SasquatchMac */,
 				D3C31C231E8E75B300B288CE /* SasquatchMacObjC */,
 				D3C31C611E8E763600B288CE /* SasquatchMacSwift */,
+				F8EE645E231E6F8E0007A52E /* SasquatchMacSwift-Extension */,
+				F8EE647B231E71060007A52E /* SasquatchMacSwift-Preview-Extension */,
 				D3C31C0D1E8E757300B288CE /* Products */,
 				D3C31C731E8E782900B288CE /* Frameworks */,
 			);
@@ -342,6 +366,8 @@
 				D3C31C601E8E763600B288CE /* SasquatchMacSwift.app */,
 				B2A4CFD4210A716E00199B4F /* SasquatchMacObjC-Preview.app */,
 				B2A4CFF1210A77D400199B4F /* SasquatchMacSwift-Preview.app */,
+				F8EE645B231E6F8E0007A52E /* SasquatchMacSwift-Extension.appex */,
+				F8EE6479231E71060007A52E /* SasquatchMacSwift-Preview-Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -387,6 +413,7 @@
 		D3C31C611E8E763600B288CE /* SasquatchMacSwift */ = {
 			isa = PBXGroup;
 			children = (
+				F8B8DCC32321210600BF7DAA /* CrashLoader.swift */,
 				046964571F2A721100F9D31F /* SasquatchMacSwift.entitlements */,
 				D3C31C621E8E763600B288CE /* AppDelegate.swift */,
 				5C9BBC801EC4829200CA77A3 /* AppCenterDelegateSwift.swift */,
@@ -444,6 +471,7 @@
 				042319CC1EAAD720008FACA0 /* AppCenterCrashes.framework */,
 				04ED31D31EAAC7510033BAAE /* AppCenterAnalytics.framework */,
 				04ED31D41EAAC7510033BAAE /* AppCenter.framework */,
+				F8EE645C231E6F8E0007A52E /* NotificationCenter.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -455,6 +483,27 @@
 				F84BA0B821133A740020F13B /* Sasquatch.xcconfig */,
 			);
 			path = Config;
+			sourceTree = "<group>";
+		};
+		F8EE645E231E6F8E0007A52E /* SasquatchMacSwift-Extension */ = {
+			isa = PBXGroup;
+			children = (
+				F8EE645F231E6F8E0007A52E /* TodayViewController.swift */,
+				F8EE6461231E6F8E0007A52E /* TodayViewController.xib */,
+				F8EE6464231E6F8E0007A52E /* Info.plist */,
+				F8EE6465231E6F8E0007A52E /* InfoPlist.strings */,
+				F8EE6468231E6F8E0007A52E /* SasquatchMacSwift_Today_Extension.entitlements */,
+			);
+			path = "SasquatchMacSwift-Extension";
+			sourceTree = "<group>";
+		};
+		F8EE647B231E71060007A52E /* SasquatchMacSwift-Preview-Extension */ = {
+			isa = PBXGroup;
+			children = (
+				F8EE6482231E71060007A52E /* InfoPlist.strings */,
+				F8EE6485231E71060007A52E /* SasquatchMacSwift_Preview_Today_Extension.entitlements */,
+			);
+			path = "SasquatchMacSwift-Preview-Extension";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -473,7 +522,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				C2AB5BB62334F4A100654274 /* PBXTargetDependency */,
 			);
 			name = "SasquatchMacObjC-Preview";
 			productName = SasquatchMacObjC;
@@ -489,11 +537,12 @@
 				B2A4CFE3210A77D400199B4F /* Frameworks */,
 				B2A4CFE9210A77D400199B4F /* Resources */,
 				B2A4CFEC210A77D400199B4F /* Embed Frameworks */,
+				F8EE648C231E71060007A52E /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				C22AA71F2334F5AB003D6D05 /* PBXTargetDependency */,
+				F8EE6487231E71060007A52E /* PBXTargetDependency */,
 			);
 			name = "SasquatchMacSwift-Preview";
 			productName = SasquatchMacSwift;
@@ -514,7 +563,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				C2AB5BB42334F49B00654274 /* PBXTargetDependency */,
 			);
 			name = SasquatchMacObjC;
 			productName = SasquatchMacObjC;
@@ -527,20 +575,57 @@
 			buildPhases = (
 				F849248D2112FDFA00E14DBE /* Verify no buildSettings */,
 				D3C31C5C1E8E763600B288CE /* Sources */,
+				F845068C2317D7FC00A959D6 /* Remove the wrong framework */,
 				D3C31C5D1E8E763600B288CE /* Frameworks */,
 				D3C31C5E1E8E763600B288CE /* Resources */,
 				8065B5B91F4C4121004FF622 /* Embed Frameworks */,
-				F845068C2317D7FC00A959D6 /* Remove the wrong framework */,
+				F8EE646F231E6F8F0007A52E /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				C2AB5BB82334F4AB00654274 /* PBXTargetDependency */,
+				F8EE646A231E6F8E0007A52E /* PBXTargetDependency */,
 			);
 			name = SasquatchMacSwift;
 			productName = SasquatchMacSwift;
 			productReference = D3C31C601E8E763600B288CE /* SasquatchMacSwift.app */;
 			productType = "com.apple.product-type.application";
+		};
+		F8EE645A231E6F8E0007A52E /* SasquatchMacSwift-Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F8EE646E231E6F8E0007A52E /* Build configuration list for PBXNativeTarget "SasquatchMacSwift-Extension" */;
+			buildPhases = (
+				F8EE6473231E70040007A52E /* Verify No Build Settings */,
+				F8EE6457231E6F8E0007A52E /* Sources */,
+				F8EE6458231E6F8E0007A52E /* Frameworks */,
+				F8EE6459231E6F8E0007A52E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SasquatchMacSwift-Extension";
+			productName = "SasquatchMacSwift-Extension";
+			productReference = F8EE645B231E6F8E0007A52E /* SasquatchMacSwift-Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		F8EE6478231E71060007A52E /* SasquatchMacSwift-Preview-Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F8EE6489231E71060007A52E /* Build configuration list for PBXNativeTarget "SasquatchMacSwift-Preview-Extension" */;
+			buildPhases = (
+				F8EE648F231E71230007A52E /* Verify No Build Settings */,
+				F8EE6475231E71060007A52E /* Sources */,
+				F8EE6476231E71060007A52E /* Frameworks */,
+				F8EE6477231E71060007A52E /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SasquatchMacSwift-Preview-Extension";
+			productName = "SasquatchMacSwift-Preview-Extension";
+			productReference = F8EE6479231E71060007A52E /* SasquatchMacSwift-Preview-Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -580,6 +665,26 @@
 							};
 						};
 					};
+					F8EE645A231E6F8E0007A52E = {
+						CreatedOnToolsVersion = 10.2.1;
+						DevelopmentTeam = KYJ84ZC369;
+						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.Sandbox = {
+								enabled = 1;
+							};
+						};
+					};
+					F8EE6478231E71060007A52E = {
+						CreatedOnToolsVersion = 10.2.1;
+						DevelopmentTeam = KYJ84ZC369;
+						ProvisioningStyle = Manual;
+						SystemCapabilities = {
+							com.apple.Sandbox = {
+								enabled = 1;
+							};
+						};
+					};
 				};
 			};
 			buildConfigurationList = D3C31C071E8E757300B288CE /* Build configuration list for PBXProject "SasquatchMac" */;
@@ -587,51 +692,24 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
 			mainGroup = D3C31C031E8E757300B288CE;
 			productRefGroup = D3C31C0D1E8E757300B288CE /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = C2AB5BA82334F48800654274 /* Products */;
-					ProjectRef = C2AB5BA72334F48800654274 /* CrashLib.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				D3C31C211E8E75B300B288CE /* SasquatchMacObjC */,
 				B2A4CFB8210A716E00199B4F /* SasquatchMacObjC-Preview */,
 				D3C31C5F1E8E763600B288CE /* SasquatchMacSwift */,
 				B2A4CFD6210A77D400199B4F /* SasquatchMacSwift-Preview */,
+				F8EE645A231E6F8E0007A52E /* SasquatchMacSwift-Extension */,
+				F8EE6478231E71060007A52E /* SasquatchMacSwift-Preview-Extension */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		C2AB5BAE2334F48800654274 /* CrashLibIOS.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = CrashLibIOS.framework;
-			remoteRef = C2AB5BAD2334F48800654274 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		C2AB5BB02334F48800654274 /* CrashLibTV.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = CrashLibTV.framework;
-			remoteRef = C2AB5BAF2334F48800654274 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		C2AB5BB22334F48800654274 /* CrashLibMac.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = CrashLibMac.framework;
-			remoteRef = C2AB5BB12334F48800654274 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		B2A4CFCC210A716E00199B4F /* Resources */ = {
@@ -667,6 +745,24 @@
 			files = (
 				D3C31C801E8E7BD200B288CE /* SasquatchMac.storyboard in Resources */,
 				D3C31C671E8E763600B288CE /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8EE6459231E6F8E0007A52E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8EE6463231E6F8E0007A52E /* TodayViewController.xib in Resources */,
+				F8EE6467231E6F8E0007A52E /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8EE6477231E71060007A52E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8EE6484231E71060007A52E /* InfoPlist.strings in Resources */,
+				F8E69C842322C308006209D2 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -771,6 +867,44 @@
 			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
 			showEnvVarsInLog = 0;
 		};
+		F8EE6473231E70040007A52E /* Verify No Build Settings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Verify No Build Settings";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+			showEnvVarsInLog = 0;
+		};
+		F8EE648F231E71230007A52E /* Verify No Build Settings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Verify No Build Settings";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -782,6 +916,7 @@
 				B2A4CFBB210A716E00199B4F /* EventFilterViewController.swift in Sources */,
 				4A0A708722044A37007565A6 /* TransmissionViewController.swift in Sources */,
 				B2A4CFBC210A716E00199B4F /* MSEventFilter.m in Sources */,
+				F8B8DCCF2321815A00BF7DAA /* CrashLoader.swift in Sources */,
 				B2A4CFBD210A716E00199B4F /* CustomPropertiesViewControler.swift in Sources */,
 				B2A4CFBE210A716E00199B4F /* CrashesViewController.swift in Sources */,
 				B2A4CFBF210A716E00199B4F /* AppCenterDelegate.swift in Sources */,
@@ -814,6 +949,7 @@
 				B2A4CFE1210A77D400199B4F /* AnalyticsViewController.swift in Sources */,
 				4A0A708922044A37007565A6 /* TransmissionViewController.swift in Sources */,
 				B2A4CFE2210A77D400199B4F /* AppCenterDelegate.swift in Sources */,
+				F8B8DCC52321210600BF7DAA /* CrashLoader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -825,6 +961,7 @@
 				353332F820126200009B0946 /* EventFilterViewController.swift in Sources */,
 				4A0A708622044A37007565A6 /* TransmissionViewController.swift in Sources */,
 				358F9BCC2019639100B9E22C /* MSEventFilter.m in Sources */,
+				F8B8DCCE2321815900BF7DAA /* CrashLoader.swift in Sources */,
 				F8B8EC731FD853E800445BD4 /* CustomPropertiesViewControler.swift in Sources */,
 				5C6F9BB81EB8F2E9009E52D8 /* CrashesViewController.swift in Sources */,
 				042496851EC3CE2F00502B62 /* AppCenterDelegate.swift in Sources */,
@@ -857,31 +994,41 @@
 				5C6F9BB61EB8EEFC009E52D8 /* AnalyticsViewController.swift in Sources */,
 				4A0A708822044A37007565A6 /* TransmissionViewController.swift in Sources */,
 				042496871EC3CE3500502B62 /* AppCenterDelegate.swift in Sources */,
+				F8B8DCC42321210600BF7DAA /* CrashLoader.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8EE6457231E6F8E0007A52E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8B8DCCB232121C900BF7DAA /* CrashLoader.swift in Sources */,
+				F8EE6490231E71CD0007A52E /* TodayViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F8EE6475231E71060007A52E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8B8DCC12321205100BF7DAA /* TodayViewController.swift in Sources */,
+				F8B8DCC22321205400BF7DAA /* TodayViewController.xib in Sources */,
+				F8B8DCCA232121C800BF7DAA /* CrashLoader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		C22AA71F2334F5AB003D6D05 /* PBXTargetDependency */ = {
+		F8EE646A231E6F8E0007A52E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = CrashLibMac;
-			targetProxy = C22AA71E2334F5AB003D6D05 /* PBXContainerItemProxy */;
+			target = F8EE645A231E6F8E0007A52E /* SasquatchMacSwift-Extension */;
+			targetProxy = F8EE6469231E6F8E0007A52E /* PBXContainerItemProxy */;
 		};
-		C2AB5BB42334F49B00654274 /* PBXTargetDependency */ = {
+		F8EE6487231E71060007A52E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = CrashLibMac;
-			targetProxy = C2AB5BB32334F49B00654274 /* PBXContainerItemProxy */;
-		};
-		C2AB5BB62334F4A100654274 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CrashLibMac;
-			targetProxy = C2AB5BB52334F4A100654274 /* PBXContainerItemProxy */;
-		};
-		C2AB5BB82334F4AB00654274 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CrashLibMac;
-			targetProxy = C2AB5BB72334F4AB00654274 /* PBXContainerItemProxy */;
+			target = F8EE6478231E71060007A52E /* SasquatchMacSwift-Preview-Extension */;
+			targetProxy = F8EE6486231E71060007A52E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -892,6 +1039,30 @@
 				D3C31C161E8E757300B288CE /* Base */,
 			);
 			name = SasquatchMac.storyboard;
+			sourceTree = "<group>";
+		};
+		F8EE6461231E6F8E0007A52E /* TodayViewController.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F8EE6462231E6F8E0007A52E /* Base */,
+			);
+			name = TodayViewController.xib;
+			sourceTree = "<group>";
+		};
+		F8EE6465231E6F8E0007A52E /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F8EE6466231E6F8E0007A52E /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		F8EE6482231E71060007A52E /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F8EE6483231E71060007A52E /* en */,
+			);
+			name = InfoPlist.strings;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
@@ -929,6 +1100,7 @@
 				CODE_SIGN_ENTITLEMENTS = SasquatchMacSwift/SasquatchMacSwift.entitlements;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = KYJ84ZC369;
 				INFOPLIST_FILE = "$(SRCROOT)/SasquatchMacSwift/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac;
 				PROVISIONING_PROFILE = "cb0c0f7a-d8d1-4b90-9aac-98b0acad5847";
@@ -1017,6 +1189,62 @@
 			};
 			name = Release;
 		};
+		F8EE646C231E6F8E0007A52E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "SasquatchMacSwift-Extension/SasquatchMacSwift_Today_Extension.entitlements";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = KYJ84ZC369;
+				INFOPLIST_FILE = "SasquatchMacSwift-Extension/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac.extension;
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+			};
+			name = Debug;
+		};
+		F8EE646D231E6F8E0007A52E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "SasquatchMacSwift-Extension/SasquatchMacSwift_Today_Extension.entitlements";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = KYJ84ZC369;
+				INFOPLIST_FILE = "SasquatchMacSwift-Extension/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac.extension;
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+			};
+			name = Release;
+		};
+		F8EE648A231E71060007A52E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "SasquatchMacSwift-Preview-Extension/SasquatchMacSwift_Preview_Today_Extension.entitlements";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = KYJ84ZC369;
+				INFOPLIST_FILE = "SasquatchMacSwift-Extension/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac.extension;
+				PROVISIONING_PROFILE = "cb0c0f7a-d8d1-4b90-9aac-98b0acad5847";
+				PROVISIONING_PROFILE_SPECIFIER = "AppCenter SDK SasquatchSwift Mac Ext Debug";
+			};
+			name = Debug;
+		};
+		F8EE648B231E71060007A52E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "SasquatchMacSwift-Preview-Extension/SasquatchMacSwift_Preview_Today_Extension.entitlements";
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = KYJ84ZC369;
+				INFOPLIST_FILE = "SasquatchMacSwift-Extension/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac.extension;
+				PROVISIONING_PROFILE = "18941b56-5e23-45ca-86df-da36fdbcc922";
+				PROVISIONING_PROFILE_SPECIFIER = "AppCenter SDK SasquatchSwift Mac Ext In-house";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1061,6 +1289,24 @@
 			buildConfigurations = (
 				D3C31C6D1E8E763600B288CE /* Debug */,
 				D3C31C6E1E8E763600B288CE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F8EE646E231E6F8E0007A52E /* Build configuration list for PBXNativeTarget "SasquatchMacSwift-Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F8EE646C231E6F8E0007A52E /* Debug */,
+				F8EE646D231E6F8E0007A52E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F8EE6489231E71060007A52E /* Build configuration list for PBXNativeTarget "SasquatchMacSwift-Preview-Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F8EE648A231E71060007A52E /* Debug */,
+				F8EE648B231E71060007A52E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
+++ b/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
@@ -1685,7 +1685,6 @@
 				DEVELOPMENT_TEAM = KYJ84ZC369;
 				INFOPLIST_FILE = "$(SRCROOT)/SasquatchMacSwift/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "cb0c0f7a-d8d1-4b90-9aac-98b0acad5847";
 				PROVISIONING_PROFILE_SPECIFIER = "AppCenter SDK SasquatchSwift Mac Debug";
 			};
@@ -1699,7 +1698,6 @@
 				CODE_SIGN_STYLE = Manual;
 				INFOPLIST_FILE = "$(SRCROOT)/SasquatchMacSwift/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "18941b56-5e23-45ca-86df-da36fdbcc922";
 				PROVISIONING_PROFILE_SPECIFIER = "AppCenter SDK SasquatchSwift Mac Release In-house";
 			};
@@ -1713,7 +1711,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "$(SRCROOT)/SasquatchMacSwift/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
@@ -1727,7 +1724,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "$(SRCROOT)/SasquatchMacSwift/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac;
-				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};

--- a/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
+++ b/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
@@ -90,6 +90,54 @@
 		C2F1576C2338E6AD00798480 /* CrashLibMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C2F157702338E6B500798480 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; };
 		C2F157712338E6BB00798480 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; };
+		C9057441233B6FE600F69C92 /* TransmissionTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0A7080220449C7007565A6 /* TransmissionTargets.swift */; };
+		C9057442233B6FE600F69C92 /* AppCenterDelegateSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9BBC801EC4829200CA77A3 /* AppCenterDelegateSwift.swift */; };
+		C9057443233B6FE600F69C92 /* MSEventFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 358F9BCA2019639100B9E22C /* MSEventFilter.m */; };
+		C9057444233B6FE600F69C92 /* AppCenterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD625791ECDA4280053DC6C /* AppCenterViewController.swift */; };
+		C9057445233B6FE600F69C92 /* CustomPropertiesViewControler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8EC721FD853E800445BD4 /* CustomPropertiesViewControler.swift */; };
+		C9057446233B6FE600F69C92 /* AuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3147512206896100B0FC8A /* AuthenticationViewController.swift */; };
+		C9057447233B6FE600F69C92 /* AppCenterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042496841EC3CE2F00502B62 /* AppCenterProvider.swift */; };
+		C9057448233B6FE600F69C92 /* EventFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353332F620126200009B0946 /* EventFilterViewController.swift */; };
+		C9057449233B6FE600F69C92 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C31C621E8E763600B288CE /* AppDelegate.swift */; };
+		C905744A233B6FE600F69C92 /* CrashesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C6F9BB71EB8F2E9009E52D8 /* CrashesViewController.swift */; };
+		C905744B233B6FE600F69C92 /* PushViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803CFF371F6A87180072B9BA /* PushViewController.swift */; };
+		C905744C233B6FE600F69C92 /* AnalyticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C6F9BAC1EB8B730009E52D8 /* AnalyticsViewController.swift */; };
+		C905744D233B6FE600F69C92 /* TransmissionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0A708522044A37007565A6 /* TransmissionViewController.swift */; };
+		C905744E233B6FE600F69C92 /* AppCenterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042496831EC3CE2F00502B62 /* AppCenterDelegate.swift */; };
+		C905744F233B6FE600F69C92 /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
+		C9057451233B6FE600F69C92 /* AppCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04ED31D41EAAC7510033BAAE /* AppCenter.framework */; };
+		C9057452233B6FE600F69C92 /* AppCenterAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04ED31D31EAAC7510033BAAE /* AppCenterAnalytics.framework */; };
+		C9057453233B6FE600F69C92 /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042319CC1EAAD720008FACA0 /* AppCenterCrashes.framework */; };
+		C9057454233B6FE600F69C92 /* AppCenterPush.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 046964551F2A607D00F9D31F /* AppCenterPush.framework */; };
+		C9057455233B6FE600F69C92 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; };
+		C9057457233B6FE600F69C92 /* SasquatchMac.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C151E8E757300B288CE /* SasquatchMac.storyboard */; };
+		C9057458233B6FE600F69C92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C661E8E763600B288CE /* Assets.xcassets */; };
+		C905745A233B6FE600F69C92 /* SasquatchMacSwift-Preview-Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F8EE6479231E71060007A52E /* SasquatchMacSwift-Preview-Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		C905745C233B6FE600F69C92 /* CrashLibMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C905746B233B6FFB00F69C92 /* TransmissionTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0A7080220449C7007565A6 /* TransmissionTargets.swift */; };
+		C905746C233B6FFB00F69C92 /* AppCenterDelegateSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9BBC801EC4829200CA77A3 /* AppCenterDelegateSwift.swift */; };
+		C905746D233B6FFB00F69C92 /* MSEventFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 358F9BCA2019639100B9E22C /* MSEventFilter.m */; };
+		C905746E233B6FFB00F69C92 /* AppCenterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD625791ECDA4280053DC6C /* AppCenterViewController.swift */; };
+		C905746F233B6FFB00F69C92 /* CustomPropertiesViewControler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8EC721FD853E800445BD4 /* CustomPropertiesViewControler.swift */; };
+		C9057470233B6FFB00F69C92 /* AuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3147512206896100B0FC8A /* AuthenticationViewController.swift */; };
+		C9057471233B6FFB00F69C92 /* AppCenterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042496841EC3CE2F00502B62 /* AppCenterProvider.swift */; };
+		C9057472233B6FFB00F69C92 /* EventFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353332F620126200009B0946 /* EventFilterViewController.swift */; };
+		C9057473233B6FFB00F69C92 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C31C621E8E763600B288CE /* AppDelegate.swift */; };
+		C9057474233B6FFB00F69C92 /* CrashesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C6F9BB71EB8F2E9009E52D8 /* CrashesViewController.swift */; };
+		C9057475233B6FFB00F69C92 /* PushViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803CFF371F6A87180072B9BA /* PushViewController.swift */; };
+		C9057476233B6FFB00F69C92 /* AnalyticsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C6F9BAC1EB8B730009E52D8 /* AnalyticsViewController.swift */; };
+		C9057477233B6FFB00F69C92 /* TransmissionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0A708522044A37007565A6 /* TransmissionViewController.swift */; };
+		C9057478233B6FFB00F69C92 /* AppCenterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042496831EC3CE2F00502B62 /* AppCenterDelegate.swift */; };
+		C9057479233B6FFB00F69C92 /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
+		C905747C233B6FFB00F69C92 /* AppCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04ED31D41EAAC7510033BAAE /* AppCenter.framework */; };
+		C905747D233B6FFB00F69C92 /* AppCenterAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04ED31D31EAAC7510033BAAE /* AppCenterAnalytics.framework */; };
+		C905747E233B6FFB00F69C92 /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042319CC1EAAD720008FACA0 /* AppCenterCrashes.framework */; };
+		C905747F233B6FFB00F69C92 /* AppCenterPush.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 046964551F2A607D00F9D31F /* AppCenterPush.framework */; };
+		C9057480233B6FFB00F69C92 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; };
+		C9057482233B6FFB00F69C92 /* SasquatchMac.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C151E8E757300B288CE /* SasquatchMac.storyboard */; };
+		C9057483233B6FFB00F69C92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C661E8E763600B288CE /* Assets.xcassets */; };
+		C9057485233B6FFB00F69C92 /* SasquatchMacSwift-Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F8EE645B231E6F8E0007A52E /* SasquatchMacSwift-Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		C9057487233B6FFB00F69C92 /* CrashLibMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D3C31C261E8E75B300B288CE /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D3C31C251E8E75B300B288CE /* AppDelegate.m */; };
 		D3C31C291E8E75B300B288CE /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D3C31C281E8E75B300B288CE /* main.m */; };
 		D3C31C2E1E8E75B300B288CE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C2D1E8E75B300B288CE /* Assets.xcassets */; };
@@ -110,12 +158,10 @@
 		F8EE645D231E6F8E0007A52E /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8EE645C231E6F8E0007A52E /* NotificationCenter.framework */; };
 		F8EE6463231E6F8E0007A52E /* TodayViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = F8EE6461231E6F8E0007A52E /* TodayViewController.xib */; };
 		F8EE6467231E6F8E0007A52E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F8EE6465231E6F8E0007A52E /* InfoPlist.strings */; };
-		F8EE646B231E6F8E0007A52E /* SasquatchMacSwift-Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F8EE645B231E6F8E0007A52E /* SasquatchMacSwift-Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F8EE6470231E6FF50007A52E /* AppCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04ED31D41EAAC7510033BAAE /* AppCenter.framework */; };
 		F8EE6471231E6FF50007A52E /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042319CC1EAAD720008FACA0 /* AppCenterCrashes.framework */; };
 		F8EE647A231E71060007A52E /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8EE645C231E6F8E0007A52E /* NotificationCenter.framework */; };
 		F8EE6484231E71060007A52E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F8EE6482231E71060007A52E /* InfoPlist.strings */; };
-		F8EE6488231E71060007A52E /* SasquatchMacSwift-Preview-Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F8EE6479231E71060007A52E /* SasquatchMacSwift-Preview-Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F8EE648D231E711D0007A52E /* AppCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04ED31D41EAAC7510033BAAE /* AppCenter.framework */; };
 		F8EE648E231E711E0007A52E /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042319CC1EAAD720008FACA0 /* AppCenterCrashes.framework */; };
 		F8EE6490231E71CD0007A52E /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE645F231E6F8E0007A52E /* TodayViewController.swift */; };
@@ -213,6 +259,48 @@
 			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
 			remoteInfo = CrashLibMac;
 		};
+		C905743A233B6FE600F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C905743C233B6FE600F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D3C31C041E8E757300B288CE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F8EE6478231E71060007A52E;
+			remoteInfo = "SasquatchMacSwift-Preview-Extension";
+		};
+		C905743E233B6FE600F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C9057464233B6FFB00F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C9057466233B6FFB00F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D3C31C041E8E757300B288CE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F8EE645A231E6F8E0007A52E;
+			remoteInfo = "SasquatchMacSwift-Extension";
+		};
+		C9057468233B6FFB00F69C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
 		F8EE6469231E6F8E0007A52E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D3C31C041E8E757300B288CE /* Project object */;
@@ -274,13 +362,56 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C9057459233B6FE600F69C92 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				C905745A233B6FE600F69C92 /* SasquatchMacSwift-Preview-Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C905745B233B6FE600F69C92 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				C905745C233B6FE600F69C92 /* CrashLibMac.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C9057484233B6FFB00F69C92 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				C9057485233B6FFB00F69C92 /* SasquatchMacSwift-Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C9057486233B6FFB00F69C92 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				C9057487233B6FFB00F69C92 /* CrashLibMac.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F8EE646F231E6F8F0007A52E /* Embed App Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				F8EE646B231E6F8E0007A52E /* SasquatchMacSwift-Extension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -291,7 +422,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				F8EE6488231E71060007A52E /* SasquatchMacSwift-Preview-Extension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -326,6 +456,8 @@
 		B2A4CFF1210A77D400199B4F /* SasquatchMacSwift-Preview.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SasquatchMacSwift-Preview.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2CD74CF1F22C3150070E7DF /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		C2F156AF2338C27700798480 /* CrashLib.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CrashLib.xcodeproj; path = ../../CrashLib/CrashLib.xcodeproj; sourceTree = "<group>"; };
+		C9057460233B6FE600F69C92 /* SasquatchMacSwift-Preview-ContainingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SasquatchMacSwift-Preview-ContainingApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C905748B233B6FFB00F69C92 /* SasquatchMacSwift-ContainingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SasquatchMacSwift-ContainingApp.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3C31C161E8E757300B288CE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/SasquatchMac.storyboard; sourceTree = "<group>"; };
 		D3C31C221E8E75B300B288CE /* SasquatchMacObjC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SasquatchMacObjC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3C31C241E8E75B300B288CE /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -375,6 +507,30 @@
 				B2A4CFE6210A77D400199B4F /* AppCenterCrashes.framework in Frameworks */,
 				B2A4CFE7210A77D400199B4F /* AppCenterPush.framework in Frameworks */,
 				C2F1575C2338E5E800798480 /* CrashLibMac.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C9057450233B6FE600F69C92 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C9057451233B6FE600F69C92 /* AppCenter.framework in Frameworks */,
+				C9057452233B6FE600F69C92 /* AppCenterAnalytics.framework in Frameworks */,
+				C9057453233B6FE600F69C92 /* AppCenterCrashes.framework in Frameworks */,
+				C9057454233B6FE600F69C92 /* AppCenterPush.framework in Frameworks */,
+				C9057455233B6FE600F69C92 /* CrashLibMac.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C905747B233B6FFB00F69C92 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C905747C233B6FFB00F69C92 /* AppCenter.framework in Frameworks */,
+				C905747D233B6FFB00F69C92 /* AppCenterAnalytics.framework in Frameworks */,
+				C905747E233B6FFB00F69C92 /* AppCenterCrashes.framework in Frameworks */,
+				C905747F233B6FFB00F69C92 /* AppCenterPush.framework in Frameworks */,
+				C9057480233B6FFB00F69C92 /* CrashLibMac.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -479,6 +635,8 @@
 				B2A4CFF1210A77D400199B4F /* SasquatchMacSwift-Preview.app */,
 				F8EE645B231E6F8E0007A52E /* SasquatchMacSwift-Extension.appex */,
 				F8EE6479231E71060007A52E /* SasquatchMacSwift-Preview-Extension.appex */,
+				C9057460233B6FE600F69C92 /* SasquatchMacSwift-Preview-ContainingApp.app */,
+				C905748B233B6FFB00F69C92 /* SasquatchMacSwift-ContainingApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -663,6 +821,53 @@
 			productReference = B2A4CFF1210A77D400199B4F /* SasquatchMacSwift-Preview.app */;
 			productType = "com.apple.product-type.application";
 		};
+		C9057438233B6FE600F69C92 /* SasquatchMacSwift-Preview-ContainingApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C905745D233B6FE600F69C92 /* Build configuration list for PBXNativeTarget "SasquatchMacSwift-Preview-ContainingApp" */;
+			buildPhases = (
+				C905743F233B6FE600F69C92 /* Verify no buildSettings */,
+				C9057440233B6FE600F69C92 /* Sources */,
+				C9057450233B6FE600F69C92 /* Frameworks */,
+				C9057456233B6FE600F69C92 /* Resources */,
+				C9057459233B6FE600F69C92 /* Embed App Extensions */,
+				C905745B233B6FE600F69C92 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C9057439233B6FE600F69C92 /* PBXTargetDependency */,
+				C905743B233B6FE600F69C92 /* PBXTargetDependency */,
+				C905743D233B6FE600F69C92 /* PBXTargetDependency */,
+			);
+			name = "SasquatchMacSwift-Preview-ContainingApp";
+			productName = SasquatchMacSwift;
+			productReference = C9057460233B6FE600F69C92 /* SasquatchMacSwift-Preview-ContainingApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		C9057462233B6FFB00F69C92 /* SasquatchMacSwift-ContainingApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C9057488233B6FFB00F69C92 /* Build configuration list for PBXNativeTarget "SasquatchMacSwift-ContainingApp" */;
+			buildPhases = (
+				C9057469233B6FFB00F69C92 /* Verify no buildSettings */,
+				C905746A233B6FFB00F69C92 /* Sources */,
+				C905747A233B6FFB00F69C92 /* Remove the wrong framework */,
+				C905747B233B6FFB00F69C92 /* Frameworks */,
+				C9057481233B6FFB00F69C92 /* Resources */,
+				C9057484233B6FFB00F69C92 /* Embed App Extensions */,
+				C9057486233B6FFB00F69C92 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C9057463233B6FFB00F69C92 /* PBXTargetDependency */,
+				C9057465233B6FFB00F69C92 /* PBXTargetDependency */,
+				C9057467233B6FFB00F69C92 /* PBXTargetDependency */,
+			);
+			name = "SasquatchMacSwift-ContainingApp";
+			productName = SasquatchMacSwift;
+			productReference = C905748B233B6FFB00F69C92 /* SasquatchMacSwift-ContainingApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 		D3C31C211E8E75B300B288CE /* SasquatchMacObjC */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D3C31C331E8E75B300B288CE /* Build configuration list for PBXNativeTarget "SasquatchMacObjC" */;
@@ -765,6 +970,14 @@
 						DevelopmentTeam = KYJ84ZC369;
 						ProvisioningStyle = Manual;
 					};
+					C9057438233B6FE600F69C92 = {
+						DevelopmentTeam = KYJ84ZC369;
+						ProvisioningStyle = Manual;
+					};
+					C9057462233B6FFB00F69C92 = {
+						DevelopmentTeam = KYJ84ZC369;
+						ProvisioningStyle = Automatic;
+					};
 					D3C31C211E8E75B300B288CE = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = KYJ84ZC369;
@@ -831,6 +1044,8 @@
 				B2A4CFB8210A716E00199B4F /* SasquatchMacObjC-Preview */,
 				D3C31C5F1E8E763600B288CE /* SasquatchMacSwift */,
 				B2A4CFD6210A77D400199B4F /* SasquatchMacSwift-Preview */,
+				C9057462233B6FFB00F69C92 /* SasquatchMacSwift-ContainingApp */,
+				C9057438233B6FE600F69C92 /* SasquatchMacSwift-Preview-ContainingApp */,
 				F8EE645A231E6F8E0007A52E /* SasquatchMacSwift-Extension */,
 				F8EE6478231E71060007A52E /* SasquatchMacSwift-Preview-Extension */,
 			);
@@ -880,6 +1095,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C9057456233B6FE600F69C92 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C9057457233B6FE600F69C92 /* SasquatchMac.storyboard in Resources */,
+				C9057458233B6FE600F69C92 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C9057481233B6FFB00F69C92 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C9057482233B6FFB00F69C92 /* SasquatchMac.storyboard in Resources */,
+				C9057483233B6FFB00F69C92 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D3C31C201E8E75B300B288CE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -918,6 +1151,55 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		C905743F233B6FE600F69C92 /* Verify no buildSettings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Verify no buildSettings";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj";
+			showEnvVarsInLog = 0;
+		};
+		C9057469233B6FFB00F69C92 /* Verify no buildSettings */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Verify no buildSettings";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Scripts/VerifyNoBuildSettings.swift\" ${PROJECT_NAME}.xcodeproj/project.pbxproj\n";
+			showEnvVarsInLog = 0;
+		};
+		C905747A233B6FFB00F69C92 /* Remove the wrong framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Remove the wrong framework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# We test the app on the fat fake framework produced by our script. \n# In order for linker to not pick up the simple static framework\n# (which it does by default), we need to remove it.\nrm -rf \"${BUILT_PRODUCTS_DIR}\"/AppCenter*.framework\n";
+			showEnvVarsInLog = 0;
+		};
 		F845068B2317D7E600A959D6 /* Remove the wrong framework */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1102,6 +1384,50 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C9057440233B6FE600F69C92 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C9057441233B6FE600F69C92 /* TransmissionTargets.swift in Sources */,
+				C9057442233B6FE600F69C92 /* AppCenterDelegateSwift.swift in Sources */,
+				C9057443233B6FE600F69C92 /* MSEventFilter.m in Sources */,
+				C9057444233B6FE600F69C92 /* AppCenterViewController.swift in Sources */,
+				C9057445233B6FE600F69C92 /* CustomPropertiesViewControler.swift in Sources */,
+				C9057446233B6FE600F69C92 /* AuthenticationViewController.swift in Sources */,
+				C9057447233B6FE600F69C92 /* AppCenterProvider.swift in Sources */,
+				C9057448233B6FE600F69C92 /* EventFilterViewController.swift in Sources */,
+				C9057449233B6FE600F69C92 /* AppDelegate.swift in Sources */,
+				C905744A233B6FE600F69C92 /* CrashesViewController.swift in Sources */,
+				C905744B233B6FE600F69C92 /* PushViewController.swift in Sources */,
+				C905744C233B6FE600F69C92 /* AnalyticsViewController.swift in Sources */,
+				C905744D233B6FE600F69C92 /* TransmissionViewController.swift in Sources */,
+				C905744E233B6FE600F69C92 /* AppCenterDelegate.swift in Sources */,
+				C905744F233B6FE600F69C92 /* CrashLoader.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C905746A233B6FFB00F69C92 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C905746B233B6FFB00F69C92 /* TransmissionTargets.swift in Sources */,
+				C905746C233B6FFB00F69C92 /* AppCenterDelegateSwift.swift in Sources */,
+				C905746D233B6FFB00F69C92 /* MSEventFilter.m in Sources */,
+				C905746E233B6FFB00F69C92 /* AppCenterViewController.swift in Sources */,
+				C905746F233B6FFB00F69C92 /* CustomPropertiesViewControler.swift in Sources */,
+				C9057470233B6FFB00F69C92 /* AuthenticationViewController.swift in Sources */,
+				C9057471233B6FFB00F69C92 /* AppCenterProvider.swift in Sources */,
+				C9057472233B6FFB00F69C92 /* EventFilterViewController.swift in Sources */,
+				C9057473233B6FFB00F69C92 /* AppDelegate.swift in Sources */,
+				C9057474233B6FFB00F69C92 /* CrashesViewController.swift in Sources */,
+				C9057475233B6FFB00F69C92 /* PushViewController.swift in Sources */,
+				C9057476233B6FFB00F69C92 /* AnalyticsViewController.swift in Sources */,
+				C9057477233B6FFB00F69C92 /* TransmissionViewController.swift in Sources */,
+				C9057478233B6FFB00F69C92 /* AppCenterDelegate.swift in Sources */,
+				C9057479233B6FFB00F69C92 /* CrashLoader.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D3C31C1E1E8E75B300B288CE /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1219,6 +1545,36 @@
 			name = CrashLibMac;
 			targetProxy = C2F1576D2338E6AD00798480 /* PBXContainerItemProxy */;
 		};
+		C9057439233B6FE600F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C905743A233B6FE600F69C92 /* PBXContainerItemProxy */;
+		};
+		C905743B233B6FE600F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F8EE6478231E71060007A52E /* SasquatchMacSwift-Preview-Extension */;
+			targetProxy = C905743C233B6FE600F69C92 /* PBXContainerItemProxy */;
+		};
+		C905743D233B6FE600F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C905743E233B6FE600F69C92 /* PBXContainerItemProxy */;
+		};
+		C9057463233B6FFB00F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C9057464233B6FFB00F69C92 /* PBXContainerItemProxy */;
+		};
+		C9057465233B6FFB00F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F8EE645A231E6F8E0007A52E /* SasquatchMacSwift-Extension */;
+			targetProxy = C9057466233B6FFB00F69C92 /* PBXContainerItemProxy */;
+		};
+		C9057467233B6FFB00F69C92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C9057468233B6FFB00F69C92 /* PBXContainerItemProxy */;
+		};
 		F8EE646A231E6F8E0007A52E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = F8EE645A231E6F8E0007A52E /* SasquatchMacSwift-Extension */;
@@ -1317,6 +1673,63 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac;
 				PROVISIONING_PROFILE = "18941b56-5e23-45ca-86df-da36fdbcc922";
 				PROVISIONING_PROFILE_SPECIFIER = "AppCenter SDK SasquatchSwift Mac Release In-house";
+			};
+			name = Release;
+		};
+		C905745E233B6FE600F69C92 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SasquatchMacSwift/SasquatchMacSwift.entitlements;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = KYJ84ZC369;
+				INFOPLIST_FILE = "$(SRCROOT)/SasquatchMacSwift/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "cb0c0f7a-d8d1-4b90-9aac-98b0acad5847";
+				PROVISIONING_PROFILE_SPECIFIER = "AppCenter SDK SasquatchSwift Mac Debug";
+			};
+			name = Debug;
+		};
+		C905745F233B6FE600F69C92 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SasquatchMacSwift/SasquatchMacSwift.entitlements;
+				CODE_SIGN_IDENTITY = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
+				INFOPLIST_FILE = "$(SRCROOT)/SasquatchMacSwift/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "18941b56-5e23-45ca-86df-da36fdbcc922";
+				PROVISIONING_PROFILE_SPECIFIER = "AppCenter SDK SasquatchSwift Mac Release In-house";
+			};
+			name = Release;
+		};
+		C9057489233B6FFB00F69C92 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SasquatchMacSwift/SasquatchMacSwift.entitlements;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "$(SRCROOT)/SasquatchMacSwift/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+			};
+			name = Debug;
+		};
+		C905748A233B6FFB00F69C92 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SasquatchMacSwift/SasquatchMacSwift.entitlements;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = "$(SRCROOT)/SasquatchMacSwift/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.appcenter.sasquatchswift.mac;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
 		};
@@ -1461,6 +1874,24 @@
 			buildConfigurations = (
 				B2A4CFEF210A77D400199B4F /* Debug */,
 				B2A4CFF0210A77D400199B4F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C905745D233B6FE600F69C92 /* Build configuration list for PBXNativeTarget "SasquatchMacSwift-Preview-ContainingApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C905745E233B6FE600F69C92 /* Debug */,
+				C905745F233B6FE600F69C92 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C9057488233B6FFB00F69C92 /* Build configuration list for PBXNativeTarget "SasquatchMacSwift-ContainingApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C9057489233B6FFB00F69C92 /* Debug */,
+				C905748A233B6FFB00F69C92 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
+++ b/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
@@ -44,10 +44,6 @@
 		5CD6257A1ECDA4280053DC6C /* AppCenterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD625791ECDA4280053DC6C /* AppCenterViewController.swift */; };
 		803CFF381F6A87180072B9BA /* PushViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803CFF371F6A87180072B9BA /* PushViewController.swift */; };
 		803CFF391F6A87180072B9BA /* PushViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803CFF371F6A87180072B9BA /* PushViewController.swift */; };
-		8065B5BB1F4C4169004FF622 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; };
-		8065B5BC1F4C4169004FF622 /* CrashLibMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		8065B5BD1F4C6778004FF622 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; };
-		8065B5BE1F4C6778004FF622 /* CrashLibMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B2A4CFBA210A716E00199B4F /* AppCenterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 042496841EC3CE2F00502B62 /* AppCenterProvider.swift */; };
 		B2A4CFBB210A716E00199B4F /* EventFilterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 353332F620126200009B0946 /* EventFilterViewController.swift */; };
 		B2A4CFBC210A716E00199B4F /* MSEventFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 358F9BCA2019639100B9E22C /* MSEventFilter.m */; };
@@ -64,10 +60,8 @@
 		B2A4CFC8210A716E00199B4F /* AppCenterAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04ED31D31EAAC7510033BAAE /* AppCenterAnalytics.framework */; };
 		B2A4CFC9210A716E00199B4F /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042319CC1EAAD720008FACA0 /* AppCenterCrashes.framework */; };
 		B2A4CFCA210A716E00199B4F /* AppCenterPush.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 046964551F2A607D00F9D31F /* AppCenterPush.framework */; };
-		B2A4CFCB210A716E00199B4F /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; };
 		B2A4CFCD210A716E00199B4F /* SasquatchMac.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C151E8E757300B288CE /* SasquatchMac.storyboard */; };
 		B2A4CFCE210A716E00199B4F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C2D1E8E75B300B288CE /* Assets.xcassets */; };
-		B2A4CFD0210A716E00199B4F /* CrashLibMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B2A4CFD8210A77D400199B4F /* AppCenterDelegateSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9BBC801EC4829200CA77A3 /* AppCenterDelegateSwift.swift */; };
 		B2A4CFD9210A77D400199B4F /* MSEventFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 358F9BCA2019639100B9E22C /* MSEventFilter.m */; };
 		B2A4CFDA210A77D400199B4F /* AppCenterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD625791ECDA4280053DC6C /* AppCenterViewController.swift */; };
@@ -83,11 +77,19 @@
 		B2A4CFE5210A77D400199B4F /* AppCenterAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04ED31D31EAAC7510033BAAE /* AppCenterAnalytics.framework */; };
 		B2A4CFE6210A77D400199B4F /* AppCenterCrashes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042319CC1EAAD720008FACA0 /* AppCenterCrashes.framework */; };
 		B2A4CFE7210A77D400199B4F /* AppCenterPush.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 046964551F2A607D00F9D31F /* AppCenterPush.framework */; };
-		B2A4CFE8210A77D400199B4F /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; };
 		B2A4CFEA210A77D400199B4F /* SasquatchMac.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C151E8E757300B288CE /* SasquatchMac.storyboard */; };
 		B2A4CFEB210A77D400199B4F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C661E8E763600B288CE /* Assets.xcassets */; };
-		B2A4CFED210A77D400199B4F /* CrashLibMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C2A4A2691EE7684A0080FD22 /* AppCenterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD625791ECDA4280053DC6C /* AppCenterViewController.swift */; };
+		C2F1575C2338E5E800798480 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; };
+		C2F1575D2338E5E800798480 /* CrashLibMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C2F157612338E64000798480 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; };
+		C2F157622338E64000798480 /* CrashLibMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C2F157662338E6A800798480 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; };
+		C2F157672338E6A800798480 /* CrashLibMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C2F1576B2338E6AD00798480 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; };
+		C2F1576C2338E6AD00798480 /* CrashLibMac.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C2F157702338E6B500798480 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; };
+		C2F157712338E6BB00798480 /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2F156BA2338C27700798480 /* CrashLibMac.framework */; };
 		D3C31C261E8E75B300B288CE /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D3C31C251E8E75B300B288CE /* AppDelegate.m */; };
 		D3C31C291E8E75B300B288CE /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D3C31C281E8E75B300B288CE /* main.m */; };
 		D3C31C2E1E8E75B300B288CE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3C31C2D1E8E75B300B288CE /* Assets.xcassets */; };
@@ -101,8 +103,6 @@
 		F8B8DCC52321210600BF7DAA /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
 		F8B8DCCA232121C800BF7DAA /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
 		F8B8DCCB232121C900BF7DAA /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
-		F8B8DCCC232121D200BF7DAA /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; };
-		F8B8DCCD232121D900BF7DAA /* CrashLibMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */; };
 		F8B8DCCE2321815900BF7DAA /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
 		F8B8DCCF2321815A00BF7DAA /* CrashLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8DCC32321210600BF7DAA /* CrashLoader.swift */; };
 		F8B8EC731FD853E800445BD4 /* CustomPropertiesViewControler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B8EC721FD853E800445BD4 /* CustomPropertiesViewControler.swift */; };
@@ -122,6 +122,97 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		C2F156B52338C27700798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = B21A71DB1DD2A38C0044BB1C;
+			remoteInfo = CrashLibIOS;
+		};
+		C2F156B72338C27700798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 80F991211F0265070040FAD7;
+			remoteInfo = CrashLibTV;
+		};
+		C2F156B92338C27700798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 8065B5781F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C2F157502338E58200798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C2F157522338E58700798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C2F157542338E59800798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C2F157562338E5A300798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C2F157582338E5D300798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C2F1575A2338E5D900798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C2F1575E2338E5E800798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C2F157632338E64000798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C2F157682338E6A800798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
+		C2F1576D2338E6AD00798480 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 8065B5771F4C3FF4004FF622;
+			remoteInfo = CrashLibMac;
+		};
 		F8EE6469231E6F8E0007A52E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D3C31C041E8E757300B288CE /* Project object */;
@@ -139,46 +230,46 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		8065B5B61F4C40FC004FF622 /* Embed Frameworks */ = {
+		C2F157602338E5E800798480 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				8065B5BE1F4C6778004FF622 /* CrashLibMac.framework in Embed Frameworks */,
+				C2F1575D2338E5E800798480 /* CrashLibMac.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8065B5B91F4C4121004FF622 /* Embed Frameworks */ = {
+		C2F157652338E64000798480 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				8065B5BC1F4C4169004FF622 /* CrashLibMac.framework in Embed Frameworks */,
+				C2F157622338E64000798480 /* CrashLibMac.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B2A4CFCF210A716E00199B4F /* Embed Frameworks */ = {
+		C2F1576A2338E6A800798480 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B2A4CFD0210A716E00199B4F /* CrashLibMac.framework in Embed Frameworks */,
+				C2F157672338E6A800798480 /* CrashLibMac.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B2A4CFEC210A77D400199B4F /* Embed Frameworks */ = {
+		C2F1576F2338E6AD00798480 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B2A4CFED210A77D400199B4F /* CrashLibMac.framework in Embed Frameworks */,
+				C2F1576C2338E6AD00798480 /* CrashLibMac.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -230,11 +321,11 @@
 		5CA0000921EDB16D00127624 /* Constants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		5CD625791ECDA4280053DC6C /* AppCenterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCenterViewController.swift; sourceTree = "<group>"; };
 		803CFF371F6A87180072B9BA /* PushViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushViewController.swift; sourceTree = "<group>"; };
-		8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CrashLibMac.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		80A3A89A1F0BF30100FBE3B6 /* SasquatchMac-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SasquatchMac-Bridging-Header.h"; sourceTree = "<group>"; };
 		B2A4CFD4210A716E00199B4F /* SasquatchMacObjC-Preview.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SasquatchMacObjC-Preview.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2A4CFF1210A77D400199B4F /* SasquatchMacSwift-Preview.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SasquatchMacSwift-Preview.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B2CD74CF1F22C3150070E7DF /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
+		C2F156AF2338C27700798480 /* CrashLib.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CrashLib.xcodeproj; path = ../../CrashLib/CrashLib.xcodeproj; sourceTree = "<group>"; };
 		D3C31C161E8E757300B288CE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/SasquatchMac.storyboard; sourceTree = "<group>"; };
 		D3C31C221E8E75B300B288CE /* SasquatchMacObjC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SasquatchMacObjC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3C31C241E8E75B300B288CE /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -271,7 +362,7 @@
 				B2A4CFC8210A716E00199B4F /* AppCenterAnalytics.framework in Frameworks */,
 				B2A4CFC9210A716E00199B4F /* AppCenterCrashes.framework in Frameworks */,
 				B2A4CFCA210A716E00199B4F /* AppCenterPush.framework in Frameworks */,
-				B2A4CFCB210A716E00199B4F /* CrashLibMac.framework in Frameworks */,
+				C2F157662338E6A800798480 /* CrashLibMac.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -283,7 +374,7 @@
 				B2A4CFE5210A77D400199B4F /* AppCenterAnalytics.framework in Frameworks */,
 				B2A4CFE6210A77D400199B4F /* AppCenterCrashes.framework in Frameworks */,
 				B2A4CFE7210A77D400199B4F /* AppCenterPush.framework in Frameworks */,
-				B2A4CFE8210A77D400199B4F /* CrashLibMac.framework in Frameworks */,
+				C2F1575C2338E5E800798480 /* CrashLibMac.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -295,7 +386,7 @@
 				04ED31E61EAAD1B30033BAAE /* AppCenterAnalytics.framework in Frameworks */,
 				042319CD1EAAD720008FACA0 /* AppCenterCrashes.framework in Frameworks */,
 				046964561F2A607D00F9D31F /* AppCenterPush.framework in Frameworks */,
-				8065B5BD1F4C6778004FF622 /* CrashLibMac.framework in Frameworks */,
+				C2F157612338E64000798480 /* CrashLibMac.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -307,7 +398,7 @@
 				042319CE1EAAD73F008FACA0 /* AppCenterAnalytics.framework in Frameworks */,
 				042319CF1EAAD73F008FACA0 /* AppCenterCrashes.framework in Frameworks */,
 				046964581F2A74E600F9D31F /* AppCenterPush.framework in Frameworks */,
-				8065B5BB1F4C4169004FF622 /* CrashLibMac.framework in Frameworks */,
+				C2F1576B2338E6AD00798480 /* CrashLibMac.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -315,9 +406,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F8B8DCCC232121D200BF7DAA /* CrashLibMac.framework in Frameworks */,
 				F8EE6470231E6FF50007A52E /* AppCenter.framework in Frameworks */,
 				F8EE6471231E6FF50007A52E /* AppCenterCrashes.framework in Frameworks */,
+				C2F157702338E6B500798480 /* CrashLibMac.framework in Frameworks */,
 				F8EE645D231E6F8E0007A52E /* NotificationCenter.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -326,9 +417,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F8B8DCCD232121D900BF7DAA /* CrashLibMac.framework in Frameworks */,
 				F8EE648D231E711D0007A52E /* AppCenter.framework in Frameworks */,
 				F8EE648E231E711E0007A52E /* AppCenterCrashes.framework in Frameworks */,
+				C2F157712338E6BB00798480 /* CrashLibMac.framework in Frameworks */,
 				F8EE647A231E71060007A52E /* NotificationCenter.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -345,9 +436,29 @@
 			path = EventFilter;
 			sourceTree = "<group>";
 		};
+		C2F156A22338C23700798480 /* CrashLib */ = {
+			isa = PBXGroup;
+			children = (
+				C2F156AF2338C27700798480 /* CrashLib.xcodeproj */,
+			);
+			name = CrashLib;
+			path = Cra;
+			sourceTree = "<group>";
+		};
+		C2F156B02338C27700798480 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C2F156B62338C27700798480 /* CrashLibIOS.framework */,
+				C2F156B82338C27700798480 /* CrashLibTV.framework */,
+				C2F156BA2338C27700798480 /* CrashLibMac.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		D3C31C031E8E757300B288CE = {
 			isa = PBXGroup;
 			children = (
+				C2F156A22338C23700798480 /* CrashLib */,
 				F84BA0B621133A740020F13B /* Config */,
 				D3C31C0E1E8E757300B288CE /* SasquatchMac */,
 				D3C31C231E8E75B300B288CE /* SasquatchMacObjC */,
@@ -466,7 +577,6 @@
 			isa = PBXGroup;
 			children = (
 				B2CD74CF1F22C3150070E7DF /* libsqlite3.tbd */,
-				8065B5BA1F4C4169004FF622 /* CrashLibMac.framework */,
 				046964551F2A607D00F9D31F /* AppCenterPush.framework */,
 				042319CC1EAAD720008FACA0 /* AppCenterCrashes.framework */,
 				04ED31D31EAAC7510033BAAE /* AppCenterAnalytics.framework */,
@@ -517,11 +627,13 @@
 				B2A4CFB9210A716E00199B4F /* Sources */,
 				B2A4CFC6210A716E00199B4F /* Frameworks */,
 				B2A4CFCC210A716E00199B4F /* Resources */,
-				B2A4CFCF210A716E00199B4F /* Embed Frameworks */,
+				C2F1576A2338E6A800798480 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				C2F157532338E58700798480 /* PBXTargetDependency */,
+				C2F157692338E6A800798480 /* PBXTargetDependency */,
 			);
 			name = "SasquatchMacObjC-Preview";
 			productName = SasquatchMacObjC;
@@ -536,13 +648,15 @@
 				B2A4CFD7210A77D400199B4F /* Sources */,
 				B2A4CFE3210A77D400199B4F /* Frameworks */,
 				B2A4CFE9210A77D400199B4F /* Resources */,
-				B2A4CFEC210A77D400199B4F /* Embed Frameworks */,
 				F8EE648C231E71060007A52E /* Embed App Extensions */,
+				C2F157602338E5E800798480 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				C2F157572338E5A300798480 /* PBXTargetDependency */,
 				F8EE6487231E71060007A52E /* PBXTargetDependency */,
+				C2F1575F2338E5E800798480 /* PBXTargetDependency */,
 			);
 			name = "SasquatchMacSwift-Preview";
 			productName = SasquatchMacSwift;
@@ -558,11 +672,13 @@
 				D3C31C1E1E8E75B300B288CE /* Sources */,
 				D3C31C1F1E8E75B300B288CE /* Frameworks */,
 				D3C31C201E8E75B300B288CE /* Resources */,
-				8065B5B61F4C40FC004FF622 /* Embed Frameworks */,
+				C2F157652338E64000798480 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				C2F157512338E58200798480 /* PBXTargetDependency */,
+				C2F157642338E64000798480 /* PBXTargetDependency */,
 			);
 			name = SasquatchMacObjC;
 			productName = SasquatchMacObjC;
@@ -578,13 +694,15 @@
 				F845068C2317D7FC00A959D6 /* Remove the wrong framework */,
 				D3C31C5D1E8E763600B288CE /* Frameworks */,
 				D3C31C5E1E8E763600B288CE /* Resources */,
-				8065B5B91F4C4121004FF622 /* Embed Frameworks */,
 				F8EE646F231E6F8F0007A52E /* Embed App Extensions */,
+				C2F1576F2338E6AD00798480 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				C2F157552338E59800798480 /* PBXTargetDependency */,
 				F8EE646A231E6F8E0007A52E /* PBXTargetDependency */,
+				C2F1576E2338E6AD00798480 /* PBXTargetDependency */,
 			);
 			name = SasquatchMacSwift;
 			productName = SasquatchMacSwift;
@@ -603,6 +721,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				C2F157592338E5D300798480 /* PBXTargetDependency */,
 			);
 			name = "SasquatchMacSwift-Extension";
 			productName = "SasquatchMacSwift-Extension";
@@ -621,6 +740,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				C2F1575B2338E5D900798480 /* PBXTargetDependency */,
 			);
 			name = "SasquatchMacSwift-Preview-Extension";
 			productName = "SasquatchMacSwift-Preview-Extension";
@@ -699,6 +819,12 @@
 			mainGroup = D3C31C031E8E757300B288CE;
 			productRefGroup = D3C31C0D1E8E757300B288CE /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = C2F156B02338C27700798480 /* Products */;
+					ProjectRef = C2F156AF2338C27700798480 /* CrashLib.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				D3C31C211E8E75B300B288CE /* SasquatchMacObjC */,
@@ -710,6 +836,30 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		C2F156B62338C27700798480 /* CrashLibIOS.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CrashLibIOS.framework;
+			remoteRef = C2F156B52338C27700798480 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		C2F156B82338C27700798480 /* CrashLibTV.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CrashLibTV.framework;
+			remoteRef = C2F156B72338C27700798480 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		C2F156BA2338C27700798480 /* CrashLibMac.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CrashLibMac.framework;
+			remoteRef = C2F156B92338C27700798480 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		B2A4CFCC210A716E00199B4F /* Resources */ = {
@@ -762,7 +912,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8EE6484231E71060007A52E /* InfoPlist.strings in Resources */,
-				F8E69C842322C308006209D2 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1020,6 +1169,56 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		C2F157512338E58200798480 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C2F157502338E58200798480 /* PBXContainerItemProxy */;
+		};
+		C2F157532338E58700798480 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C2F157522338E58700798480 /* PBXContainerItemProxy */;
+		};
+		C2F157552338E59800798480 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C2F157542338E59800798480 /* PBXContainerItemProxy */;
+		};
+		C2F157572338E5A300798480 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C2F157562338E5A300798480 /* PBXContainerItemProxy */;
+		};
+		C2F157592338E5D300798480 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C2F157582338E5D300798480 /* PBXContainerItemProxy */;
+		};
+		C2F1575B2338E5D900798480 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C2F1575A2338E5D900798480 /* PBXContainerItemProxy */;
+		};
+		C2F1575F2338E5E800798480 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C2F1575E2338E5E800798480 /* PBXContainerItemProxy */;
+		};
+		C2F157642338E64000798480 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C2F157632338E64000798480 /* PBXContainerItemProxy */;
+		};
+		C2F157692338E6A800798480 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C2F157682338E6A800798480 /* PBXContainerItemProxy */;
+		};
+		C2F1576E2338E6AD00798480 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibMac;
+			targetProxy = C2F1576D2338E6AD00798480 /* PBXContainerItemProxy */;
+		};
 		F8EE646A231E6F8E0007A52E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = F8EE645A231E6F8E0007A52E /* SasquatchMacSwift-Extension */;

--- a/SasquatchMac/SasquatchMac.xcodeproj/xcshareddata/xcschemes/SasquatchMacSwift-Extension.xcscheme
+++ b/SasquatchMac/SasquatchMac.xcodeproj/xcshareddata/xcschemes/SasquatchMacSwift-Extension.xcscheme
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F8EE645A231E6F8E0007A52E"
+               BuildableName = "SasquatchMacSwift-Extension.appex"
+               BlueprintName = "SasquatchMacSwift-Extension"
+               ReferencedContainer = "container:SasquatchMac.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D3C31C5F1E8E763600B288CE"
+               BuildableName = "SasquatchMacSwift.app"
+               BlueprintName = "SasquatchMacSwift"
+               ReferencedContainer = "container:SasquatchMac.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8EE645A231E6F8E0007A52E"
+            BuildableName = "SasquatchMacSwift-Extension.appex"
+            BlueprintName = "SasquatchMacSwift-Extension"
+            ReferencedContainer = "container:SasquatchMac.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D3C31C5F1E8E763600B288CE"
+            BuildableName = "SasquatchMacSwift.app"
+            BlueprintName = "SasquatchMacSwift"
+            ReferencedContainer = "container:SasquatchMac.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D3C31C5F1E8E763600B288CE"
+            BuildableName = "SasquatchMacSwift.app"
+            BlueprintName = "SasquatchMacSwift"
+            ReferencedContainer = "container:SasquatchMac.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SasquatchMac/SasquatchMac.xcodeproj/xcshareddata/xcschemes/SasquatchMacSwift-Preview-Extension.xcscheme
+++ b/SasquatchMac/SasquatchMac.xcodeproj/xcshareddata/xcschemes/SasquatchMacSwift-Preview-Extension.xcscheme
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F8EE6478231E71060007A52E"
+               BuildableName = "SasquatchMacSwift-Preview-Extension.appex"
+               BlueprintName = "SasquatchMacSwift-Preview-Extension"
+               ReferencedContainer = "container:SasquatchMac.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B2A4CFD6210A77D400199B4F"
+               BuildableName = "SasquatchMacSwift-Preview.app"
+               BlueprintName = "SasquatchMacSwift-Preview"
+               ReferencedContainer = "container:SasquatchMac.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8EE6478231E71060007A52E"
+            BuildableName = "SasquatchMacSwift-Preview-Extension.appex"
+            BlueprintName = "SasquatchMacSwift-Preview-Extension"
+            ReferencedContainer = "container:SasquatchMac.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B2A4CFD6210A77D400199B4F"
+            BuildableName = "SasquatchMacSwift-Preview.app"
+            BlueprintName = "SasquatchMacSwift-Preview"
+            ReferencedContainer = "container:SasquatchMac.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B2A4CFD6210A77D400199B4F"
+            BuildableName = "SasquatchMacSwift-Preview.app"
+            BlueprintName = "SasquatchMacSwift-Preview"
+            ReferencedContainer = "container:SasquatchMac.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SasquatchMac/SasquatchMac/ViewControllers/CrashesViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/CrashesViewController.swift
@@ -16,7 +16,7 @@ class CrashesViewController : NSViewController, NSTableViewDataSource, NSTableVi
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    loadAllCrashes()
+    crashes = CrashLoader.loadAllCrashes()
     crashesTableView.dataSource = self
     crashesTableView.delegate = self
     textAttachmentView.delegate = self
@@ -127,41 +127,6 @@ class CrashesViewController : NSViewController, NSTableViewDataSource, NSTableVi
   
   private func isHeader(row: Int) -> Bool {
     return crashes[row] is String
-  }
-
-  private func loadAllCrashes() {
-    pokeAllCrashes()
-    var sortedCrashes = MSCrash.allCrashes() as! [MSCrash]
-    sortedCrashes = sortedCrashes.sorted { (crash1, crash2) -> Bool in
-      if crash1.category == crash2.category{
-        return crash1.title > crash2.title
-      } else {
-        return crash1.category < crash2.category
-      }
-    }
-    if sortedCrashes.count > 0 {
-      var currentCategory = sortedCrashes[0].category!
-      crashes.append(currentCategory as Any)
-      for crash in sortedCrashes {
-        if currentCategory != crash.category {
-          currentCategory = crash.category
-          crashes.append(currentCategory as Any)
-        }
-        crashes.append(crash as Any)
-      }
-    }
-  }
-
-  private func pokeAllCrashes() {
-    var count = UInt32(0)
-    let classList = objc_copyClassList(&count)
-    MSCrash.removeAllCrashes()
-    for i in 0..<Int(count){
-      let className: AnyClass = classList![i]!
-      if class_getSuperclass(className) == MSCrash.self && className != MSCrash.self{
-        MSCrash.register((className as! MSCrash.Type).init())
-      }
-    }
   }
   
   private func fileAttachmentDescription(url: URL?) -> String {

--- a/SasquatchMac/SasquatchMacSwift-Extension/Base.lproj/TodayViewController.xib
+++ b/SasquatchMac/SasquatchMacSwift-Extension/Base.lproj/TodayViewController.xib
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="TodayViewController" customModule="SasquatchMacSwift_Extension" customModuleProvider="target">
+            <connections>
+                <outlet property="addAttachments" destination="V6r-mP-Oon" id="caI-gy-I5t"/>
+                <outlet property="extensionLabel" destination="1sU-Wy-afS" id="H9c-eI-0nu"/>
+                <outlet property="popupButton" destination="3eE-SZ-0tS" id="985-Dk-fgZ"/>
+                <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView simulatedAppContext="notificationCenter" translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
+            <rect key="frame" x="0.0" y="0.0" width="507" height="112"/>
+            <subviews>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1sU-Wy-afS">
+                    <rect key="frame" x="6" y="88" width="495" height="16"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Run #000000" id="bTn-1C-B7R">
+                        <font key="font" metaFont="cellTitle"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="V6r-mP-Oon" userLabel="Checkbox">
+                    <rect key="frame" x="6" y="64" width="495" height="18"/>
+                    <buttonCell key="cell" type="check" title="Add attachments to crashes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="5Af-Y3-d6o">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                </button>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hzq-IV-DAH" userLabel="CrashMe">
+                    <rect key="frame" x="2" y="30" width="503" height="32"/>
+                    <buttonCell key="cell" type="push" title="Crash Me!" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="3hJ-SQ-2CW">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="crashMe:" target="-2" id="6hS-fk-vgb"/>
+                    </connections>
+                </button>
+                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3eE-SZ-0tS">
+                    <rect key="frame" x="6" y="5" width="496" height="25"/>
+                    <popUpButtonCell key="cell" type="push" title="Crashes" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="1C5-pp-Iha" id="0P7-Sz-HMm">
+                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="menu"/>
+                        <menu key="menu" id="TSK-ex-IXo">
+                            <items>
+                                <menuItem title="Crashes" state="on" id="1C5-pp-Iha"/>
+                                <menuItem title="Item 2" id="3cj-OI-Z2L"/>
+                                <menuItem title="Item 3" id="SLX-i2-ql7"/>
+                            </items>
+                        </menu>
+                    </popUpButtonCell>
+                </popUpButton>
+            </subviews>
+            <constraints>
+                <constraint firstItem="1sU-Wy-afS" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="0za-kV-ANi"/>
+                <constraint firstItem="3eE-SZ-0tS" firstAttribute="top" secondItem="Hzq-IV-DAH" secondAttribute="bottom" constant="8" id="55j-bi-L9W"/>
+                <constraint firstItem="Hzq-IV-DAH" firstAttribute="leading" secondItem="1sU-Wy-afS" secondAttribute="leading" id="AvQ-s8-PYf"/>
+                <constraint firstItem="V6r-mP-Oon" firstAttribute="top" secondItem="1sU-Wy-afS" secondAttribute="bottom" constant="8" id="Elb-mj-xqn"/>
+                <constraint firstItem="1sU-Wy-afS" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="8" id="FhG-Ze-3qQ"/>
+                <constraint firstAttribute="trailing" secondItem="1sU-Wy-afS" secondAttribute="trailing" constant="8" id="Gee-EA-ysn"/>
+                <constraint firstItem="3eE-SZ-0tS" firstAttribute="trailing" secondItem="Hzq-IV-DAH" secondAttribute="trailing" id="IdX-1s-NGB"/>
+                <constraint firstAttribute="bottom" secondItem="3eE-SZ-0tS" secondAttribute="bottom" constant="8" id="R7f-UB-ZPc"/>
+                <constraint firstItem="V6r-mP-Oon" firstAttribute="bottom" secondItem="Hzq-IV-DAH" secondAttribute="top" constant="-8" id="XyC-6L-4WO"/>
+                <constraint firstItem="3eE-SZ-0tS" firstAttribute="leading" secondItem="Hzq-IV-DAH" secondAttribute="leading" id="YMa-H2-oLU"/>
+                <constraint firstItem="Hzq-IV-DAH" firstAttribute="trailing" secondItem="1sU-Wy-afS" secondAttribute="trailing" id="oHE-TF-z9T"/>
+                <constraint firstItem="V6r-mP-Oon" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="oLo-dz-hhp"/>
+                <constraint firstAttribute="trailing" secondItem="V6r-mP-Oon" secondAttribute="trailing" constant="8" id="rWo-kw-fY0"/>
+            </constraints>
+            <point key="canvasLocation" x="138.5" y="174"/>
+        </customView>
+    </objects>
+</document>

--- a/SasquatchMac/SasquatchMacSwift-Extension/Info.plist
+++ b/SasquatchMac/SasquatchMacSwift-Extension/Info.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>SasquatchMacSwift Today Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionPointVersion</key>
+			<string>3.0</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widget-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).TodayViewController</string>
+		<key>com.apple.notificationcenter.widget.description</key>
+		<string>SasquatchMacSwift Today Extension</string>
+	</dict>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2019 Microsoft. All rights reserved.</string>
+</dict>
+</plist>

--- a/SasquatchMac/SasquatchMacSwift-Extension/SasquatchMacSwift_Today_Extension.entitlements
+++ b/SasquatchMac/SasquatchMacSwift-Extension/SasquatchMacSwift_Today_Extension.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>

--- a/SasquatchMac/SasquatchMacSwift-Extension/TodayViewController.swift
+++ b/SasquatchMac/SasquatchMacSwift-Extension/TodayViewController.swift
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import AppCenter
+import AppCenterCrashes
+import Cocoa
+import NotificationCenter
+
+class TodayViewController: NSViewController, NCWidgetProviding, MSCrashesDelegate {
+  
+    @IBOutlet weak var addAttachments: NSButton!
+    @IBOutlet weak var popupButton: NSPopUpButton!
+    @IBOutlet weak var extensionLabel: NSTextField!
+    var crashes = [MSCrash]()
+    
+    override var nibName: NSNib.Name? {
+        return NSNib.Name("TodayViewController")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let dateString = DateFormatter.localizedString(from: Date.init(), dateStyle: DateFormatter.Style.medium, timeStyle: DateFormatter.Style.medium)
+        extensionLabel.stringValue = "Run #\(dateString)"
+        MSAppCenter.setLogLevel(.verbose)
+        MSCrashes.setDelegate(self)
+        MSAppCenter.start("aca58ea0-d791-4409-989d-2efec0283800", withServices: [MSCrashes.self])
+        crashes = CrashLoader.loadAllCrashes(withCategories: false) as! [MSCrash]
+        popupButton.menu?.removeAllItems()
+        for (index, crash) in crashes.enumerated() {
+            popupButton.menu?.addItem(NSMenuItem(title: crash.title, action: nil, keyEquivalent: "\(index)"))
+        }
+    }
+    
+    @IBAction func crashMe(_ sender: Any) {
+        let selectedCrashIndex = popupButton.indexOfSelectedItem
+        crashes[selectedCrashIndex].crash()
+    }
+    
+    func widgetPerformUpdate(completionHandler: (@escaping (NCUpdateResult) -> Void)) {
+        completionHandler(.noData)
+    }
+    
+    func attachments(with crashes: MSCrashes, for errorReport: MSErrorReport) -> [MSErrorAttachmentLog] {
+        if (addAttachments.state == NSOnState) {
+            let attachment1 = MSErrorAttachmentLog.attachment(withText: "Hello world!", filename: "hello.txt")
+            let attachment2 = MSErrorAttachmentLog.attachment(withBinary: "Fake image".data(using: String.Encoding.utf8), filename: nil, contentType: "image/jpeg")
+            return [attachment1!, attachment2!]
+        }
+        return [];
+    }
+}

--- a/SasquatchMac/SasquatchMacSwift-Extension/TodayViewController.swift
+++ b/SasquatchMac/SasquatchMacSwift-Extension/TodayViewController.swift
@@ -23,7 +23,7 @@ class TodayViewController: NSViewController, NCWidgetProviding, MSCrashesDelegat
         extensionLabel.stringValue = "Run #\(dateString)"
         MSAppCenter.setLogLevel(.verbose)
         MSCrashes.setDelegate(self)
-        MSAppCenter.start("aca58ea0-d791-4409-989d-2efec0283800", withServices: [MSCrashes.self])
+        MSAppCenter.start("0b559191-f276-4e9d-9b70-4dadd5886c4e", withServices: [MSCrashes.self])
         crashes = CrashLoader.loadAllCrashes(withCategories: false) as! [MSCrash]
         popupButton.menu?.removeAllItems()
         for (index, crash) in crashes.enumerated() {

--- a/SasquatchMac/SasquatchMacSwift-Extension/en.lproj/InfoPlist.strings
+++ b/SasquatchMac/SasquatchMacSwift-Extension/en.lproj/InfoPlist.strings
@@ -1,0 +1,4 @@
+/* Display name and description for this extension. */
+"CFBundleDisplayName" = "SasquatchMacSwift Today Extension";
+"com.apple.notificationcenter.widget.description" = "Extension test app for Sasquatch Swift Preview.";
+

--- a/SasquatchMac/SasquatchMacSwift-Preview-Extension/SasquatchMacSwift_Preview_Today_Extension.entitlements
+++ b/SasquatchMac/SasquatchMacSwift-Preview-Extension/SasquatchMacSwift_Preview_Today_Extension.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>

--- a/SasquatchMac/SasquatchMacSwift-Preview-Extension/en.lproj/InfoPlist.strings
+++ b/SasquatchMac/SasquatchMacSwift-Preview-Extension/en.lproj/InfoPlist.strings
@@ -1,0 +1,4 @@
+/* Display name and description for this extension. */
+"CFBundleDisplayName" = "SasquatchMacSwift-Preview Today Extension";
+"com.apple.notificationcenter.widget.description" = "Extension test app for Sasquatch Swift Preview.";
+

--- a/SasquatchMac/SasquatchMacSwift/CrashLoader.swift
+++ b/SasquatchMac/SasquatchMacSwift/CrashLoader.swift
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import Foundation
+
+class CrashLoader {
+    public static func loadAllCrashes(withCategories appendCategories: Bool = true) -> [Any] {
+        var resultCrashes = [Any]()
+        pokeAllCrashes()
+        var sortedCrashes = MSCrash.allCrashes() as! [MSCrash]
+        sortedCrashes = sortedCrashes.sorted { (crash1, crash2) -> Bool in
+            if crash1.category == crash2.category {
+                return crash1.title > crash2.title
+            } else {
+                return crash1.category < crash2.category
+            }
+        }
+        if sortedCrashes.count > 0 {
+            var currentCategory = sortedCrashes[0].category!
+            if (appendCategories) {
+                resultCrashes.append(currentCategory as Any)
+            }
+            for crash in sortedCrashes {
+                if (appendCategories) {
+                    if currentCategory != crash.category {
+                        currentCategory = crash.category
+                        resultCrashes.append(currentCategory as Any)
+                    }
+                }
+                resultCrashes.append(crash as Any)
+            }
+        }
+        return resultCrashes
+    }
+    
+    private static func pokeAllCrashes() {
+        var count = UInt32(0)
+        let classList = objc_copyClassList(&count)
+        MSCrash.removeAllCrashes()
+        for i in 0..<Int(count) {
+            let className: AnyClass = classList![i]!
+            if class_getSuperclass(className) == MSCrash.self && className != MSCrash.self {
+                MSCrash.register((className as! MSCrash.Type).init())
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR will "revert the revert" (MacOS demo extension) and create separate targets for Apps, containing extensions, to allow AC build build non-containing apps.

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [X] Did you check UI tests on the sample app? They are not executed on CI.
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

[AB#66881](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/66881)