### PR TITLE
Fix issues in jwt parsing and add tests

### DIFF
--- a/AppCenter/AppCenter/Internals/Context/AuthToken/MSAuthTokenContextDelegateWrapper.m
+++ b/AppCenter/AppCenter/Internals/Context/AuthToken/MSAuthTokenContextDelegateWrapper.m
@@ -3,8 +3,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "MSAuthTokenContextDelegateWrapper.h"
 #import "MSAppCenterInternal.h"
+#import "MSAuthTokenContextDelegateWrapper.h"
 
 @class MSAuthTokenContextDelegate;
 

--- a/AppCenter/AppCenter/Internals/Util/MSJwtClaims.m
+++ b/AppCenter/AppCenter/Internals/Util/MSJwtClaims.m
@@ -39,7 +39,7 @@ static NSString *const kMSExpirationClaim = @"exp";
    * Learn more here: https://tools.ietf.org/html/rfc4648#section-4.
    */
   if ((base64ClaimsPart.length % 4) == 1) {
-    MSLogError([MSAppCenter logTag], @"Failed to parse JWT, base64 data is not a valid length.");
+    MSLogError([MSAppCenter logTag], @"Failed to parse JWT; invalid base64 data length.");
     return nil;
   }
   unsigned long targetLength = base64ClaimsPart.length + (4 - base64ClaimsPart.length % 4) % 4;

--- a/AppCenter/AppCenter/Internals/Util/MSJwtClaims.m
+++ b/AppCenter/AppCenter/Internals/Util/MSJwtClaims.m
@@ -33,6 +33,19 @@ static NSString *const kMSExpirationClaim = @"exp";
     return nil;
   }
   NSString *base64ClaimsPart = parts[1];
+
+  /*
+   * NSData's base64 parser expects the length to be padded with '=' to indicate the size of the last "chunk."
+   * Learn more here: https://tools.ietf.org/html/rfc4648#section-4.
+   */
+  int padding = 0;
+  if ((base64ClaimsPart.length % 4) == 3) {
+    padding = 1;
+  } else if ((base64ClaimsPart.length % 4) == 2) {
+    padding = 2;
+  }
+  unsigned long targetLength = base64ClaimsPart.length + padding;
+  base64ClaimsPart = [base64ClaimsPart stringByPaddingToLength:targetLength withString:@"=" startingAtIndex:0];
   NSError *error;
   NSData *claimsPartData = [[NSData alloc] initWithBase64EncodedString:base64ClaimsPart options:0];
   NSDictionary *claims = [NSJSONSerialization JSONObjectWithData:claimsPartData options:0 error:&error];
@@ -50,7 +63,7 @@ static NSString *const kMSExpirationClaim = @"exp";
     return nil;
   }
   return [[MSJwtClaims alloc] initWithSubject:[claims objectForKey:kMSSubjectClaim]
-                                   expiration:[[NSDate alloc] initWithTimeIntervalSince1970:[((NSNumber *)expirationTimeIntervalSince1970) intValue]]];
+                                   expiration:[[NSDate alloc] initWithTimeIntervalSince1970:[((NSNumber *)expirationTimeIntervalSince1970) longValue]]];
 }
 
 @end

--- a/AppCenter/AppCenter/Internals/Util/MSJwtClaims.m
+++ b/AppCenter/AppCenter/Internals/Util/MSJwtClaims.m
@@ -3,8 +3,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "MSJwtClaims.h"
 #import "MSAppCenterInternal.h"
+#import "MSJwtClaims.h"
 #import "MSLogger.h"
 
 static NSString *const kMSJwtPartsSeparator = @".";
@@ -62,8 +62,9 @@ static NSString *const kMSExpirationClaim = @"exp";
     MSLogError([MSAppCenter logTag], @"Failed to parse JWT, `exp` claim in incorrect format.");
     return nil;
   }
-  return [[MSJwtClaims alloc] initWithSubject:[claims objectForKey:kMSSubjectClaim]
-                                   expiration:[[NSDate alloc] initWithTimeIntervalSince1970:[((NSNumber *)expirationTimeIntervalSince1970) longValue]]];
+  return [[MSJwtClaims alloc]
+      initWithSubject:[claims objectForKey:kMSSubjectClaim]
+           expiration:[[NSDate alloc] initWithTimeIntervalSince1970:[((NSNumber *)expirationTimeIntervalSince1970) longValue]]];
 }
 
 @end

--- a/AppCenter/AppCenter/Internals/Util/MSJwtClaims.m
+++ b/AppCenter/AppCenter/Internals/Util/MSJwtClaims.m
@@ -35,16 +35,14 @@ static NSString *const kMSExpirationClaim = @"exp";
   NSString *base64ClaimsPart = parts[1];
 
   /*
-   * NSData's base64 parser expects the length to be padded with '=' to indicate the size of the last "chunk."
+   * NSData's base64 parser expects the length to be padded with '=' to indicate the size of the last "chunk" (which can be 2, 3, or 4 bytes).
    * Learn more here: https://tools.ietf.org/html/rfc4648#section-4.
    */
-  int padding = 0;
-  if ((base64ClaimsPart.length % 4) == 3) {
-    padding = 1;
-  } else if ((base64ClaimsPart.length % 4) == 2) {
-    padding = 2;
+  if ((base64ClaimsPart.length % 4) == 1) {
+    MSLogError([MSAppCenter logTag], @"Failed to parse JWT, base64 data is not a valid length.");
+    return nil;
   }
-  unsigned long targetLength = base64ClaimsPart.length + padding;
+  unsigned long targetLength = base64ClaimsPart.length + (4 - base64ClaimsPart.length % 4) % 4;
   base64ClaimsPart = [base64ClaimsPart stringByPaddingToLength:targetLength withString:@"=" startingAtIndex:0];
   NSError *error;
   NSData *claimsPartData = [[NSData alloc] initWithBase64EncodedString:base64ClaimsPart options:0];

--- a/AppCenter/AppCenter/MSAppCenter.m
+++ b/AppCenter/AppCenter/MSAppCenter.m
@@ -202,11 +202,10 @@ static const long kMSMinUpperSizeLimitInBytes = 24 * 1024;
   MSAuthTokenContext *authTokenContext = [MSAuthTokenContext sharedInstance];
   @synchronized(self.authTokenContextDelegateWrapper) {
     if (authTokenDelegate != nil) {
-      self.authTokenContextDelegateWrapper = [[MSAuthTokenContextDelegateWrapper alloc]
-           initWithAuthTokenDelegate:authTokenDelegate
-          authTokenCompletionHandler:^(NSString *jwt) {
-            [[MSAppCenter sharedInstance] setAuthToken:jwt];
-          }];
+      self.authTokenContextDelegateWrapper = [[MSAuthTokenContextDelegateWrapper alloc] initWithAuthTokenDelegate:authTokenDelegate
+                                                                                       authTokenCompletionHandler:^(NSString *jwt) {
+                                                                                         [[MSAppCenter sharedInstance] setAuthToken:jwt];
+                                                                                       }];
       MSLogInfo(MSAppCenter.logTag, @"Setting up auth token refresh listener.");
       [authTokenContext preventResetAuthTokenAfterStart];
       [authTokenContext addDelegate:self.authTokenContextDelegateWrapper];

--- a/AppCenter/AppCenterTests/MSByoiTests.m
+++ b/AppCenter/AppCenterTests/MSByoiTests.m
@@ -84,7 +84,7 @@ static NSString *const kMSJwtFormat = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.%@"
   // When
   [MSAppCenter setAuthTokenDelegate:delegateMock];
   [self.authTokenContextMock checkIfTokenNeedsToBeRefreshed:validityInfo];
-  
+
   // Then
   OCMVerifyAll(delegateMock);
 }

--- a/AppCenter/AppCenterTests/MSJwtClaimsTests.m
+++ b/AppCenter/AppCenterTests/MSJwtClaimsTests.m
@@ -91,6 +91,54 @@ static NSString *const kMSJwtFormat = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.%@"
   XCTAssertNil(claims);
 }
 
+- (void)testInvalidDataWithRightNumberOfParts {
+  // If
+  NSString *combinedJwt = @"this.is.invalid";
+
+  // When
+  MSJwtClaims *claims = [MSJwtClaims parse:combinedJwt];
+
+  // Then
+  XCTAssertNil(claims);
+}
+
+- (void)testUnpaddedBase64Data {
+
+  // If
+  // These values are hard-coded into the JWT below.
+  NSDate *expirationAsDate = [[NSDate alloc] initWithTimeIntervalSince1970:2000000000];
+  NSString *subject = @"thesubject";
+  NSString *jwt = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0aGVzdWJqZWN0IiwiZXhwIjoyMDAwMDAwMDAwfQ.CoPAl7CUGLXBkCHe4_D2ko_q-0gWSC_x6le5gZCtVJs";
+
+  // When
+  MSJwtClaims *claims = [MSJwtClaims parse:jwt];
+
+  // Then
+  XCTAssertNotNil(claims);
+  XCTAssertEqualObjects(claims.subject, subject);
+  XCTAssertEqualObjects(claims.expiration, expirationAsDate);
+}
+
+- (void)testExpOverMaxInt {
+
+  // If
+  long expiration = 190000000000;
+  NSString *userId = @"some_user_id";
+  NSDate *expirationAsDate = [[NSDate alloc] initWithTimeIntervalSince1970:expiration];
+  NSString *jsonClaims = [NSString stringWithFormat:@"{\"sub\":\"%@\",\"exp\":%li}", userId, expiration];
+  NSData *nsdata = [jsonClaims dataUsingEncoding:NSUTF8StringEncoding];
+  NSString *base64Encoded = [nsdata base64EncodedStringWithOptions:0];
+  NSString *combinedJwt = [NSString stringWithFormat:kMSJwtFormat, base64Encoded];
+
+  // When
+  MSJwtClaims *claims = [MSJwtClaims parse:combinedJwt];
+
+  // Then
+  XCTAssertNotNil(claims);
+  XCTAssertEqualObjects(claims.subject, userId);
+  XCTAssertEqualObjects(claims.expiration, expirationAsDate);
+}
+
 - (void)testInvalidBase64Token {
 
   // If

--- a/AppCenter/AppCenterTests/MSJwtClaimsTests.m
+++ b/AppCenter/AppCenterTests/MSJwtClaimsTests.m
@@ -34,10 +34,10 @@ static NSString *const kMSJwtFormat = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.%@"
 }
 
 - (void)testNilJwt {
-  
+
   // When
   MSJwtClaims *claims = [MSJwtClaims parse:nil];
-  
+
   // Then
   XCTAssertNil(claims);
 }
@@ -108,7 +108,8 @@ static NSString *const kMSJwtFormat = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.%@"
   // These values are hard-coded into the JWT below.
   NSDate *expirationAsDate = [[NSDate alloc] initWithTimeIntervalSince1970:2000000000];
   NSString *subject = @"thesubject";
-  NSString *jwt = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0aGVzdWJqZWN0IiwiZXhwIjoyMDAwMDAwMDAwfQ.CoPAl7CUGLXBkCHe4_D2ko_q-0gWSC_x6le5gZCtVJs";
+  NSString *jwt = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0aGVzdWJqZWN0IiwiZXhwIjoyMDAwMDAwMDAwfQ.CoPAl7CUGLXBkCHe4_D2ko_q-0gWSC_"
+                  @"x6le5gZCtVJs";
 
   // When
   MSJwtClaims *claims = [MSJwtClaims parse:jwt];

--- a/AppCenter/AppCenterTests/MSJwtClaimsTests.m
+++ b/AppCenter/AppCenterTests/MSJwtClaimsTests.m
@@ -153,6 +153,20 @@ static NSString *const kMSJwtFormat = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.%@"
   XCTAssertNil(claims);
 }
 
+- (void)testJwtWithDataLength1 {
+
+  // If
+  NSString *invalidTokenPart = @"a.b.c";
+  NSString *combinedJwt = [NSString stringWithFormat:kMSJwtFormat, invalidTokenPart];
+
+  // When
+  MSJwtClaims *claims = [MSJwtClaims parse:combinedJwt];
+
+  // Then
+  XCTAssertNil(claims);
+}
+
+
 - (void)testMissingParts {
 
   // If

--- a/AppCenter/AppCenterTests/MSJwtClaimsTests.m
+++ b/AppCenter/AppCenterTests/MSJwtClaimsTests.m
@@ -91,17 +91,6 @@ static NSString *const kMSJwtFormat = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.%@"
   XCTAssertNil(claims);
 }
 
-- (void)testInvalidDataWithRightNumberOfParts {
-  // If
-  NSString *combinedJwt = @"this.is.invalid";
-
-  // When
-  MSJwtClaims *claims = [MSJwtClaims parse:combinedJwt];
-
-  // Then
-  XCTAssertNil(claims);
-}
-
 - (void)testUnpaddedBase64Data {
 
   // If
@@ -140,32 +129,20 @@ static NSString *const kMSJwtFormat = @"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.%@"
   XCTAssertEqualObjects(claims.expiration, expirationAsDate);
 }
 
-- (void)testInvalidBase64Token {
+- (void)testInvalidJwtWithDifferentDataLengths {
+  for (unsigned int i = 0; i < 5; ++i) {
 
-  // If
-  NSString *invalidTokenPart = @"invalidTokenPart";
-  NSString *combinedJwt = [NSString stringWithFormat:kMSJwtFormat, invalidTokenPart];
+    // If
+    NSString *dataSection = [@"" stringByPaddingToLength:i withString:@"a" startingAtIndex:0];
+    NSString *combinedJwt = [NSString stringWithFormat:kMSJwtFormat, dataSection];
 
-  // When
-  MSJwtClaims *claims = [MSJwtClaims parse:combinedJwt];
+    // When
+    MSJwtClaims *claims = [MSJwtClaims parse:combinedJwt];
 
-  // Then
-  XCTAssertNil(claims);
+    // Then
+    XCTAssertNil(claims);
+  }
 }
-
-- (void)testJwtWithDataLength1 {
-
-  // If
-  NSString *invalidTokenPart = @"a.b.c";
-  NSString *combinedJwt = [NSString stringWithFormat:kMSJwtFormat, invalidTokenPart];
-
-  // When
-  MSJwtClaims *claims = [MSJwtClaims parse:combinedJwt];
-
-  // Then
-  XCTAssertNil(claims);
-}
-
 
 - (void)testMissingParts {
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fixes 2 issues with JWT parsing:
1) JWT base64 data does not require padding, but the SDK crashes if the padding is missing
2) expirations with offsets over the max int are perfectly valid but were not parsed correctly
