### PR TITLE
[BYOI] Mach-o exception during validation fix

### DIFF
--- a/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
+++ b/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
@@ -44,8 +44,6 @@
 		048C22732345148000316020 /* SimpleKeychain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04C5166D233C3644001C9011 /* SimpleKeychain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C22742345149000316020 /* FBSDKCoreKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04A950182342984C00F49AEE /* FBSDKCoreKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C22752345149000316020 /* FBSDKLoginKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04A950192342984C00F49AEE /* FBSDKLoginKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		048C22762345149000316020 /* FirebaseCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF6BE233EC78C0003CFA8 /* FirebaseCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		048C22772345149000316020 /* FirebaseAuth.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF6A0233EA91E0003CFA8 /* FirebaseAuth.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C22782345149000316020 /* FirebaseAuthUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF661233EA8350003CFA8 /* FirebaseAuthUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C22792345149000316020 /* FirebaseFacebookAuthUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04A950132342866C00F49AEE /* FirebaseFacebookAuthUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C227A2345149000316020 /* GoogleUtilities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF6B4233EB2440003CFA8 /* GoogleUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1110,8 +1108,6 @@
 			files = (
 				048C22742345149000316020 /* FBSDKCoreKit.framework in Embed Frameworks */,
 				048C22752345149000316020 /* FBSDKLoginKit.framework in Embed Frameworks */,
-				048C22762345149000316020 /* FirebaseCore.framework in Embed Frameworks */,
-				048C22772345149000316020 /* FirebaseAuth.framework in Embed Frameworks */,
 				048C22782345149000316020 /* FirebaseAuthUI.framework in Embed Frameworks */,
 				048C22792345149000316020 /* FirebaseFacebookAuthUI.framework in Embed Frameworks */,
 				048C227A2345149000316020 /* GoogleUtilities.framework in Embed Frameworks */,

--- a/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
+++ b/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
@@ -24,8 +24,6 @@
 		048933631F8D395A00C38A87 /* Sasquatch.strings in Resources */ = {isa = PBXBuildFile; fileRef = 041A4BAF1F8C28A3009E1B6C /* Sasquatch.strings */; };
 		048C22232345109C00316020 /* FBSDKCoreKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04A950182342984C00F49AEE /* FBSDKCoreKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C22242345109C00316020 /* FBSDKLoginKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04A950192342984C00F49AEE /* FBSDKLoginKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		048C22252345109C00316020 /* FirebaseCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF6BE233EC78C0003CFA8 /* FirebaseCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		048C22262345109C00316020 /* FirebaseAuth.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF6A0233EA91E0003CFA8 /* FirebaseAuth.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C22272345109C00316020 /* FirebaseAuthUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF661233EA8350003CFA8 /* FirebaseAuthUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C22282345109C00316020 /* FirebaseFacebookAuthUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04A950132342866C00F49AEE /* FirebaseFacebookAuthUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C22292345109C00316020 /* GoogleUtilities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF6B4233EB2440003CFA8 /* GoogleUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1075,8 +1073,6 @@
 			files = (
 				048C22232345109C00316020 /* FBSDKCoreKit.framework in Embed Frameworks */,
 				048C22242345109C00316020 /* FBSDKLoginKit.framework in Embed Frameworks */,
-				048C22252345109C00316020 /* FirebaseCore.framework in Embed Frameworks */,
-				048C22262345109C00316020 /* FirebaseAuth.framework in Embed Frameworks */,
 				048C22272345109C00316020 /* FirebaseAuthUI.framework in Embed Frameworks */,
 				048C22282345109C00316020 /* FirebaseFacebookAuthUI.framework in Embed Frameworks */,
 				048C22292345109C00316020 /* GoogleUtilities.framework in Embed Frameworks */,

--- a/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
+++ b/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
@@ -35,8 +35,6 @@
 		048C222D2345109C00316020 /* SimpleKeychain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04C5166D233C3644001C9011 /* SimpleKeychain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C22692345148000316020 /* FBSDKCoreKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04A950182342984C00F49AEE /* FBSDKCoreKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C226A2345148000316020 /* FBSDKLoginKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04A950192342984C00F49AEE /* FBSDKLoginKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		048C226B2345148000316020 /* FirebaseCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF6BE233EC78C0003CFA8 /* FirebaseCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		048C226C2345148000316020 /* FirebaseAuth.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF6A0233EA91E0003CFA8 /* FirebaseAuth.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C226D2345148000316020 /* FirebaseAuthUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF661233EA8350003CFA8 /* FirebaseAuthUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C226E2345148000316020 /* FirebaseFacebookAuthUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04A950132342866C00F49AEE /* FirebaseFacebookAuthUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		048C226F2345148000316020 /* GoogleUtilities.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 04DFF6B4233EB2440003CFA8 /* GoogleUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -1326,8 +1324,6 @@
 			files = (
 				048C22692345148000316020 /* FBSDKCoreKit.framework in Embed Frameworks */,
 				048C226A2345148000316020 /* FBSDKLoginKit.framework in Embed Frameworks */,
-				048C226B2345148000316020 /* FirebaseCore.framework in Embed Frameworks */,
-				048C226C2345148000316020 /* FirebaseAuth.framework in Embed Frameworks */,
 				048C226D2345148000316020 /* FirebaseAuthUI.framework in Embed Frameworks */,
 				048C226E2345148000316020 /* FirebaseFacebookAuthUI.framework in Embed Frameworks */,
 				048C226F2345148000316020 /* GoogleUtilities.framework in Embed Frameworks */,


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Are the files formatted correctly?
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes `Found an unexpected Mach-O header code: 0x72613c21` that we get on CI. As I found **FirebaseCore.framework** and **FirebaseAuth.framework** should not be used in the _Embed frameworks_ section as they are static ones. For more details, see [Embedded Static Libraries](https://developer.apple.com/library/archive/technotes/tn2435/_index.html).

## Related PRs or issues

[AB#70160](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/70160)

## Misc

[Embedded Static Libraries](https://developer.apple.com/library/archive/technotes/tn2435/_index.html)
