### PR TITLE
 Find framework name from their info.plist

### DIFF
--- a/Scripts/remove-frameworks-extra-archs.sh
+++ b/Scripts/remove-frameworks-extra-archs.sh
@@ -7,16 +7,18 @@
 echo "Architecture(s) built for this product: $ARCHS."
 for f in $BUILT_PRODUCTS_DIR/$FRAMEWORKS_FOLDER_PATH/*.framework/ ; do
 
-    # Not all the frameworks correctly specify the CFBundleExecutable from their info.plist so default to naming convention.
-    FRAMEWORK_NAME=$(basename ${f%.*})
+    # Read info.plist for the framework executable binary name.
+    FRAMEWORK_EXECUTABLE_NAME=$(defaults read "$f/Info.plist" CFBundleExecutable)
 
     # lipo -archs would be better but introduced in Xcode 10.1 toolchain only (we still support 10.0).
-    FRAMEWORK_ARCHITECTURES=$(lipo -detailed_info "$f/$FRAMEWORK_NAME" | awk '/^architecture/{print $2}' ORS=' ')
+    FRAMEWORK_ARCHITECTURES=$(lipo -detailed_info "$f/$FRAMEWORK_EXECUTABLE_NAME" | awk '/^architecture/{print $2}' ORS=' ')
     ARCHS_TO_REMOVE=$(comm -13  <(tr ' ' '\n' <<<$ARCHS | sort) <(tr ' ' '\n' <<<$FRAMEWORK_ARCHITECTURES | sort))
     if [ ! -z "$ARCHS_TO_REMOVE" ];  then
         
-        # Remove all the extra architecture from this framework at once.
-        lipo -remove $(sed 's/ / -remove /g' <<<$ARCHS_TO_REMOVE) "$f/$FRAMEWORK_NAME" -o "$f/$FRAMEWORK_NAME"
-        echo "Architecture(s) $(sed 's/\n/ /g' <<<$ARCHS_TO_REMOVE) removed from framework $FRAMEWORK_NAME."
+        # Remove all the extra architectures from this framework at once.
+        lipo -remove $(sed 's/ / -remove /g' <<<$ARCHS_TO_REMOVE) "$f/$FRAMEWORK_EXECUTABLE_NAME" -o "$f/$FRAMEWORK_EXECUTABLE_NAME"
+        echo "Architecture(s) $(sed 's/\n/ /g' <<<$ARCHS_TO_REMOVE) removed from framework $FRAMEWORK_EXECUTABLE_NAME."
+    else
+        echo "No architecture to remove for framework $FRAMEWORK_EXECUTABLE_NAME."
     fi
 done


### PR DESCRIPTION
 Find framework name from their info.plist + improvements

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

In the morning we realized the importance of the `CFBundleExecutable` from the framework info.plist. It's somewhat used at the time of the signing when building the test apps to run on real devices. The signing would fail if this value is wrong, we fixed the frameworks and updated the script to use this value instead of the folder name.

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
