### PR TITLE
Implement trackModelException with attachments

### DIFF
--- a/AppCenterCrashes/AppCenterCrashes/Internals/MSCrashesInternal.h
+++ b/AppCenterCrashes/AppCenterCrashes/Internals/MSCrashesInternal.h
@@ -66,17 +66,12 @@ static NSString *const kMSAppDidReceiveMemoryWarningKey = @"MSAppDidReceiveMemor
  * This API is not public and is used by wrapper SDKs.
  *
  * @param exception model form exception.
- */
-+ (void)trackModelException:(MSException *)exception;
-
-/*
- * Track handled exception directly as model form.
- * This API is not public and is used by wrapper SDKs.
- *
- * @param exception model form exception.
  * @param properties dictionary of properties.
+ * @param attachments a list of attachments.
  */
-+ (void)trackModelException:(MSException *)exception withProperties:(nullable NSDictionary<NSString *, NSString *> *)properties;
++ (void)trackModelException:(MSException *)exception
+             withProperties:(nullable NSDictionary<NSString *, NSString *> *)properties
+            withAttachments:(nullable NSArray<MSErrorAttachmentLog *> *)attachments;
 
 @end
 

--- a/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
@@ -877,7 +877,7 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   assertThat(properties, is(expectedProperties));
 }
 
-- (void)testTrackModelExceptionWitExceptionAndAttachments {
+- (void)testTrackModelExceptionWithExceptionAndAttachments {
 
   // If
   __block NSString *type;


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Remove old trackModelException methods and introduce a new trackModelException API that takes attachments for handled error used by wrapper SDKs. This is internal use only and not exposed for public usages. No CHANGELOG changes.

## Related PRs or issues

[AB#71070](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/71070)
