### PR TITLE
Fix missing alert dialogs on iOS 13 when project uses new scenes API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### App Center Distribute
 
-* **[Fix]** Fix missing alert dialogs in apps that use iOS 13's new UIScenes API.
+* **[Fix]** Fix missing alert dialogs in apps that use iOS 13's new `UIScene` API (multiple scenes are not yet supported).
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Distribute
 
-* **[Fix]** Fix missing alert dialogs on iOS 13 when project uses new scenes API.
+* **[Fix]** Fix missing alert dialogs in apps that use iOS 13's new UIScenes API.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 2.5.2 (Under development)
 
+### App Center Distribute
+
+* **[Fix]** Fix missing alert dialogs on iOS 13 when project uses new scenes API.
+
 ___
 
 ## Version 2.5.1

--- a/Vendor/iOS/MSAlertController/MSAlertController.m
+++ b/Vendor/iOS/MSAlertController/MSAlertController.m
@@ -146,19 +146,19 @@ static dispatch_queue_t alertsQueue;
   }
 }
 
-#define DISPATCH_SELECTOR(class, selectorName, ...) ({ \
+#define MS_DISPATCH_SELECTOR(result, class, selectorName, ...) ({ \
   SEL selector = NSSelectorFromString(@#selectorName); \
   IMP impl = [class methodForSelector:selector]; \
-  ((id (*)(id, SEL, ...)) impl)(class, selector, ##__VA_ARGS__); \
+  ((result (*)(id, SEL, ...)) impl)(class, selector, ##__VA_ARGS__); \
 })
 
 + (void)makeKeyAndVisible {
   if (@available(iOS 13.0, *)) {
-    UIApplication *application = (UIApplication *)DISPATCH_SELECTOR([UIApplication class], sharedApplication);
-    NSSet *scenes = (NSSet *)DISPATCH_SELECTOR(application, connectedScenes);
+    UIApplication *application = MS_DISPATCH_SELECTOR(UIApplication *, [UIApplication class], sharedApplication);
+    NSSet *scenes = MS_DISPATCH_SELECTOR(NSSet *, application, connectedScenes);
     NSObject *windowScene = nil;
     for (NSObject *scene in scenes) {
-      NSInteger activationState = (NSInteger)DISPATCH_SELECTOR(scene, activationState);
+      NSInteger activationState = MS_DISPATCH_SELECTOR(NSInteger, scene, activationState);
       if (activationState == 0 /* UISceneActivationStateForegroundActive */) {
         windowScene = scene;
         break;
@@ -167,7 +167,7 @@ static dispatch_queue_t alertsQueue;
     if (!windowScene) {
       windowScene = scenes.anyObject;
     }
-    DISPATCH_SELECTOR(window, setWindowScene:, windowScene);
+    MS_DISPATCH_SELECTOR(void, window, setWindowScene:, windowScene);
   }
   [window makeKeyAndVisible];
 }

--- a/Vendor/iOS/MSAlertController/MSAlertController.m
+++ b/Vendor/iOS/MSAlertController/MSAlertController.m
@@ -156,13 +156,18 @@ static dispatch_queue_t alertsQueue;
   if (@available(iOS 13.0, *)) {
     UIApplication *application = (UIApplication *)DISPATCH_SELECTOR([UIApplication class], sharedApplication);
     NSSet *scenes = (NSSet *)DISPATCH_SELECTOR(application, connectedScenes);
+    NSObject *windowScene = nil;
     for (NSObject *scene in scenes) {
       NSInteger activationState = (NSInteger)DISPATCH_SELECTOR(scene, activationState);
       if (activationState == 0 /* UISceneActivationStateForegroundActive */) {
-        DISPATCH_SELECTOR(window, setWindowScene:, scene);
+        windowScene = scene;
         break;
       }
     }
+    if (!windowScene) {
+      windowScene = scenes.anyObject;
+    }
+    DISPATCH_SELECTOR(window, setWindowScene:, windowScene);
   }
   [window makeKeyAndVisible];
 }


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix missing alert dialogs on iOS 13 when project uses new scenes API

## Related PRs or issues

#1852
[AB#72440](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/72440)
