### PR TITLE
Release script fixed

### DIFF
--- a/vsts/publish.sh
+++ b/vsts/publish.sh
@@ -208,11 +208,11 @@ uploadToGithub() {
   upload_url="$(echo $REQUEST_UPLOAD_URL_TEMPLATE | sed 's/{id}/'$id'/g')"
   url="$(echo $upload_url | sed 's/{filename}/'$1'/g')"
   resp="$(curl -s -X POST -H 'Content-Type: application/zip' --data-binary @$1 $url)"
-  id="$(echo $resp | jq -r '.id')"
+  upload_id="$(echo $resp | jq -r '.id')"
 
   # Log error if response doesn't contain "id" key
-  if [ -z $id ] || [ "$id" == "" ] || [ "$id" == "null" ]; then
-    echo "Cannot upload" $file
+  if [ -z $upload_id ] || [ "$upload_id" == "" ] || [ "$upload_id" == "null" ]; then
+    echo "Cannot upload" $1
     echo "Request URL:" $url
     echo "Response:" $resp
     exit 1


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

After the first zip file was uploaded the '$id' value was changed. But the '$id' value is used in upload URL and the next time when we try to upload 'carthage' zip file we have the wrong upload URL. We don't need to change the '$id' inside 'uploadToGithub' function.

## Misc

[AB#72315](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/72315)
