### PR TITLE
Fix default log url is One Collector log URL when startup mode is "None" or "Skip" on iOS and mac demo apps 

### DIFF
--- a/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
@@ -312,14 +312,16 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
   }
   
   func defaultLogUrl() -> String {
-    if StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.OneCollector || StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.None || StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.Skip {
-      return ocProdLogUrl;
+    switch StartupMode.allValues[startUpModeForCurrentSession] {
+    case .OneCollector, .None, .Skip:
+      return ocProdLogUrl
+    default:
+      #if ACTIVE_COMPILATION_CONDITION_PUPPET
+      return kMSIntLogUrl
+      #else
+      return acProdLogUrl
+      #endif
     }
-    #if ACTIVE_COMPILATION_CONDITION_PUPPET
-    return kMSIntLogUrl
-    #else
-    return acProdLogUrl
-    #endif
   }
     
   func showUserId () -> String {

--- a/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
@@ -312,7 +312,7 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
   }
   
   func defaultLogUrl() -> String {
-    if StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.OneCollector {
+    if StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.OneCollector || StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.None || StartupMode.allValues[startUpModeForCurrentSession] == StartupMode.Skip {
       return ocProdLogUrl;
     }
     #if ACTIVE_COMPILATION_CONDITION_PUPPET

--- a/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
@@ -248,8 +248,8 @@ class AppCenterViewController : NSViewController, NSTextFieldDelegate, NSTextVie
   }
 
   private func prodLogUrl() -> String {
-    switch StartupMode.allValues[startUpModeForCurrentSession] {
-    case .OneCollector, .None, .Skip: return ocProdLogUrl
+    switch startUpModeForCurrentSession {
+    case StartupMode.OneCollector.rawValue, StartupMode.None.rawValue, StartupMode.Skip.rawValue: return ocProdLogUrl
     default: return acProdLogUrl
     }
   }

--- a/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
@@ -248,7 +248,7 @@ class AppCenterViewController : NSViewController, NSTextFieldDelegate, NSTextVie
   }
 
   private func prodLogUrl() -> String {
-    return startUpModeForCurrentSession == StartupMode.OneCollector.rawValue ? ocProdLogUrl : acProdLogUrl
+    return startUpModeForCurrentSession == StartupMode.OneCollector.rawValue || startUpModeForCurrentSession == StartupMode.None.rawValue || startUpModeForCurrentSession == StartupMode.Skip.rawValue ? ocProdLogUrl : acProdLogUrl
   }
   
   private func prodAppSecret() -> String {

--- a/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
@@ -248,7 +248,10 @@ class AppCenterViewController : NSViewController, NSTextFieldDelegate, NSTextVie
   }
 
   private func prodLogUrl() -> String {
-    return startUpModeForCurrentSession == StartupMode.OneCollector.rawValue || startUpModeForCurrentSession == StartupMode.None.rawValue || startUpModeForCurrentSession == StartupMode.Skip.rawValue ? ocProdLogUrl : acProdLogUrl
+    switch StartupMode.allValues[startUpModeForCurrentSession] {
+    case .OneCollector, .None, .Skip: return ocProdLogUrl
+    default: return acProdLogUrl
+    }
   }
   
   private func prodAppSecret() -> String {


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix default log url is https://mobile.events.data.microsoft.com when startup mode is "None" or "Skip" on iOS and mac demo apps.

## Related PRs or issues

 [#72260](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/72260)
