### PR TITLE
Fix targets initialization in iOS/macOS apps

### DIFF
--- a/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
@@ -73,8 +73,8 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
     self.startupModeField.tintColor = UIColor.clear
     
     // Make sure it is initialized before changing the startup mode.
-    // Otherwise channelGroup would be nil.
     // Do not initialize too early if we start from library later.
+    // Otherwise channelGroup would be nil.
     if (StartupMode.allValues[startupMode] != .Skip && StartupMode.allValues[startupMode] != .None) {
         _ = MSTransmissionTargets.shared
     }

--- a/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSMainViewController.swift
@@ -73,7 +73,11 @@ class MSMainViewController: UITableViewController, AppCenterProtocol {
     self.startupModeField.tintColor = UIColor.clear
     
     // Make sure it is initialized before changing the startup mode.
-    _ = MSTransmissionTargets.shared
+    // Otherwise channelGroup would be nil.
+    // Do not initialize too early if we start from library later.
+    if (StartupMode.allValues[startupMode] != .Skip && StartupMode.allValues[startupMode] != .None) {
+        _ = MSTransmissionTargets.shared
+    }
 
     // Storage size section.
     let storageMaxSize = UserDefaults.standard.object(forKey: kMSStorageMaxSizeKey) as? Int ?? kMSDefaultDatabaseSize

--- a/SasquatchMac/SasquatchMac/TransmissionTargets.swift
+++ b/SasquatchMac/SasquatchMac/TransmissionTargets.swift
@@ -18,7 +18,7 @@ class TransmissionTargets {
     case skip
   }
     
-  static let defaultTransmissionTargetIsEnabled: Bool = TransmissionTargets.startTarget == StartupMode.oneCollector.rawValue || startTarget == StartupMode.both.rawValue
+  static let defaultTransmissionTargetWasEnabled: Bool = TransmissionTargets.startTarget == StartupMode.oneCollector.rawValue || startTarget == StartupMode.both.rawValue
 
   private init() {
 

--- a/SasquatchMac/SasquatchMac/TransmissionTargets.swift
+++ b/SasquatchMac/SasquatchMac/TransmissionTargets.swift
@@ -7,9 +7,8 @@ private let kDefaultTargetKey = "defaultTargetKey"
 
 class TransmissionTargets {
   static let shared = TransmissionTargets.init()
-
+  static let startTarget = UserDefaults.standard.integer(forKey: kMSStartTargetKey)
   var transmissionTargets = [String: MSAnalyticsTransmissionTarget]()
-  let defaultTransmissionTargetIsEnabled: Bool
   private var sendsAnalyticsEvents = [String: Bool]()
   enum StartupMode: Int {
     case appCenter
@@ -18,12 +17,12 @@ class TransmissionTargets {
     case none
     case skip
   }
+    
+  static let defaultTransmissionTargetIsEnabled: Bool = TransmissionTargets.startTarget == StartupMode.oneCollector.rawValue || startTarget == StartupMode.both.rawValue
 
   private init() {
 
     // Default target.
-    let startTarget = UserDefaults.standard.integer(forKey: kMSStartTargetKey)
-    defaultTransmissionTargetIsEnabled = startTarget == StartupMode.oneCollector.rawValue || startTarget == StartupMode.both.rawValue
     sendsAnalyticsEvents[kDefaultTargetKey] = true
 
     // Parent target.

--- a/SasquatchMac/SasquatchMac/ViewControllers/TransmissionViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/TransmissionViewController.swift
@@ -41,14 +41,14 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
   dynamic var child2Properties = [EventProperty]()
 
   private class TransmissionTargetSection: NSObject {
-    static var defaultTransmissionTargetIsEnabled: Bool?
+    static var defaultTransmissionTargetWasEnabled: Bool?
 
     var token: String?
     var isDefault = false
 
     func isTransmissionTargetEnabled() -> Bool {
       if isDefault {
-        return TransmissionTargets.defaultTransmissionTargetIsEnabled
+        return TransmissionTargets.defaultTransmissionTargetWasEnabled
       } else {
         return getTransmissionTarget()?.isEnabled() ?? false
       }

--- a/SasquatchMac/SasquatchMac/ViewControllers/TransmissionViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/TransmissionViewController.swift
@@ -9,7 +9,8 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
   var transmissionTargetMapping: [String]?
   var propertyValues: [String: [String]]!
   var collectDeviceIdStates: [String: Bool]!
-
+  
+  static var targetsShared: TransmissionTargets?
   let kDeviceIdRow = 0
   let kAppNameRow = 1
   let kAppVersionRow = 2
@@ -47,9 +48,9 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
 
     func isTransmissionTargetEnabled() -> Bool {
       if isDefault {
-        return TransmissionTargets.shared.defaultTransmissionTargetIsEnabled
+        return TransmissionTargets.defaultTransmissionTargetIsEnabled
       } else {
-        return getTransmissionTarget()!.isEnabled()
+        return getTransmissionTarget()?.isEnabled() ?? false
       }
     }
 
@@ -63,21 +64,21 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
       if isDefault {
         return nil
       }
-      return TransmissionTargets.shared.transmissionTargets[token!]
+      return targetsShared?.transmissionTargets[token!]
     }
 
     func shouldSendAnalytics() -> Bool {
       if isDefault {
-        return TransmissionTargets.shared.defaultTargetShouldSendAnalyticsEvents()
+        return targetsShared?.defaultTargetShouldSendAnalyticsEvents() ?? false
       }
-      return TransmissionTargets.shared.targetShouldSendAnalyticsEvents(targetToken: token!)
+      return targetsShared?.targetShouldSendAnalyticsEvents(targetToken: token!) ?? false
     }
 
     func setShouldSendAnalytics(enabledState: Bool) {
       if isDefault {
-        TransmissionTargets.shared.setShouldDefaultTargetSendAnalyticsEvents(enabledState: enabledState)
+        targetsShared!.setShouldDefaultTargetSendAnalyticsEvents(enabledState: enabledState)
       } else {
-        TransmissionTargets.shared.setShouldSendAnalyticsEvents(targetToken: token!, enabledState: enabledState)
+        targetsShared!.setShouldSendAnalyticsEvents(targetToken: token!, enabledState: enabledState)
       }
     }
  
@@ -143,6 +144,15 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
 
   override func viewWillAppear() {
     appCenter.startAnalyticsFromLibrary()
+    
+    // We should initialize the targets only after starting from library,
+    // Otherwise channelGroup would be nil.
+    // After that we should reload tables data with actual "enabled" states.
+    TransmissionViewController.targetsShared = TransmissionTargets.shared
+    defaultTable.reloadData()
+    runtimeTable.reloadData()
+    child1Table.reloadData()
+    child2Table.reloadData()
   }
 
   override func viewDidLoad() {
@@ -426,7 +436,7 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
 
     // Update the transmission target.
     let selectedTarget = selectedTransmissionTarget(commonSelector)
-    let target = TransmissionTargets.shared.transmissionTargets[selectedTarget!]!
+    let target = TransmissionViewController.targetsShared!.transmissionTargets[selectedTarget!]!
     target.propertyConfigurator.collectDeviceId()
 
     // Update in memory state for display.
@@ -461,7 +471,7 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
   func propertyValueChanged(sender: NSTextField!) {
     let selectedTarget = selectedTransmissionTarget(commonSelector)
     let propertyIndex = getCellRow(forTextField: sender)
-    let target = TransmissionTargets.shared.transmissionTargets[selectedTarget!]!
+    let target = TransmissionViewController.targetsShared!.transmissionTargets[selectedTarget!]!
     propertyValues[selectedTarget!]![propertyIndex] = sender.stringValue
     let value = sender.stringValue.isEmpty ? nil as String! : sender.stringValue
     switch CommonSchemaPropertyRow(rawValue: propertyIndex - 1)! {
@@ -518,7 +528,7 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
     property.addObserver(self, forKeyPath: #keyPath(EventProperty.dateTime), options: .new, context: nil)
     arrayController.addObject(property)
     let selectedTarget = selectedTransmissionTarget(propertySelector)
-    let target = TransmissionTargets.shared.transmissionTargets[selectedTarget!]!
+    let target = TransmissionViewController.targetsShared!.transmissionTargets[selectedTarget!]!
     setEventPropertyState(property, forTarget: target)
 
     let propertyNoObserver = EventProperty()
@@ -558,7 +568,7 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
       arrayController.removeObject(selectedProperty)
       selectedProperty.removeObserver(self, forKeyPath: #keyPath(EventProperty.type), context: nil)
       let selectedTarget = selectedTransmissionTarget(propertySelector)
-      let target = TransmissionTargets.shared.transmissionTargets[selectedTarget!]!
+      let target = TransmissionViewController.targetsShared!.transmissionTargets[selectedTarget!]!
       target.propertyConfigurator.removeEventProperty(forKey: selectedProperty.key)
     }
   }
@@ -620,7 +630,7 @@ class TransmissionViewController: NSViewController, NSTableViewDataSource, NSTab
       break
     }
     let selectedTarget = transmissionTargetMapping![currentTarget]
-    let target = TransmissionTargets.shared.transmissionTargets[selectedTarget]!
+    let target = TransmissionViewController.targetsShared!.transmissionTargets[selectedTarget]!
     target.propertyConfigurator.removeEventProperty(forKey: key)
     setEventPropertyState(property, forTarget: target)
   }


### PR DESCRIPTION
* [X] Are the files formatted correctly?
* [X] Did you check UI tests on the sample app? They are not executed on CI.
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Problem: we were initialising transmission targets too early (before `startFromLibrary` call), as a result at the moment of initialisation there were no `channelGroup` to subscribe `propertyConfigurator` to.

_NOTE:_ on macOS, `startFromLibrary` is called in `viewWillAppear` (due to the fact that `viewDidLoad` is called for all the tabbed app at its start, and we need the logic of starting Analytics at **Transmission** tab only). 
It made the fix more complicated, because the start call at `viewWillAppear` and targets initialisation (which is required to load the table view and fill out `isEnabled` values) are performed concurrently, creating a "race condition". 
Fix: I had to move the target initialisation to `viewWillAppear`, after the start from library call, and then reload the tables again with the actual `isEnabled` values.

## Related PRs or issues

[AB#72259](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/72259)