### PR TITLE
Fix validating attachment size to avoid server error

### DIFF
--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -60,6 +60,8 @@ static NSString *const kMSTargetTokenFileExtension = @"targettoken";
 
 static unsigned int kMaxAttachmentsPerCrashReport = 2;
 
+static unsigned int kMaxAttachmentSize = 7 * 1024 * 1024;
+
 /**
  * Delay in nanoseconds before processing crashes.
  */
@@ -939,6 +941,10 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
     attachment.errorId = incidentIdentifier;
     if (![MSCrashes validatePropertiesForAttachment:attachment]) {
       MSLogError([MSCrashes logTag], @"Not all required fields are present in MSErrorAttachmentLog.");
+      continue;
+    }
+    if ([attachment data].length > kMaxAttachmentSize) {
+      MSLogError([MSCrashes logTag], @"Discarding attachment with size above %u bytes: size=%tu, fileName=%@.", kMaxAttachmentSize, [attachment data].length, [attachment filename]);
       continue;
     }
     [self.channelUnit enqueueItem:attachment flags:MSFlagsDefault];

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -944,7 +944,8 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
       continue;
     }
     if ([attachment data].length > kMaxAttachmentSize) {
-      MSLogError([MSCrashes logTag], @"Discarding attachment with size above %u bytes: size=%tu, fileName=%@.", kMaxAttachmentSize, [attachment data].length, [attachment filename]);
+      MSLogError([MSCrashes logTag], @"Discarding attachment with size above %u bytes: size=%tu, fileName=%@.", kMaxAttachmentSize,
+                 [attachment data].length, [attachment filename]);
       continue;
     }
     [self.channelUnit enqueueItem:attachment flags:MSFlagsDefault];

--- a/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
@@ -387,13 +387,15 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   NSString *validString = @"valid";
   NSData *validData = [validString dataUsingEncoding:NSUTF8StringEncoding];
   NSData *emptyData = [@"" dataUsingEncoding:NSUTF8StringEncoding];
+  NSMutableData *hugeData = [[NSMutableData alloc] initWithLength:7 * 1024 * 1024 + 1];
   NSArray *invalidLogs = @[
     [self attachmentWithAttachmentId:nil attachmentData:validData contentType:validString],
     [self attachmentWithAttachmentId:@"" attachmentData:validData contentType:validString],
     [self attachmentWithAttachmentId:validString attachmentData:nil contentType:validString],
     [self attachmentWithAttachmentId:validString attachmentData:emptyData contentType:validString],
     [self attachmentWithAttachmentId:validString attachmentData:validData contentType:nil],
-    [self attachmentWithAttachmentId:validString attachmentData:validData contentType:@""]
+    [self attachmentWithAttachmentId:validString attachmentData:validData contentType:@""],
+    [self attachmentWithAttachmentId:validString attachmentData:hugeData contentType:validString]
   ];
   id channelUnitMock = OCMProtocolMock(@protocol(MSChannelUnitProtocol));
   OCMStub([channelGroupMock addChannelUnitWithConfiguration:[OCMArg checkWithBlock:^BOOL(MSChannelUnitConfiguration *configuration) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 2.5.2 (Under development)
 
+### App Center Crashes
+
+* **[Fix]** Validate error attachment size to avoid server error or out of memory issues (using the documented limit which is 7MB).
+
 ___
 
 ## Version 2.5.1


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix validating attachment size to avoid server error

## Related PRs or issues

[AB#70760](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/70760)
