### PR TITLE
[iOS Sasquatch Puppet] Fix ingestion 404 error When send events on "OneCollector", "None" or "Skip" startup mode

### DIFF
--- a/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -60,6 +60,7 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   [MSAppCenter setLogLevel:MSLogLevelVerbose];
+  NSInteger startTarget = [[NSUserDefaults standardUserDefaults] integerForKey:kMSStartTargetKey];
 #if GCC_PREPROCESSOR_MACRO_PUPPET
   self.analyticsResult = [MSAnalyticsResult new];
   [MSAnalytics setDelegate:self];
@@ -69,7 +70,9 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
       [(MSAnalyticsViewController *)controller setAnalyticsResult:self.analyticsResult];
     }
   }
-  [MSAppCenter setLogUrl:kMSIntLogUrl];
+  if (startTarget == APPCENTER || startTarget == BOTH) {
+    [MSAppCenter setLogUrl:kMSIntLogUrl];
+  }
   [MSAuth setConfigUrl:kMSIntConfigUrl];
   [MSData setTokenExchangeUrl:kMSIntTokenExchangeUrl];
   [MSDistribute setApiUrl:kMSIntApiUrl];
@@ -125,7 +128,6 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
   // Start App Center SDK.
   NSArray<Class> *services =
       @ [[MSAnalytics class], [MSCrashes class], [MSData class], [MSDistribute class], [MSAuth class], [MSPush class]];
-  NSInteger startTarget = [[NSUserDefaults standardUserDefaults] integerForKey:kMSStartTargetKey];
 #if GCC_PREPROCESSOR_MACRO_PUPPET
   NSString *appSecret = [[NSUserDefaults standardUserDefaults] objectForKey:kMSAppSecret] ?: kMSPuppetAppSecret;
 #else


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
On SasquatchPuppet for iOS:

• Set to OneCollector/None/Skip startup mode.
• Restart.
• Send events from transmission targets
• => 404 because the logs are sent to the wrong endpoint

`setLogUrl` is called when UI is initialized with AppCenter INT url but this should not be done if the launch mode is OneCollector, None or Skip. 

## Related PRs or issues

[#73019](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/73019)
