### PR TITLE
Fix device info is attached to crashes

### DIFF
--- a/AppCenter/AppCenter/Internals/Context/Device/MSDeviceTracker.h
+++ b/AppCenter/AppCenter/Internals/Context/Device/MSDeviceTracker.h
@@ -23,7 +23,7 @@
 + (instancetype)sharedInstance;
 
 /**
- * Clears the device history in memory and in NSUserDefaults as well as the current device.
+ * Clears the device history in memory and in NSUserDefaults keeping the current device.
  */
 - (void)clearDevices;
 

--- a/AppCenter/AppCenter/Internals/Context/Device/MSDeviceTracker.m
+++ b/AppCenter/AppCenter/Internals/Context/Device/MSDeviceTracker.m
@@ -250,6 +250,7 @@ static MSDeviceTracker *sharedInstance = nil;
 
 - (void)clearDevices {
   @synchronized(self) {
+      
     // Remember the information about the current device.
     MSDeviceHistoryInfo *currentDeviceHistory = [[MSDeviceHistoryInfo alloc] initWithTimestamp:[NSDate date]
                                                                                      andDevice:self.device];
@@ -259,8 +260,10 @@ static MSDeviceTracker *sharedInstance = nil;
     [MS_USER_DEFAULTS setObject:[NSKeyedArchiver archivedDataWithRootObject:deviceHistory] forKey:kMSPastDevicesKey];
 
     // Clear cache.
-    self.device = nil;
     [self.deviceHistory removeAllObjects];
+
+    // Keep the latest information about the device in memory.
+    [self.deviceHistory addObject:currentDeviceHistory];
   }
 }
 

--- a/AppCenter/AppCenter/Internals/Context/Device/MSDeviceTracker.m
+++ b/AppCenter/AppCenter/Internals/Context/Device/MSDeviceTracker.m
@@ -250,9 +250,13 @@ static MSDeviceTracker *sharedInstance = nil;
 
 - (void)clearDevices {
   @synchronized(self) {
+    // Remember the information about the current device.
+    MSDeviceHistoryInfo *currentDeviceHistory = [[MSDeviceHistoryInfo alloc] initWithTimestamp:[NSDate date]
+                                                                                     andDevice:self.device];
+    NSArray* deviceHistory = [NSArray arrayWithObject:currentDeviceHistory];
 
-    // Clear persistence.
-    [MS_USER_DEFAULTS removeObjectForKey:kMSPastDevicesKey];
+    // Clear persistence, but keep the latest information about the device.
+    [MS_USER_DEFAULTS setObject:[NSKeyedArchiver archivedDataWithRootObject:deviceHistory] forKey:kMSPastDevicesKey];
 
     // Clear cache.
     self.device = nil;

--- a/AppCenter/AppCenter/Internals/Context/Device/MSDeviceTracker.m
+++ b/AppCenter/AppCenter/Internals/Context/Device/MSDeviceTracker.m
@@ -251,19 +251,16 @@ static MSDeviceTracker *sharedInstance = nil;
 - (void)clearDevices {
   @synchronized(self) {
       
-    // Remember the information about the current device.
-    MSDeviceHistoryInfo *currentDeviceHistory = [[MSDeviceHistoryInfo alloc] initWithTimestamp:[NSDate date]
-                                                                                     andDevice:self.device];
-    NSArray* deviceHistory = [NSArray arrayWithObject:currentDeviceHistory];
+    // Refresh current device info if needed before archive.
+    [self device];
+
+    // Clear information about the entire history, except for the current device.
+    if (self.deviceHistory.count > 1) {
+        [self.deviceHistory removeObjectsInRange: NSMakeRange(0, self.deviceHistory.count - 1)];
+    }
 
     // Clear persistence, but keep the latest information about the device.
-    [MS_USER_DEFAULTS setObject:[NSKeyedArchiver archivedDataWithRootObject:deviceHistory] forKey:kMSPastDevicesKey];
-
-    // Clear cache.
-    [self.deviceHistory removeAllObjects];
-
-    // Keep the latest information about the device in memory.
-    [self.deviceHistory addObject:currentDeviceHistory];
+    [MS_USER_DEFAULTS setObject:[NSKeyedArchiver archivedDataWithRootObject: self.deviceHistory] forKey:kMSPastDevicesKey];
   }
 }
 

--- a/AppCenter/AppCenter/Internals/Context/Device/MSDeviceTracker.m
+++ b/AppCenter/AppCenter/Internals/Context/Device/MSDeviceTracker.m
@@ -68,10 +68,10 @@ static MSDeviceTracker *sharedInstance = nil;
     // Create new array and create device info in case we don't have any from disk.
     if (_deviceHistory == nil) {
       _deviceHistory = [NSMutableArray<MSDeviceHistoryInfo *> new];
-
-      // This will instantiate the device property to make sure we have a history.
-      [self device];
     }
+
+    // This will instantiate the device property to make sure we have a history.
+    [self device];
   }
   return self;
 }
@@ -250,9 +250,6 @@ static MSDeviceTracker *sharedInstance = nil;
 
 - (void)clearDevices {
   @synchronized(self) {
-      
-    // Refresh current device info if needed before archive.
-    [self device];
 
     // Clear information about the entire history, except for the current device.
     if (self.deviceHistory.count > 1) {

--- a/AppCenter/AppCenterTests/MSDeviceTrackerTests.m
+++ b/AppCenter/AppCenterTests/MSDeviceTrackerTests.m
@@ -467,6 +467,21 @@ static NSString *const kMSDeviceManufacturerTest = @"Apple";
   XCTAssertNotEqual(expected, self.sut.device);
 }
 
+- (void) testLastDeviceHistorySaved {
+    MSMockUserDefaults *defaults = [MSMockUserDefaults new];
+
+    // If the storage is empty, remember the current device.
+    [self.sut device];
+
+    // When
+    [self.sut clearDevices];
+
+    // Then
+    XCTAssertNotNil([defaults objectForKey:kMSPastDevicesKey]);
+
+    [defaults stopMocking];
+}
+
 - (void)testClearingDeviceHistoryWorks {
 
   MSMockUserDefaults *defaults = [MSMockUserDefaults new];

--- a/AppCenter/AppCenterTests/MSDeviceTrackerTests.m
+++ b/AppCenter/AppCenterTests/MSDeviceTrackerTests.m
@@ -467,34 +467,17 @@ static NSString *const kMSDeviceManufacturerTest = @"Apple";
   XCTAssertNotEqual(expected, self.sut.device);
 }
 
-- (void) testLastDeviceHistorySaved {
-    MSMockUserDefaults *defaults = [MSMockUserDefaults new];
-
-    // If the storage is empty, remember the current device.
-    [self.sut device];
-
-    // When
-    [self.sut clearDevices];
-
-    // Then
-    XCTAssertNotNil([defaults objectForKey:kMSPastDevicesKey]);
-
-    [defaults stopMocking];
-}
-
 - (void)testClearingDeviceHistoryWorks {
 
   MSMockUserDefaults *defaults = [MSMockUserDefaults new];
 
   // When
+  // If the storage is empty, remember the current device.
+  [self.sut device];
   [self.sut clearDevices];
 
   // Then
   XCTAssertTrue([self.sut.deviceHistory count] == 0);
-  XCTAssertNil([defaults objectForKey:kMSPastDevicesKey]);
-
-  // When
-  [self.sut device];
   XCTAssertNotNil([defaults objectForKey:kMSPastDevicesKey]);
 
   [defaults stopMocking];

--- a/AppCenter/AppCenterTests/MSDeviceTrackerTests.m
+++ b/AppCenter/AppCenterTests/MSDeviceTrackerTests.m
@@ -467,17 +467,34 @@ static NSString *const kMSDeviceManufacturerTest = @"Apple";
   XCTAssertNotEqual(expected, self.sut.device);
 }
 
+- (void)testNSUserDefaultsDeviceHistory {
+    MSMockUserDefaults *defaults = [MSMockUserDefaults new];
+
+    // When
+    [self.sut clearDevices];
+
+    // Restore past devices from NSUserDefaults.
+    NSData *devices = [defaults objectForKey:kMSPastDevicesKey];
+    NSArray *arrayFromData = [NSKeyedUnarchiver unarchiveObjectWithData:devices];
+
+    NSMutableArray<MSDeviceHistoryInfo *> *deviceHistory = [NSMutableArray arrayWithArray:arrayFromData];
+
+    // Then
+    XCTAssertTrue([deviceHistory count] == 1);
+
+    [defaults stopMocking];
+}
+
 - (void)testClearingDeviceHistoryWorks {
 
   MSMockUserDefaults *defaults = [MSMockUserDefaults new];
 
   // When
   // If the storage is empty, remember the current device.
-  [self.sut device];
   [self.sut clearDevices];
 
   // Then
-  XCTAssertTrue([self.sut.deviceHistory count] == 0);
+  XCTAssertTrue([self.sut.deviceHistory count] == 1);
   XCTAssertNotNil([defaults objectForKey:kMSPastDevicesKey]);
 
   [defaults stopMocking];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### App Center Crashes
 
 * **[Fix]** Fix sending crashes if an application is launched in background.
-* **[Fix]** Fix sending device info is attached to crashes.
+* **[Fix]** Fix an issue where the information attached to the error contains incorrect information about the device.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * **[Fix]** Fix sending crashes if an application is launched in background.
 * **[Fix]** Validate error attachment size to avoid server error or out of memory issues (using the documented limit which is 7MB).
-* **[Fix]** Fix an issue where crash might contain incorrect data if there was a 2nd crash in a row in the previous version of the application.
+* **[Fix]** Fix an issue where crash might contain incorrect data if two consecutive crashes occurred in a previous version of the application.
 
 ### App Center Distribute
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * **[Fix]** Fix sending crashes if an application is launched in background.
 * **[Fix]** Validate error attachment size to avoid server error or out of memory issues (using the documented limit which is 7MB).
-* **[Fix]** Fix an issue where the information attached to the error contains incorrect information about the device.
+* **[Fix]** Fix an issue where crash might contain incorrect data if there was a 2nd crash in a row in the previous version of the application.
 
 ___
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fix device info is attached to crashes.
After reading the crash reporter's logs, we link a specific log and a device from the history and after we're deleting the entire history of the devices from storage. We need to save the information about the last device so that we can always link the last log to the device on which the crash occurred.
Actions that caused the error (Before fix):
1. Run the application, invoke the crash
2. Restart the application (AppCenter will try to find crash, link his information with the device from the history and clear the entire history of the devices)
3. Cause the app to crash again
4. Upgrade your app version
5. Restart the application (AppCenter will try to link the crash with the device from the history, but the history has been cleared and we will take the device with an updated version of the application, which is incorrect)

## Related PRs or issues

[[AB#70439](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/70439)]