### PR TITLE
Fix/handle keychain errors

### DIFF
--- a/AppCenter/AppCenter/Internals/Util/MSEncrypter.m
+++ b/AppCenter/AppCenter/Internals/Util/MSEncrypter.m
@@ -142,7 +142,7 @@ static NSObject *const classLock;
   }
 
   // If key is not in memory; try loading it from Keychain.
-  NSString *stringKey = [MSKeychainUtil stringForKey:keyTag];
+  NSString *stringKey = [MSKeychainUtil stringForKey:keyTag withStatusCode:nil];
   if (stringKey) {
     keyData = [[NSData alloc] initWithBase64EncodedString:stringKey options:0];
   } else {
@@ -151,7 +151,7 @@ static NSObject *const classLock;
     @synchronized(classLock) {
 
       // Recheck if the key has been written from another thread.
-      stringKey = [MSKeychainUtil stringForKey:keyTag];
+      stringKey = [MSKeychainUtil stringForKey:keyTag withStatusCode:nil];
       if (!stringKey) {
         keyData = [MSEncrypter generateAndSaveKeyWithTag:keyTag];
       }

--- a/AppCenter/AppCenter/Internals/Util/MSEncrypter.m
+++ b/AppCenter/AppCenter/Internals/Util/MSEncrypter.m
@@ -142,7 +142,7 @@ static NSObject *const classLock;
   }
 
   // If key is not in memory; try loading it from Keychain.
-  NSString *stringKey = [MSKeychainUtil stringForKey:keyTag withStatusCode:nil];
+  NSString *stringKey = [MSKeychainUtil stringForKey:keyTag statusCode:nil];
   if (stringKey) {
     keyData = [[NSData alloc] initWithBase64EncodedString:stringKey options:0];
   } else {
@@ -151,7 +151,7 @@ static NSObject *const classLock;
     @synchronized(classLock) {
 
       // Recheck if the key has been written from another thread.
-      stringKey = [MSKeychainUtil stringForKey:keyTag withStatusCode:nil];
+      stringKey = [MSKeychainUtil stringForKey:keyTag statusCode:nil];
       if (!stringKey) {
         keyData = [MSEncrypter generateAndSaveKeyWithTag:keyTag];
       }

--- a/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.h
+++ b/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A string data if exists.
  */
-+ (NSString *_Nullable)stringForKey:(NSString *)key;
++ (NSString *_Nullable)stringForKey:(NSString *)key withStatusCode:(OSStatus *_Nullable)statusCode;
 
 /**
  * Clear all keys and strings.

--- a/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.h
+++ b/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return A string data if exists.
  */
-+ (NSString *_Nullable)stringForKey:(NSString *)key withStatusCode:(OSStatus *_Nullable)statusCode;
++ (NSString *_Nullable)stringForKey:(NSString *)key statusCode:(OSStatus *_Nullable)statusCode;
 
 /**
  * Clear all keys and strings.

--- a/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
+++ b/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
@@ -37,7 +37,7 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
     return YES;
   }
   MSLogWarning([MSAppCenter logTag], @"Failed to store item with key='%@', service='%@' to keychain. OS Status code %i", key, serviceName,
-               status);
+               (int)status);
   return NO;
 }
 
@@ -55,7 +55,7 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
       return string;
     }
     MSLogWarning([MSAppCenter logTag], @"Failed to delete item with key='%@', service='%@' from keychain. OS Status code %i", key,
-                 serviceName, status);
+                 serviceName, (int)status);
   }
   return nil;
 }
@@ -82,7 +82,7 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
     return [[NSString alloc] initWithData:(__bridge_transfer NSData *)result encoding:NSUTF8StringEncoding];
   }
   MSLogWarning([MSAppCenter logTag], @"Failed to retrieve item with key='%@', service='%@' from keychain. OS Status code %i", key,
-               serviceName, *statusCode);
+               serviceName, (int)*statusCode);
   return nil;
 }
 

--- a/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
+++ b/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
@@ -19,6 +19,9 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
 
 + (BOOL)storeString:(NSString *)string forKey:(NSString *)key withServiceName:(NSString *)serviceName {
   NSMutableDictionary *attributes = [MSKeychainUtil generateItem:key withServiceName:serviceName];
+  
+  // By default the keychain is not accessible when the device is locked, this will make it accessible after the first unlock.
+  attributes[(__bridge id)kSecAttrAccessible] = (__bridge id)(kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly);
   attributes[(__bridge id)kSecValueData] = [string dataUsingEncoding:NSUTF8StringEncoding];
   OSStatus status = [self addSecItem:attributes];
 

--- a/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
+++ b/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
@@ -36,7 +36,8 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
     MSLogVerbose([MSAppCenter logTag], @"Stored a string with key='%@', service='%@' to keychain.", key, serviceName);
     return YES;
   }
-  MSLogWarning([MSAppCenter logTag], @"Failed to store item with key='%@', service='%@' to keychain. OS Status code %i", key, serviceName, status);
+  MSLogWarning([MSAppCenter logTag], @"Failed to store item with key='%@', service='%@' to keychain. OS Status code %i", key, serviceName,
+               status);
   return NO;
 }
 
@@ -53,7 +54,8 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
       MSLogVerbose([MSAppCenter logTag], @"Deleted a string with key='%@', service='%@' from keychain.", key, serviceName);
       return string;
     }
-    MSLogWarning([MSAppCenter logTag], @"Failed to delete item with key='%@', service='%@' from keychain. OS Status code %i", key, serviceName, status);
+    MSLogWarning([MSAppCenter logTag], @"Failed to delete item with key='%@', service='%@' from keychain. OS Status code %i", key,
+                 serviceName, status);
   }
   return nil;
 }
@@ -79,7 +81,8 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
     MSLogVerbose([MSAppCenter logTag], @"Retrieved a string with key='%@', service='%@' from keychain.", key, serviceName);
     return [[NSString alloc] initWithData:(__bridge_transfer NSData *)result encoding:NSUTF8StringEncoding];
   }
-  MSLogWarning([MSAppCenter logTag], @"Failed to retrieve item with key='%@', service='%@' from keychain. OS Status code %i", key, serviceName, *statusCode);
+  MSLogWarning([MSAppCenter logTag], @"Failed to retrieve item with key='%@', service='%@' from keychain. OS Status code %i", key,
+               serviceName, *statusCode);
   return nil;
 }
 

--- a/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
+++ b/AppCenter/AppCenter/Internals/Util/MSKeychainUtil.m
@@ -46,7 +46,7 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
 }
 
 + (NSString *)deleteStringForKey:(NSString *)key withServiceName:(NSString *)serviceName {
-  NSString *string = [MSKeychainUtil stringForKey:key withStatusCode:nil];
+  NSString *string = [MSKeychainUtil stringForKey:key statusCode:nil];
   if (string) {
     NSMutableDictionary *query = [MSKeychainUtil generateItem:key withServiceName:serviceName];
     OSStatus status = [self deleteSecItem:query];
@@ -64,14 +64,13 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
   return [MSKeychainUtil deleteStringForKey:key withServiceName:AppCenterKeychainServiceName(kMSServiceSuffix)];
 }
 
-+ (NSString *)stringForKey:(NSString *)key withServiceName:(NSString *)serviceName withStatusCode:(OSStatus *)statusCode {
++ (NSString *)stringForKey:(NSString *)key withServiceName:(NSString *)serviceName statusCode:(OSStatus *)statusCode {
   NSMutableDictionary *query = [MSKeychainUtil generateItem:key withServiceName:serviceName];
   query[(__bridge id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
   query[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
   CFTypeRef result = nil;
 
-  // Create placeholder to use in case given status code pointer is NULL. Can't put it inside the if statement or it can get deallocated too
-  // early.
+  // Create placeholder to use in case given status code pointer is NULL. Can't put it inside the if statement or it can get deallocated too early.
   OSStatus statusPlaceholder;
   if (!statusCode) {
     statusCode = &statusPlaceholder;
@@ -86,8 +85,8 @@ static NSString *AppCenterKeychainServiceName(NSString *suffix) {
   return nil;
 }
 
-+ (NSString *)stringForKey:(NSString *)key withStatusCode:(OSStatus *)statusCode {
-  return [MSKeychainUtil stringForKey:key withServiceName:AppCenterKeychainServiceName(kMSServiceSuffix) withStatusCode:statusCode];
++ (NSString *)stringForKey:(NSString *)key statusCode:(OSStatus *)statusCode {
+  return [MSKeychainUtil stringForKey:key withServiceName:AppCenterKeychainServiceName(kMSServiceSuffix) statusCode:statusCode];
 }
 
 + (BOOL)clear {

--- a/AppCenter/AppCenter/Internals/Util/MSKeychainUtilPrivate.h
+++ b/AppCenter/AppCenter/Internals/Util/MSKeychainUtilPrivate.h
@@ -44,7 +44,7 @@ static NSString *const kMSServiceSuffix = @"AppCenter";
  *
  * @return A string data if exists.
  */
-+ (NSString *_Nullable)stringForKey:(NSString *)key withServiceName:(NSString *)serviceName;
++ (NSString *_Nullable)stringForKey:(NSString *)key withServiceName:(NSString *)serviceName withStatusCode:(OSStatus *_Nullable)statusCode;
 
 /**
  * Deletes items that match a search query.

--- a/AppCenter/AppCenter/Internals/Util/MSKeychainUtilPrivate.h
+++ b/AppCenter/AppCenter/Internals/Util/MSKeychainUtilPrivate.h
@@ -44,7 +44,7 @@ static NSString *const kMSServiceSuffix = @"AppCenter";
  *
  * @return A string data if exists.
  */
-+ (NSString *_Nullable)stringForKey:(NSString *)key withServiceName:(NSString *)serviceName withStatusCode:(OSStatus *_Nullable)statusCode;
++ (NSString *_Nullable)stringForKey:(NSString *)key withServiceName:(NSString *)serviceName statusCode:(OSStatus *_Nullable)statusCode;
 
 /**
  * Deletes items that match a search query.

--- a/AppCenter/AppCenterTests/MSKeychainUtilTests.m
+++ b/AppCenter/AppCenterTests/MSKeychainUtilTests.m
@@ -60,7 +60,7 @@
 
   // When
   [MSKeychainUtil storeString:value forKey:key];
-  [MSKeychainUtil stringForKey:key withStatusCode:nil];
+  [MSKeychainUtil stringForKey:key statusCode:nil];
   [MSKeychainUtil deleteStringForKey:key];
 
   // Then
@@ -76,7 +76,7 @@
 
   // When
   OSStatus statusReceived;
-  NSString *result = [MSKeychainUtil stringForKey:key withStatusCode:&statusReceived];
+  NSString *result = [MSKeychainUtil stringForKey:key statusCode:&statusReceived];
 
   // Then
   XCTAssertNil(result);
@@ -91,7 +91,7 @@
   OCMStub([self.keychainUtilMock secItemCopyMatchingQuery:[OCMArg any] result:[OCMArg anyPointer]]).andReturn(statusExpected);
 
   // When
-  NSString *result = [MSKeychainUtil stringForKey:key withStatusCode:nil];
+  NSString *result = [MSKeychainUtil stringForKey:key statusCode:nil];
 
   // Then
   XCTAssertNil(result);

--- a/AppCenter/AppCenterTests/MSKeychainUtilTests.m
+++ b/AppCenter/AppCenterTests/MSKeychainUtilTests.m
@@ -59,7 +59,7 @@
 
   // When
   [MSKeychainUtil storeString:value forKey:key];
-  [MSKeychainUtil stringForKey:key];
+  [MSKeychainUtil stringForKey:key withStatusCode:nil];
   [MSKeychainUtil deleteStringForKey:key];
 
   // Then

--- a/AppCenter/AppCenterTests/MSKeychainUtilTests.m
+++ b/AppCenter/AppCenterTests/MSKeychainUtilTests.m
@@ -67,6 +67,36 @@
   OCMVerifyAll(self.keychainUtilMock);
 }
 
+- (void)testKeychainGetStringSetsError {
+
+  // If
+  NSString *key = @"Test Key";
+  OSStatus statusExpected = errSecNoAccessForItem;
+  OCMStub([self.keychainUtilMock secItemCopyMatchingQuery:[OCMArg any] result:[OCMArg anyPointer]]).andReturn(statusExpected);
+
+  // When
+  OSStatus statusReceived;
+  NSString *result = [MSKeychainUtil stringForKey:key withStatusCode:&statusReceived];
+
+  // Then
+  XCTAssertNil(result);
+  XCTAssertEqual(statusReceived, statusExpected);
+}
+
+- (void)testKeychainGetStringAllowsNilErrorArgument {
+
+  // If
+  NSString *key = @"Test Key";
+  OSStatus statusExpected = errSecNoAccessForItem;
+  OCMStub([self.keychainUtilMock secItemCopyMatchingQuery:[OCMArg any] result:[OCMArg anyPointer]]).andReturn(statusExpected);
+
+  // When
+  NSString *result = [MSKeychainUtil stringForKey:key withStatusCode:nil];
+
+  // Then
+  XCTAssertNil(result);
+}
+
 - (void)testStoreStringHandlesDuplicateItemError {
 
   // If

--- a/AppCenter/AppCenterTests/MSKeychainUtilTests.m
+++ b/AppCenter/AppCenterTests/MSKeychainUtilTests.m
@@ -34,7 +34,8 @@
     (__bridge id)kSecAttrService : self.acServiceName,
     (__bridge id)kSecClass : @"genp",
     (__bridge id)kSecAttrAccount : key,
-    (__bridge id)kSecValueData : (NSData * _Nonnull)[value dataUsingEncoding:NSUTF8StringEncoding]
+    (__bridge id)kSecValueData : (NSData * _Nonnull)[value dataUsingEncoding:NSUTF8StringEncoding],
+    (__bridge id)kSecAttrAccessible : (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
   };
   NSDictionary *expectedDeleteItemQuery =
       @{(__bridge id)kSecAttrService : self.acServiceName, (__bridge id)kSecClass : @"genp", (__bridge id)kSecAttrAccount : key};
@@ -43,7 +44,7 @@
     (__bridge id)kSecClass : @"genp",
     (__bridge id)kSecAttrAccount : key,
     (__bridge id)kSecReturnData : (__bridge id)kCFBooleanTrue,
-    (__bridge id)kSecMatchLimit : (__bridge id)kSecMatchLimitOne
+    (__bridge id)kSecMatchLimit : (__bridge id)kSecMatchLimitOne,
   };
 
   // Expect these stubbed calls.

--- a/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.h
+++ b/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.h
@@ -4,4 +4,7 @@
 #import "MSKeychainUtil.h"
 
 @interface MSMockKeychainUtil : MSKeychainUtil
+
++ (void)mockStatusCode:(OSStatus)statusCode forKey:(NSString *)key;
+
 @end

--- a/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.m
+++ b/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.m
@@ -105,6 +105,7 @@ static NSString *kMSDefaultServiceName = @"DefaultServiceName";
 - (void)stopMocking {
   [stringsDictionary removeAllObjects];
   [arraysDictionary removeAllObjects];
+  [statusCodes removeAllObjects];
   [self.mockKeychainUtil stopMocking];
 }
 

--- a/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.m
+++ b/AppCenter/AppCenterTests/Util/MSMockKeychainUtil.m
@@ -35,10 +35,10 @@ static NSString *kMSDefaultServiceName = @"DefaultServiceName";
     OCMStub([_mockKeychainUtil deleteStringForKey:[OCMArg any]]).andCall([self class], @selector(deleteStringForKey:));
     OCMStub([_mockKeychainUtil deleteStringForKey:[OCMArg any] withServiceName:[OCMArg any]])
         .andCall([self class], @selector(deleteStringForKey:withServiceName:));
-    OCMStub([_mockKeychainUtil stringForKey:[OCMArg any] withStatusCode:[OCMArg anyPointer]])
-        .andCall([self class], @selector(stringForKey:withStatusCode:));
-    OCMStub([_mockKeychainUtil stringForKey:[OCMArg any] withServiceName:[OCMArg any] withStatusCode:[OCMArg anyPointer]])
-        .andCall([self class], @selector(stringForKey:withServiceName:withStatusCode:));
+    OCMStub([_mockKeychainUtil stringForKey:[OCMArg any] statusCode:[OCMArg anyPointer]])
+        .andCall([self class], @selector(stringForKey:statusCode:));
+    OCMStub([_mockKeychainUtil stringForKey:[OCMArg any] withServiceName:[OCMArg any] statusCode:[OCMArg anyPointer]])
+        .andCall([self class], @selector(stringForKey:withServiceName:statusCode:));
     OCMStub([_mockKeychainUtil clear]).andCall([self class], @selector(clear));
   }
   return self;
@@ -71,11 +71,11 @@ static NSString *kMSDefaultServiceName = @"DefaultServiceName";
   return value;
 }
 
-+ (NSString *_Nullable)stringForKey:(NSString *)key withStatusCode:(OSStatus *)statusCode {
-  return [self stringForKey:key withServiceName:kMSDefaultServiceName withStatusCode:statusCode];
++ (NSString *_Nullable)stringForKey:(NSString *)key statusCode:(OSStatus *)statusCode {
+  return [self stringForKey:key withServiceName:kMSDefaultServiceName statusCode:statusCode];
 }
 
-+ (NSString *_Nullable)stringForKey:(NSString *)key withServiceName:(NSString *)serviceName withStatusCode:(OSStatus *)statusCode {
++ (NSString *_Nullable)stringForKey:(NSString *)key withServiceName:(NSString *)serviceName statusCode:(OSStatus *)statusCode {
   OSStatus placeholderStatus = noErr;
   if (statusCodes[serviceName] && statusCodes[serviceName][key]) {
     placeholderStatus = [statusCodes[serviceName][key] intValue];

--- a/AppCenterData/AppCenterData/Internal/Client/MSTokenExchange.m
+++ b/AppCenterData/AppCenterData/Internal/Client/MSTokenExchange.m
@@ -174,7 +174,7 @@ static NSString *const kMSGetTokenPath = @"/data/tokens";
 
 + (MSTokenResult *_Nullable)retrieveCachedTokenForPartition:(NSString *)partition includeExpiredToken:(BOOL)includeExpiredToken {
   if (partition) {
-    NSString *tokenString = [MSKeychainUtil stringForKey:[MSTokenExchange tokenKeyNameForPartition:partition]];
+    NSString *tokenString = [MSKeychainUtil stringForKey:[MSTokenExchange tokenKeyNameForPartition:partition] withStatusCode:nil];
     if (tokenString) {
       MSTokenResult *tokenResult = [[MSTokenResult alloc] initWithString:tokenString];
       NSDate *currentUTCDate = [NSDate date];

--- a/AppCenterData/AppCenterData/Internal/Client/MSTokenExchange.m
+++ b/AppCenterData/AppCenterData/Internal/Client/MSTokenExchange.m
@@ -174,7 +174,7 @@ static NSString *const kMSGetTokenPath = @"/data/tokens";
 
 + (MSTokenResult *_Nullable)retrieveCachedTokenForPartition:(NSString *)partition includeExpiredToken:(BOOL)includeExpiredToken {
   if (partition) {
-    NSString *tokenString = [MSKeychainUtil stringForKey:[MSTokenExchange tokenKeyNameForPartition:partition] withStatusCode:nil];
+    NSString *tokenString = [MSKeychainUtil stringForKey:[MSTokenExchange tokenKeyNameForPartition:partition] statusCode:nil];
     if (tokenString) {
       MSTokenResult *tokenResult = [[MSTokenResult alloc] initWithString:tokenString];
       NSDate *currentUTCDate = [NSDate date];

--- a/AppCenterData/AppCenterDataTests/MSTokenExchangeTests.m
+++ b/AppCenterData/AppCenterDataTests/MSTokenExchangeTests.m
@@ -114,7 +114,7 @@ static NSString *const kMSStorageUserDbTokenKey = @"MSStorageUserDbToken";
 
                                  // Then
                                  XCTAssertEqualObjects([returnedTokenResult serializeToString],
-                                                       [MSKeychainUtil stringForKey:kMSMockTokenKeyName withStatusCode:nil]);
+                                                       [MSKeychainUtil stringForKey:kMSMockTokenKeyName statusCode:nil]);
                                  XCTAssertEqualObjects(actualHeaders[@"Authorization"], @"Bearer fake-token");
                                  XCTAssertEqualObjects(actualHeaders[@"Content-Type"], @"application/json");
                                  XCTAssertEqualObjects(actualHeaders[@"App-Secret"], @"appSecret");
@@ -273,7 +273,7 @@ static NSString *const kMSStorageUserDbTokenKey = @"MSStorageUserDbToken";
 
                                  // Then
                                  XCTAssertEqualObjects([returnedTokenResult serializeToString],
-                                                       [MSKeychainUtil stringForKey:kMSMockTokenKeyName withStatusCode:nil]);
+                                                       [MSKeychainUtil stringForKey:kMSMockTokenKeyName statusCode:nil]);
                                  XCTAssertNil(actualHeaders[@"Authorization"]);
                                  XCTAssertEqualObjects(actualHeaders[@"Content-Type"], @"application/json");
                                  XCTAssertEqualObjects(actualHeaders[@"App-Secret"], @"appSecret");
@@ -574,7 +574,7 @@ static NSString *const kMSStorageUserDbTokenKey = @"MSStorageUserDbToken";
   [MSTokenExchange saveToken:nil];
 
   // Then
-  XCTAssertNil([MSKeychainUtil stringForKey:kMSMockTokenKeyName withStatusCode:nil]);
+  XCTAssertNil([MSKeychainUtil stringForKey:kMSMockTokenKeyName statusCode:nil]);
 }
 
 - (void)testSaveTokenFailsWithoutPartition {
@@ -591,7 +591,7 @@ static NSString *const kMSStorageUserDbTokenKey = @"MSStorageUserDbToken";
   [MSTokenExchange saveToken:mockResult];
 
   // Then
-  XCTAssertNil([MSKeychainUtil stringForKey:kMSMockTokenKeyName withStatusCode:nil]);
+  XCTAssertNil([MSKeychainUtil stringForKey:kMSMockTokenKeyName statusCode:nil]);
 }
 
 - (void)testRemoveAllTokens {
@@ -599,15 +599,15 @@ static NSString *const kMSStorageUserDbTokenKey = @"MSStorageUserDbToken";
   // If
   [MSKeychainUtil storeString:@"a" forKey:kMSStorageReadOnlyDbTokenKey];
   [MSKeychainUtil storeString:@"a" forKey:kMSStorageUserDbTokenKey];
-  XCTAssertNotNil([MSKeychainUtil stringForKey:kMSStorageReadOnlyDbTokenKey withStatusCode:nil]);
-  XCTAssertNotNil([MSKeychainUtil stringForKey:kMSStorageUserDbTokenKey withStatusCode:nil]);
+  XCTAssertNotNil([MSKeychainUtil stringForKey:kMSStorageReadOnlyDbTokenKey statusCode:nil]);
+  XCTAssertNotNil([MSKeychainUtil stringForKey:kMSStorageUserDbTokenKey statusCode:nil]);
 
   // When
   [MSTokenExchange removeAllCachedTokens];
 
   // Then
-  XCTAssertNil([MSKeychainUtil stringForKey:kMSStorageReadOnlyDbTokenKey withStatusCode:nil]);
-  XCTAssertNil([MSKeychainUtil stringForKey:kMSStorageUserDbTokenKey withStatusCode:nil]);
+  XCTAssertNil([MSKeychainUtil stringForKey:kMSStorageReadOnlyDbTokenKey statusCode:nil]);
+  XCTAssertNil([MSKeychainUtil stringForKey:kMSStorageUserDbTokenKey statusCode:nil]);
 }
 
 - (void)testTokenKeyNameForPartitionReturnsReadOnlyKey {

--- a/AppCenterData/AppCenterDataTests/MSTokenExchangeTests.m
+++ b/AppCenterData/AppCenterDataTests/MSTokenExchangeTests.m
@@ -114,7 +114,7 @@ static NSString *const kMSStorageUserDbTokenKey = @"MSStorageUserDbToken";
 
                                  // Then
                                  XCTAssertEqualObjects([returnedTokenResult serializeToString],
-                                                       [MSKeychainUtil stringForKey:kMSMockTokenKeyName]);
+                                                       [MSKeychainUtil stringForKey:kMSMockTokenKeyName withStatusCode:nil]);
                                  XCTAssertEqualObjects(actualHeaders[@"Authorization"], @"Bearer fake-token");
                                  XCTAssertEqualObjects(actualHeaders[@"Content-Type"], @"application/json");
                                  XCTAssertEqualObjects(actualHeaders[@"App-Secret"], @"appSecret");
@@ -273,7 +273,7 @@ static NSString *const kMSStorageUserDbTokenKey = @"MSStorageUserDbToken";
 
                                  // Then
                                  XCTAssertEqualObjects([returnedTokenResult serializeToString],
-                                                       [MSKeychainUtil stringForKey:kMSMockTokenKeyName]);
+                                                       [MSKeychainUtil stringForKey:kMSMockTokenKeyName withStatusCode:nil]);
                                  XCTAssertNil(actualHeaders[@"Authorization"]);
                                  XCTAssertEqualObjects(actualHeaders[@"Content-Type"], @"application/json");
                                  XCTAssertEqualObjects(actualHeaders[@"App-Secret"], @"appSecret");
@@ -574,7 +574,7 @@ static NSString *const kMSStorageUserDbTokenKey = @"MSStorageUserDbToken";
   [MSTokenExchange saveToken:nil];
 
   // Then
-  XCTAssertNil([MSKeychainUtil stringForKey:kMSMockTokenKeyName]);
+  XCTAssertNil([MSKeychainUtil stringForKey:kMSMockTokenKeyName withStatusCode:nil]);
 }
 
 - (void)testSaveTokenFailsWithoutPartition {
@@ -591,7 +591,7 @@ static NSString *const kMSStorageUserDbTokenKey = @"MSStorageUserDbToken";
   [MSTokenExchange saveToken:mockResult];
 
   // Then
-  XCTAssertNil([MSKeychainUtil stringForKey:kMSMockTokenKeyName]);
+  XCTAssertNil([MSKeychainUtil stringForKey:kMSMockTokenKeyName withStatusCode:nil]);
 }
 
 - (void)testRemoveAllTokens {
@@ -599,15 +599,15 @@ static NSString *const kMSStorageUserDbTokenKey = @"MSStorageUserDbToken";
   // If
   [MSKeychainUtil storeString:@"a" forKey:kMSStorageReadOnlyDbTokenKey];
   [MSKeychainUtil storeString:@"a" forKey:kMSStorageUserDbTokenKey];
-  XCTAssertNotNil([MSKeychainUtil stringForKey:kMSStorageReadOnlyDbTokenKey]);
-  XCTAssertNotNil([MSKeychainUtil stringForKey:kMSStorageUserDbTokenKey]);
+  XCTAssertNotNil([MSKeychainUtil stringForKey:kMSStorageReadOnlyDbTokenKey withStatusCode:nil]);
+  XCTAssertNotNil([MSKeychainUtil stringForKey:kMSStorageUserDbTokenKey withStatusCode:nil]);
 
   // When
   [MSTokenExchange removeAllCachedTokens];
 
   // Then
-  XCTAssertNil([MSKeychainUtil stringForKey:kMSStorageReadOnlyDbTokenKey]);
-  XCTAssertNil([MSKeychainUtil stringForKey:kMSStorageUserDbTokenKey]);
+  XCTAssertNil([MSKeychainUtil stringForKey:kMSStorageReadOnlyDbTokenKey withStatusCode:nil]);
+  XCTAssertNil([MSKeychainUtil stringForKey:kMSStorageUserDbTokenKey withStatusCode:nil]);
 }
 
 - (void)testTokenKeyNameForPartitionReturnsReadOnlyKey {

--- a/AppCenterDistribute/AppCenterDistribute/Internals/MSDistributeDataMigration.m
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/MSDistributeDataMigration.m
@@ -12,8 +12,8 @@
 
   // Migrate Mobile Center update token.
   NSString *mcServiceName = [NSString stringWithFormat:@"%@.%@", [MS_APP_MAIN_BUNDLE bundleIdentifier], @"MobileCenter"];
-  NSString *mcUpdateToken = [MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName withStatusCode:nil];
-  NSString *acUpdateToken = [MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil];
+  NSString *mcUpdateToken = [MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName statusCode:nil];
+  NSString *acUpdateToken = [MSKeychainUtil stringForKey:kMSUpdateTokenKey statusCode:nil];
   if (!acUpdateToken && mcUpdateToken) {
     [MSKeychainUtil storeString:mcUpdateToken forKey:kMSUpdateTokenKey];
   }

--- a/AppCenterDistribute/AppCenterDistribute/Internals/MSDistributeDataMigration.m
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/MSDistributeDataMigration.m
@@ -12,8 +12,8 @@
 
   // Migrate Mobile Center update token.
   NSString *mcServiceName = [NSString stringWithFormat:@"%@.%@", [MS_APP_MAIN_BUNDLE bundleIdentifier], @"MobileCenter"];
-  NSString *mcUpdateToken = [MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName];
-  NSString *acUpdateToken = [MSKeychainUtil stringForKey:kMSUpdateTokenKey];
+  NSString *mcUpdateToken = [MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName withStatusCode:nil];
+  NSString *acUpdateToken = [MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil];
   if (!acUpdateToken && mcUpdateToken) {
     [MSKeychainUtil storeString:mcUpdateToken forKey:kMSUpdateTokenKey];
   }

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -444,6 +444,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
                     // If the response payload is MSErrorDetails, consider it as a recoverable error.
                     if (!details || ![kMSErrorCodeNoReleasesForUser isEqualToString:details.code]) {
                       [MSKeychainUtil deleteStringForKey:kMSUpdateTokenKey];
+                      [MS_USER_DEFAULTS removeObjectForKey:kMSSDKHasLaunchedWithDistribute];
                       [MS_USER_DEFAULTS removeObjectForKey:kMSUpdateTokenRequestIdKey];
                       [MS_USER_DEFAULTS removeObjectForKey:kMSPostponedTimestampKey];
                       [MS_USER_DEFAULTS removeObjectForKey:kMSDistributionGroupIdKey];

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -240,7 +240,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
   if (releaseHash) {
     [self changeDistributionGroupIdAfterAppUpdateIfNeeded:releaseHash];
     OSStatus statusCode;
-    NSString *updateToken = [MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:&statusCode];
+    NSString *updateToken = [MSKeychainUtil stringForKey:kMSUpdateTokenKey statusCode:&statusCode];
     if (statusCode == errSecInteractionNotAllowed) {
       MSLogError([MSDistribute logTag], @"Failed to get update token from keychain. This might occur when the device is locked.");
       return;

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -439,7 +439,6 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
                     // If the response payload is MSErrorDetails, consider it as a recoverable error.
                     if (!details || ![kMSErrorCodeNoReleasesForUser isEqualToString:details.code]) {
                       [MSKeychainUtil deleteStringForKey:kMSUpdateTokenKey];
-                      [MS_USER_DEFAULTS removeObjectForKey:kMSSDKHasLaunchedWithDistribute];
                       [MS_USER_DEFAULTS removeObjectForKey:kMSUpdateTokenRequestIdKey];
                       [MS_USER_DEFAULTS removeObjectForKey:kMSPostponedTimestampKey];
                       [MS_USER_DEFAULTS removeObjectForKey:kMSDistributionGroupIdKey];

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -130,7 +130,6 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
   if (isEnabled) {
     MSLogInfo([MSDistribute logTag], @"Distribute service has been enabled.");
     self.releaseDetails = nil;
-    [self startUpdate];
     [[MSAppDelegateForwarder sharedInstance] addDelegate:self.appDelegate];
 
     // Enable the distribute info tracker.
@@ -142,6 +141,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
       MSLogDebug([MSDistribute logTag], @"Successfully retrieved distribution group Id setting it in distributeInfoTracker.");
       [self.distributeInfoTracker updateDistributionGroupId:distributionGroupId];
     }
+    [self startUpdate];
   } else {
     [self dismissEmbeddedSafari];
     [self.channelGroup removeDelegate:self.distributeInfoTracker];

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeDataMigrationTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeDataMigrationTests.m
@@ -39,8 +39,8 @@
   [MSDistributeDataMigration migrateKeychain];
 
   // Then
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil], is(nilValue()));
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName withStatusCode:nil], is(nilValue()));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey statusCode:nil], is(nilValue()));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName statusCode:nil], is(nilValue()));
 
   // Just the Mobile Center token.
 
@@ -51,8 +51,8 @@
   [MSDistributeDataMigration migrateKeychain];
 
   // Then
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil], is(mcToken));
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName withStatusCode:nil], is(nilValue()));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey statusCode:nil], is(mcToken));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName statusCode:nil], is(nilValue()));
 
   // Just the App Center token.
 
@@ -65,8 +65,8 @@
   [MSDistributeDataMigration migrateKeychain];
 
   // Then
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil], is(acToken));
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName withStatusCode:nil], is(nilValue()));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey statusCode:nil], is(acToken));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName statusCode:nil], is(nilValue()));
 
   // Both App Center and Mobile Center tokens.
 
@@ -77,8 +77,8 @@
   [MSDistributeDataMigration migrateKeychain];
 
   // Then
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil], is(acToken));
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName withStatusCode:nil], is(nilValue()));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey statusCode:nil], is(acToken));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName statusCode:nil], is(nilValue()));
 }
 #endif
 

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeDataMigrationTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeDataMigrationTests.m
@@ -39,8 +39,8 @@
   [MSDistributeDataMigration migrateKeychain];
 
   // Then
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey], is(nilValue()));
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName], is(nilValue()));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil], is(nilValue()));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName withStatusCode:nil], is(nilValue()));
 
   // Just the Mobile Center token.
 
@@ -51,8 +51,8 @@
   [MSDistributeDataMigration migrateKeychain];
 
   // Then
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey], is(mcToken));
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName], is(nilValue()));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil], is(mcToken));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName withStatusCode:nil], is(nilValue()));
 
   // Just the App Center token.
 
@@ -65,8 +65,8 @@
   [MSDistributeDataMigration migrateKeychain];
 
   // Then
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey], is(acToken));
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName], is(nilValue()));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil], is(acToken));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName withStatusCode:nil], is(nilValue()));
 
   // Both App Center and Mobile Center tokens.
 
@@ -77,8 +77,8 @@
   [MSDistributeDataMigration migrateKeychain];
 
   // Then
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey], is(acToken));
-  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName], is(nilValue()));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil], is(acToken));
+  assertThat([MSKeychainUtil stringForKey:kMSUpdateTokenKey withServiceName:mcServiceName withStatusCode:nil], is(nilValue()));
 }
 #endif
 

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -808,7 +808,7 @@ static NSURL *sfURL;
                                  // Then
                                  OCMVerifyAll(distributeMock);
                                  OCMVerifyAll(ingestionCallMock);
-                                 XCTAssertNil([MSMockKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil]);
+                                 XCTAssertNil([MSMockKeychainUtil stringForKey:kMSUpdateTokenKey statusCode:nil]);
                                  OCMVerify([self.settingsMock removeObjectForKey:kMSSDKHasLaunchedWithDistribute]);
                                  OCMVerify([self.settingsMock removeObjectForKey:kMSUpdateTokenRequestIdKey]);
                                  OCMVerify([self.settingsMock removeObjectForKey:kMSPostponedTimestampKey]);
@@ -870,7 +870,7 @@ static NSURL *sfURL;
                                  // Then
                                  OCMVerifyAll(distributeMock);
                                  OCMVerify([ingestionCallMock startRetryTimerWithStatusCode:500]);
-                                 XCTAssertNotNil([MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil]);
+                                 XCTAssertNotNil([MSKeychainUtil stringForKey:kMSUpdateTokenKey statusCode:nil]);
                                  XCTAssertNotNil([self.settingsMock objectForKey:kMSSDKHasLaunchedWithDistribute]);
                                  XCTAssertNotNil([self.settingsMock objectForKey:kMSUpdateTokenRequestIdKey]);
                                  XCTAssertNotNil([self.settingsMock objectForKey:kMSPostponedTimestampKey]);
@@ -1263,7 +1263,7 @@ static NSURL *sfURL;
   XCTAssertNil([self.settingsMock objectForKey:kMSUpdateTokenRequestIdKey]);
   XCTAssertNil([self.settingsMock objectForKey:kMSSDKHasLaunchedWithDistribute]);
   XCTAssertNil([self.settingsMock objectForKey:kMSPostponedTimestampKey]);
-  XCTAssertNil([MSKeychainUtil stringForKey:kMSUpdateTokenKey withStatusCode:nil]);
+  XCTAssertNil([MSKeychainUtil stringForKey:kMSUpdateTokenKey statusCode:nil]);
 
   // Clear
   [distributeMock stopMocking];

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -2344,7 +2344,6 @@ static NSURL *sfURL;
   // Stop mocking
   [distributeMock stopMocking];
   [utilityMock stopMocking];
-  [MSMockKeychainUtil mockStatusCode:noErr forKey:kMSUpdateTokenKey];
 }
 
 - (void)testShouldStillAttemptUpdateIfKeychainItemNotFound {
@@ -2371,7 +2370,6 @@ static NSURL *sfURL;
   // Stop mocking
   [distributeMock stopMocking];
   [utilityMock stopMocking];
-  [MSMockKeychainUtil mockStatusCode:noErr forKey:kMSUpdateTokenKey];
 }
 
 - (void)testShouldChangeDistributionGroupIdIfStoredIdIsNil {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Version 2.5.2 (Under development)
 
+### App Center Distribute
+
+* **[Fix]** Fix an issue where users would sometimes be prompted multiple times to sign in with App Center.
 ___
 
 ## Version 2.5.1


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes an issue where, in certain cases, the app does not have access to the update token stored in keychain. This happens when the phone is locked with a passcode but the flow is executing in the background. We've seen it a lot when there are silent pushes.

The side effects of this is that when in app updates fails to retrieve the token but tries to get release details anyways, a 403 is received because the authentication fails without the token. Then, all state is cleared and the user must sign in to app center on relaunch.

This PR fixes that by
1. enabling a mode where the update token *can* be accessed in locked mode (simple keychain flag)
2. there could still be an edge case where it is not accessed so when we see the access error, don't clear state

[AB#72031](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/72031)