### PR TITLE
Enable defaultTransmissionTarget inside setEnabled

### DIFF
--- a/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/MSAnalytics.m
@@ -124,6 +124,7 @@ __attribute__((used)) static void importCategories() { [NSString stringWithForma
   for (NSString *token in self.transmissionTargets) {
     [self.transmissionTargets[token] setEnabled:isEnabled];
   }
+  [self.defaultTransmissionTarget setEnabled:isEnabled];
 }
 
 - (void)applyEnabledState:(BOOL)isEnabled {

--- a/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
+++ b/AppCenterAnalytics/AppCenterAnalyticsTests/MSAnalyticsTests.m
@@ -1228,6 +1228,38 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   XCTAssertNotEqual([MSAnalytics sharedInstance].defaultTransmissionTarget, transmissionTarget);
 }
 
+- (void)testDefaultTransmissionTargetMirrorAnalyticsEnableState {
+
+  // If
+  MSAnalytics *service = [MSAnalytics sharedInstance];
+  [MSAppCenter configureWithAppSecret:kMSTestAppSecret];
+
+  // When
+  [[MSAnalytics sharedInstance] startWithChannelGroup:self.channelGroupMock
+                                            appSecret:kMSTestAppSecret
+                              transmissionTargetToken:kMSTestTransmissionToken
+                                      fromApplication:YES];
+
+  //Then
+  XCTAssertNotNil([MSAnalytics sharedInstance].defaultTransmissionTarget);
+  XCTAssertTrue([service isEnabled]);
+  XCTAssertTrue([service.defaultTransmissionTarget isEnabled]);
+
+  // When
+  [service setEnabled:NO];
+
+  // Then
+  XCTAssertFalse([service isEnabled]);
+  XCTAssertFalse([service.defaultTransmissionTarget isEnabled]);
+
+  // When
+  [service setEnabled:YES];
+
+  // Then
+  XCTAssertTrue([service isEnabled]);
+  XCTAssertTrue([service.defaultTransmissionTarget isEnabled]);
+}
+
 - (void)testEnableStatePropagateToTransmissionTargets {
 
   // If


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Repro steps:
1. Choose OneCollector target.
2. Disable Analytics
3. Restart the app
4. Enable Analytics
5. Try to trackEvent
6. Get 'This transmission target is disabled' error.

Fix: we should enable/disable defaultTransmissionTarget along with MSAnalytics.

## Related PRs or issues

[AB#73350](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/73350)
