### PR TITLE
Fix crash dialog for tvos

### DIFF
--- a/Vendor/iOS/MSAlertController/MSAlertController.m
+++ b/Vendor/iOS/MSAlertController/MSAlertController.m
@@ -152,8 +152,9 @@ static dispatch_queue_t alertsQueue;
   ((result (*)(id, SEL, ...)) impl)(class, selector, ##__VA_ARGS__); \
 })
 
+#if TARGET_OS_IOS
 + (void)makeKeyAndVisible {
-  if (@available(iOS 13.0, *)) {
+   if (@available(iOS 13.0, *)) {
     UIApplication *application = MS_DISPATCH_SELECTOR(UIApplication *, [UIApplication class], sharedApplication);
     NSSet *scenes = MS_DISPATCH_SELECTOR(NSSet *, application, connectedScenes);
     NSObject *windowScene = nil;
@@ -171,5 +172,10 @@ static dispatch_queue_t alertsQueue;
   }
   [window makeKeyAndVisible];
 }
+#else
++ (void)makeKeyAndVisible {
+  [window makeKeyAndVisible];
+}
+#endif
 
 @end

--- a/Vendor/iOS/MSAlertController/MSAlertController.m
+++ b/Vendor/iOS/MSAlertController/MSAlertController.m
@@ -152,9 +152,8 @@ static dispatch_queue_t alertsQueue;
   ((result (*)(id, SEL, ...)) impl)(class, selector, ##__VA_ARGS__); \
 })
 
-#if TARGET_OS_IOS
 + (void)makeKeyAndVisible {
-  if (@available(iOS 13.0, *)) {
+  if (@available(iOS 13.0, tvOS 13.0, *)) {
     UIApplication *application = MS_DISPATCH_SELECTOR(UIApplication *, [UIApplication class], sharedApplication);
     NSSet *scenes = MS_DISPATCH_SELECTOR(NSSet *, application, connectedScenes);
     NSObject *windowScene = nil;
@@ -172,10 +171,5 @@ static dispatch_queue_t alertsQueue;
   }
   [window makeKeyAndVisible];
 }
-#else
-+ (void)makeKeyAndVisible {
-  [window makeKeyAndVisible];
-}
-#endif
 
 @end

--- a/Vendor/iOS/MSAlertController/MSAlertController.m
+++ b/Vendor/iOS/MSAlertController/MSAlertController.m
@@ -154,7 +154,7 @@ static dispatch_queue_t alertsQueue;
 
 #if TARGET_OS_IOS
 + (void)makeKeyAndVisible {
-   if (@available(iOS 13.0, *)) {
+  if (@available(iOS 13.0, *)) {
     UIApplication *application = MS_DISPATCH_SELECTOR(UIApplication *, [UIApplication class], sharedApplication);
     NSSet *scenes = MS_DISPATCH_SELECTOR(NSSet *, application, connectedScenes);
     NSObject *windowScene = nil;


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Repro steps:
1. Run SasquatchTV
2. Invoke a crash
3. Restart.

Actual result: tv app crashes with unrecognized selector error.

## Related PRs or issues

[iOS 13 dialog PR](https://github.com/microsoft/appcenter-sdk-apple/pull/1873)