### PR TITLE
Fix/in app update after release note

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -92,8 +92,8 @@ static dispatch_once_t onceToken;
 
     // Proceed update whenever an application is restarted in users perspective.
     [MS_NOTIFICATION_CENTER addObserver:self
-                               selector:@selector(applicationWillEnterForeground)
-                                   name:UIApplicationWillEnterForegroundNotification
+                               selector:@selector(applicationDidBecomeActive)
+                                   name:UIApplicationDidBecomeActiveNotification
                                  object:nil];
 
     // Init the distribute info tracker.
@@ -924,6 +924,7 @@ static dispatch_once_t onceToken;
                                             * release notes.
                                             */
                                            self.releaseDetails = nil;
+                                           self.updateFlowInProgress = NO;
                                          }];
     }
 
@@ -1170,14 +1171,14 @@ static dispatch_once_t onceToken;
   }
 }
 
-- (void)applicationWillEnterForeground {
+- (void)applicationDidBecomeActive {
   if (self.canBeUsed && self.isEnabled && ![MS_USER_DEFAULTS objectForKey:kMSUpdateTokenRequestIdKey]) {
     [self startUpdate];
   }
 }
 
 - (void)dealloc {
-  [MS_NOTIFICATION_CENTER removeObserver:self name:UIApplicationWillEnterForegroundNotification object:nil];
+  [MS_NOTIFICATION_CENTER removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
 }
 
 + (void)resetSharedInstance {

--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -90,7 +90,12 @@ static dispatch_once_t onceToken;
     // Set a default value for update track.
     _updateTrack = MSUpdateTrackPublic;
 
-    // Proceed update whenever an application is restarted in users perspective.
+    /*
+     * Proceed update whenever an application is restarted in users perspective.
+     * The SDK triggered update flow on UIApplicationWillEnterForeground but listening to UIApplicationDidBecomeActiveNotification
+     * notification from version 3.0.0. It isn't reliable to make network calls on foreground so the SDK waits until the app has a
+     * focus before making any network calls.
+     */
     [MS_NOTIFICATION_CENTER addObserver:self
                                selector:@selector(applicationDidBecomeActive)
                                    name:UIApplicationDidBecomeActiveNotification

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -1937,7 +1937,7 @@ static NSURL *sfURL;
   XCTAssertFalse(result);
 }
 
-- (void)testStartUpdateWhenApplicatsionDidBecomeActive {
+- (void)testStartUpdateWhenApplicationDidBecomeActive {
 
   // If
   id notificationCenterMock = OCMPartialMock([NSNotificationCenter new]);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [X] Did you add unit tests?
* [X] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

updateFlowInProgress isn't reset when release note is display that caused the issue.
However after fixing the issue, it randomly (but very frequently) fails to get a new release with below errors.
```
2020-02-05 12:16:38.436614-0800 SasquatchPuppet[541:56301] [AppCenter] ERROR: -[MSHttpClient requestCompletedWithHttpCall:data:response:error:]/147 HTTP request error with code: 53, domain: NSPOSIXErrorDomain, description: The operation couldn’t be completed. Software caused connection abort
2020-02-05 12:16:38.436973-0800 SasquatchPuppet[541:56301] [AppCenter] DEBUG: -[MSHttpIngestion printResponse:body:error:]/202 HTTP request error with code: 53, domain: NSPOSIXErrorDomain, description: The operation couldn’t be completed. Software caused connection abort
2020-02-05 12:16:38.437046-0800 SasquatchPuppet[541:56301] [AppCenterDistribute] ERROR: -[MSDistribute checkLatestRelease:distributionGroupId:releaseHash:]_block_invoke/453 Failed to get an update response, status code: 0
```
Listening to `applicationDidBecomeActive` instead of `applicationWillEnterForeground` to make sure an app is in foreground before making an HTTP request but open to listen thoughts/opinions for the error and the change.

## Related PRs or issues

[AB#76044](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/76044)
