### PR TITLE
Don't open browser at start if checkForUpdate is manual

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -315,6 +315,14 @@ static dispatch_once_t onceToken;
 
 - (void)requestInstallInformationWith:(NSString *)releaseHash {
 
+  // Browser won't open at start if check for update was not requested or if automatic checks are disabled.
+  if ((self.distributeFlags & MSDistributeFlagsDisableAutomaticCheckForUpdate) == MSDistributeFlagsDisableAutomaticCheckForUpdate) {
+    MSLogInfo([MSDistribute logTag],
+              @"Automatic checkForUpdate is disabled. The SDK will try to get an update token the first time checkForUpdate is called.");
+    self.updateFlowInProgress = NO;
+    return;
+  }
+
   // Check if it's okay to check for updates.
   if ([self checkForUpdatesAllowed]) {
 

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeConfigureTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeConfigureTests.m
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#import "MSAppCenterInternal.h"
 #import "MSBasicMachOParser.h"
 #import "MSChannelGroupProtocol.h"
 #import "MSDistributePrivate.h"
-#import "MSGuidedAccessUtil.h"
 #import "MSTestFrameworks.h"
 #import "MSUtility+StringFormatting.h"
-#import "MS_Reachability.h"
 
 static NSString *const kMSTestAppSecret = @"IAMSECRET";
 

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeConfigureTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeConfigureTests.m
@@ -137,7 +137,8 @@ static NSString *const kMSTestAppSecret = @"IAMSECRET";
   // Then
   [self waitForExpectationsWithTimeout:1
                                handler:^(NSError *error) {
-                                 // OCMReject needs to be declared in // if, that's the checks.
+                                 // Then
+                                 OCMVerifyAll(distributeMock);
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeConfigureTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeConfigureTests.m
@@ -102,7 +102,12 @@ static NSString *const kMSTestAppSecret = @"IAMSECRET";
   OCMStub([parserMock uuid]).andReturn([[NSUUID alloc] initWithUUIDString:@"CD55E7A9-7AD1-4CA6-B722-3D133F487DA9"]);
   MSDistribute *distribute = [MSDistribute new];
   __block id distributeMock = OCMPartialMock(distribute);
-  OCMReject([distributeMock openUrlUsingSharedApp:OCMOCK_ANY]);
+  OCMStub([distributeMock checkForUpdatesAllowed]).andReturn(YES);
+  OCMStub([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:OCMOCK_ANY isTesterApp:false])
+  .andReturn([NSURL URLWithString:@"https://some_url"]);
+  OCMStub([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:OCMOCK_ANY isTesterApp:true])
+  .andReturn([NSURL URLWithString:@"some_url://"]);
+  OCMStub([distributeMock openUrlUsingSharedApp:OCMOCK_ANY]).andReturn(NO);
   OCMReject([distributeMock openUrlInAuthenticationSessionOrSafari:OCMOCK_ANY]);
   XCTestExpectation *expectation = [self expectationWithDescription:@"Start update processed"];
 

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeConfigureTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeConfigureTests.m
@@ -94,13 +94,6 @@ static NSString *const kMSTestAppSecret = @"IAMSECRET";
   id reachabilityMock = OCMClassMock([MS_Reachability class]);
   OCMStub([reachabilityMock reachabilityForInternetConnection]).andReturn(reachabilityMock);
   OCMStub([reachabilityMock currentReachabilityStatus]).andReturn(ReachableViaWiFi);
-  MSDistribute *distribute = [MSDistribute new];
-  id distributeMock = OCMPartialMock(distribute);
-  OCMStub([distributeMock sharedInstance]).andReturn(distributeMock);
-  OCMStub([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:OCMOCK_ANY isTesterApp:false])
-      .andReturn([NSURL URLWithString:@"https://some_url"]);
-  OCMStub([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:OCMOCK_ANY isTesterApp:true])
-      .andReturn([NSURL URLWithString:@"some_url://"]);
   id appCenterMock = OCMClassMock([MSAppCenter class]);
   OCMStub([appCenterMock isConfigured]).andReturn(YES);
   id guidedAccessMock = OCMClassMock([MSGuidedAccessUtil class]);
@@ -119,6 +112,13 @@ static NSString *const kMSTestAppSecret = @"IAMSECRET";
   id parserMock = OCMClassMock([MSBasicMachOParser class]);
   OCMStub([parserMock machOParserForMainBundle]).andReturn(parserMock);
   OCMStub([parserMock uuid]).andReturn([[NSUUID alloc] initWithUUIDString:@"CD55E7A9-7AD1-4CA6-B722-3D133F487DA9"]);
+  MSDistribute *distribute = [MSDistribute new];
+  id distributeMock = OCMPartialMock(distribute);
+  OCMStub([distributeMock sharedInstance]).andReturn(distributeMock);
+  OCMStub([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:OCMOCK_ANY isTesterApp:false])
+      .andReturn([NSURL URLWithString:@"https://some_url"]);
+  OCMStub([distributeMock buildTokenRequestURLWithAppSecret:OCMOCK_ANY releaseHash:OCMOCK_ANY isTesterApp:true])
+      .andReturn([NSURL URLWithString:@"some_url://"]);
   OCMReject([distributeMock openUrlUsingSharedApp:OCMOCK_ANY]);
   OCMReject([distributeMock openUrlInAuthenticationSessionOrSafari:OCMOCK_ANY]);
   XCTestExpectation *expectation = [self expectationWithDescription:@"Start update processed"];
@@ -144,11 +144,11 @@ static NSString *const kMSTestAppSecret = @"IAMSECRET";
                                }];
 
   // Cleanup
+  [distributeMock stopMocking];
   [parserMock stopMocking];
   [bundleMock stopMocking];
   [utilityMock stopMocking];
   [guidedAccessMock stopMocking];
-  [distributeMock stopMocking];
   [appCenterMock stopMocking];
   [reachabilityMock stopMocking];
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Don't open browser at start if checkForUpdate is manual.

## Related PRs or issues

[AB#76577](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/76577)

## Misc

Will require to interact with [AB#75299](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/75299) to include checking for `checkForUpdate` manual flag to open browser, maybe in another PR. 