### PR TITLE
support to build with chromium own version of clang

### DIFF
--- a/AppCenterCrashes/AppCenterCrashes/Internals/MSCrashesCXXExceptionHandler.mm
+++ b/AppCenterCrashes/AppCenterCrashes/Internals/MSCrashesCXXExceptionHandler.mm
@@ -32,7 +32,7 @@ static pthread_key_t _MSCrashesCXXExceptionInfoTSDKey = 0;
 
 @implementation MSCrashesUncaughtCXXExceptionHandlerManager
 
-extern "C" void __attribute__((noreturn)) __cxa_throw(void *exception_object, std::type_info *tinfo, void (*dest)(void *)) {
+extern "C" void __attribute__((noreturn)) inline __cxa_throw(void *exception_object, std::type_info *tinfo, void (*dest)(void *)) {
 
   /*
    * Purposely do not take a lock in this function. The aim is to be as fast as possible. While we could really use some of the info set up


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Hi, this is Zengfeng(zenye@microsoft.com) from Edge iOS team. We are reconstructing Edge iOS based on the Chromium. We are using AppCenter as our backend of crash report for Edge mobile now. And we plan to continue use AppCenter in our reconstruction.

But Chromium build product with his own version of clang, not using Xcode clang. So when I integrated AppCenter into our product powered by Chromium, there is an error as following pic while building.

![imgo](https://user-images.githubusercontent.com/17470805/75241771-b00bdb00-5801-11ea-9683-b876018d293b.jpg)

So I wonder if I can use `inline` to work this out.


## Related PRs or issues

None

## Misc

I builded a new framework with my change and integrated it into our product, it could work well.  I'm not sure if there is any influence for you. So If you have any doubt about this commit, please let me known. Thanks.
