### PR TITLE
Set userID after start is called

### DIFF
--- a/SasquatchMac/SasquatchMacSwift/AppDelegate.swift
+++ b/SasquatchMac/SasquatchMacSwift/AppDelegate.swift
@@ -67,12 +67,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, MSCrashesDelegate, MSPushDel
     if logUrl != nil {
       MSAppCenter.setLogUrl(logUrl)
     }
-
-    // Set user id.
-    let userId = UserDefaults.standard.string(forKey: kMSUserIdKey)
-    if userId != nil {
-      MSAppCenter.setUserId(userId)
-    }
     
     // Set location manager.
     locationManager.delegate = self
@@ -114,6 +108,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, MSCrashesDelegate, MSPushDel
         break
     case .skip:
         break
+    }
+      
+    // Set user id.
+    let userId = UserDefaults.standard.string(forKey: kMSUserIdKey)
+    if userId != nil {
+      MSAppCenter.setUserId(userId)
     }
 
     AppCenterProvider.shared().appCenter = AppCenterDelegateSwift()


### PR DESCRIPTION
If setUserID is called before the SDK is started, it does not work

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

With this PR of the example app, the objective is to ensure that the setUserId method is called only after the SDK is started

## Related PRs or issues

If setUserId is called before SDK start, it shows up on the AppCenter portal as `N/A`

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
