### PR TITLE
Add "Not now" button in update popup

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -908,6 +908,12 @@ static dispatch_once_t onceToken;
 
     if (!details.mandatoryUpdate) {
 
+      // Add a "Not now"-Button.
+      [alertController addDefaultActionWithTitle:MSDistributeLocalizedString(@"MSDistributeNotNow")
+                                         handler:^(__attribute__((unused)) UIAlertAction *action) {
+                                           // NO-OP
+                                         }];
+
       // Add a "Ask me in a day"-Button.
       [alertController addDefaultActionWithTitle:MSDistributeLocalizedString(@"MSDistributeAskMeInADay")
                                          handler:^(__attribute__((unused)) UIAlertAction *action) {

--- a/AppCenterDistribute/AppCenterDistribute/Resources/cs.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/cs.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "Aktualizovat";
+"MSDistributeNotNow" = "Teď ne";
 "MSDistributeAskMeInADay" = "Zeptat se za den";
 "MSDistributeViewReleaseNotes" = "Zobrazit zprávu k vydání verze";
 "MSDistributeClose" = "Zavřít";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/de.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/de.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "Jetzt aktualisieren";
+"MSDistributeNotNow" = "Nicht jetzt";
 "MSDistributeAskMeInADay" = "In einem Tag nachfragen";
 "MSDistributeViewReleaseNotes" = "Anmerkungen zu dieser Version anzeigen";
 "MSDistributeClose" = "Schließen";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/en.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/en.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "Update now";
+"MSDistributeNotNow" = "Not now";
 "MSDistributeAskMeInADay" = "Ask me in a day";
 "MSDistributeViewReleaseNotes" = "View release notes";
 "MSDistributeClose" = "Close";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/es.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/es.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "Actualizar ahora";
+"MSDistributeNotNow" = "Ahora no";
 "MSDistributeAskMeInADay" = "Preguntarme dentro de un día";
 "MSDistributeViewReleaseNotes" = "Ver notas de la versión";
 "MSDistributeClose" = "Cerrar";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/fr.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/fr.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "Mettre à jour maintenant";
+"MSDistributeNotNow" = "Pas maintenant";
 "MSDistributeAskMeInADay" = "Me le demander dans un jour";
 "MSDistributeViewReleaseNotes" = "Afficher les notes de publication";
 "MSDistributeClose" = "Fermer";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/it.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/it.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "Aggiorna adesso";
+"MSDistributeNotNow" = "Non adesso";
 "MSDistributeAskMeInADay" = "Visualizza richiesta tra un giorno";
 "MSDistributeViewReleaseNotes" = "Visualizza note sulla versione";
 "MSDistributeClose" = "Chiudi";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/ja.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/ja.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "今すぐ更新";
+"MSDistributeNotNow" = "今はやめろ";
 "MSDistributeAskMeInADay" = "明日また知らせる";
 "MSDistributeViewReleaseNotes" = "リリース ノートの表示";
 "MSDistributeClose" = "閉じる";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/ko.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/ko.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "지금 업데이트";
+"MSDistributeNotNow" = "지금은 아닙니다";
 "MSDistributeAskMeInADay" = "하루동안 열지 않기";
 "MSDistributeViewReleaseNotes" = "릴리스 정보 보기";
 "MSDistributeClose" = "닫기";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/pl.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/pl.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "Aktualizuj teraz";
+"MSDistributeNotNow" = "Nie teraz";
 "MSDistributeAskMeInADay" = "Zapytaj mnie jutro";
 "MSDistributeViewReleaseNotes" = "Wyświetl informacje o wersji";
 "MSDistributeClose" = "Zamknij";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/pt.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/pt.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "Atualizar agora";
+"MSDistributeNotNow" = "Agora não";
 "MSDistributeAskMeInADay" = "Pergunte-me em um dia";
 "MSDistributeViewReleaseNotes" = "Exibir notas de versão";
 "MSDistributeClose" = "Fechar";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/ru.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/ru.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "Обновить";
+"MSDistributeNotNow" = "Не сейчас";
 "MSDistributeAskMeInADay" = "Спросить через день";
 "MSDistributeViewReleaseNotes" = "Просмотреть заметки о выпуске";
 "MSDistributeClose" = "Закрыть";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/tr.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/tr.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "Şimdi güncelleştir";
+"MSDistributeNotNow" = "Şimdi değil";
 "MSDistributeAskMeInADay" = "Bir gün içinde sor";
 "MSDistributeViewReleaseNotes" = "Sürüm notlarını görüntüle";
 "MSDistributeClose" = "Kapat";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/zh-Hans.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/zh-Hans.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "立即更新";
+"MSDistributeNotNow" = "现在不要";
 "MSDistributeAskMeInADay" = "一天内询问我";
 "MSDistributeViewReleaseNotes" = "查看发布说明";
 "MSDistributeClose" = "关闭";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/zh-Hant.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/zh-Hant.lproj/AppCenterDistribute.strings
@@ -2,6 +2,7 @@
  * Update dialog buttons
  */
 "MSDistributeUpdateNow" = "立即更新";
+"MSDistributeNotNow" = "現在不要";
 "MSDistributeAskMeInADay" = "一天後詢問我";
 "MSDistributeViewReleaseNotes" = "檢視版本資訊";
 "MSDistributeClose" = "關閉";

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -490,6 +490,9 @@ static NSURL *sfURL;
                                  // Then
                                  OCMVerify([self.alertControllerMock alertControllerWithTitle:OCMOCK_ANY message:message]);
                                  OCMVerify([self.alertControllerMock
+                                     addDefaultActionWithTitle:MSDistributeLocalizedString(@"MSDistributeNotNow")
+                                                       handler:OCMOCK_ANY]);
+                                 OCMVerify([self.alertControllerMock
                                      addDefaultActionWithTitle:MSDistributeLocalizedString(@"MSDistributeAskMeInADay")
                                                        handler:OCMOCK_ANY]);
                                  OCMVerify([self.alertControllerMock
@@ -532,6 +535,9 @@ static NSURL *sfURL;
                                  // Then
                                  OCMVerify([self.alertControllerMock alertControllerWithTitle:OCMOCK_ANY message:message]);
                                  OCMVerify([self.alertControllerMock
+                                     addDefaultActionWithTitle:MSDistributeLocalizedString(@"MSDistributeNotNow")
+                                                       handler:OCMOCK_ANY]);
+                                 OCMVerify([self.alertControllerMock
                                      addDefaultActionWithTitle:MSDistributeLocalizedString(@"MSDistributeAskMeInADay")
                                                        handler:OCMOCK_ANY]);
                                  OCMVerify([self.alertControllerMock addPreferredActionWithTitle:OCMOCK_ANY handler:OCMOCK_ANY]);
@@ -544,6 +550,8 @@ static NSURL *sfURL;
   // If
   NSString *appName = @"Test App";
   OCMStub([self.bundleMock objectForInfoDictionaryKey:@"CFBundleDisplayName"]).andReturn(appName);
+  OCMReject([self.alertControllerMock addDefaultActionWithTitle:MSDistributeLocalizedString(@"MSDistributeNotNow")
+                                                        handler:OCMOCK_ANY]);
   OCMReject([self.alertControllerMock addDefaultActionWithTitle:MSDistributeLocalizedString(@"MSDistributeAskMeInADay")
                                                         handler:OCMOCK_ANY]);
   MSReleaseDetails *details = [MSReleaseDetails new];
@@ -628,6 +636,8 @@ static NSURL *sfURL;
   XCTestExpectation *expectation = [self expectationWithDescription:@"Confirmation alert for private distribution has been displayed"];
 
   // Mock alert.
+  OCMReject([self.alertControllerMock addDefaultActionWithTitle:MSDistributeLocalizedString(@"MSDistributeNotNow")
+                                                        handler:OCMOCK_ANY]);
   OCMReject([self.alertControllerMock addDefaultActionWithTitle:MSDistributeLocalizedString(@"MSDistributeAskMeInADay")
                                                         handler:OCMOCK_ANY]);
 


### PR DESCRIPTION
## Description

Before moving to AppCenter, the HockeyApp SDK allowed to skip the app update popup on launch. On AppCenter, the options are only:
- Ask me in a day (which will not allow you to update it easily until the next popup tomorrow)
- View release notes (which can be useful but not related to the update)
- Update now (which will update now, which is not necessarily what you want to do now either)

This PR adds a new "Not now" button, which will do nothing for now, but ask you again on the next launch.

This is essential for test apps, as it allows you to:
- Dismiss the popup (using "Not now")
- Use the test build as you were going to
- Come back to the app later and update then (using "Update now")

## Checklist

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?