### PR TITLE
Improve API ergonomics when used from Swift

### DIFF
--- a/AppCenter/AppCenter/MSService.h
+++ b/AppCenter/AppCenter/MSService.h
@@ -12,23 +12,11 @@
 @protocol MSService <NSObject>
 
 /**
- * Enable or disable this service.
- * The state is persisted in the device's storage across application launches.
- *
- * @param isEnabled Whether this service is enabled or not.
- *
- * @see isEnabled
- */
-+ (void)setEnabled:(BOOL)isEnabled;
-
-/**
  * Indicates whether this service is enabled.
  *
- * @return `YES` if this service is enabled, `NO` if it is not.
- *
- * @see setEnabled:
+ * The state is persisted in the device's storage across application launches.
  */
-+ (BOOL)isEnabled;
+@property(class, nonatomic, assign, setter=setEnabled:) BOOL isEnabled;
 
 @end
 

--- a/AppCenter/AppCenter/MSService.h
+++ b/AppCenter/AppCenter/MSService.h
@@ -16,7 +16,7 @@
  *
  * The state is persisted in the device's storage across application launches.
  */
-@property(class, nonatomic, assign, setter=setEnabled:) BOOL isEnabled;
+@property(class, nonatomic, assign, getter=isEnabled) BOOL enabled;
 
 @end
 

--- a/AppCenter/AppCenter/MSServiceAbstract.h
+++ b/AppCenter/AppCenter/MSServiceAbstract.h
@@ -48,7 +48,7 @@
  *
  * @return `YES` if the application secret is required, `NO` otherwise.
  */
-- (BOOL)isAppSecretRequired;
+@property(atomic, readonly) BOOL isAppSecretRequired;
 
 @end
 

--- a/AppCenter/AppCenter/MSServiceAbstract.h
+++ b/AppCenter/AppCenter/MSServiceAbstract.h
@@ -48,7 +48,7 @@
  *
  * @return `YES` if the application secret is required, `NO` otherwise.
  */
-@property(atomic, readonly) BOOL isAppSecretRequired;
+@property(atomic, readonly, getter=isAppSecretRequired) BOOL appSecretRequired;
 
 @end
 

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.h
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.h
@@ -87,19 +87,19 @@ typedef NS_ENUM(NSUInteger, MSUserConfirmation) {
  *
  * @return Returns YES is the app has crashed in the last session.
  */
-+ (BOOL)hasCrashedInLastSession;
+@property(class, nonatomic, assign) BOOL hasCrashedInLastSession;
 
 /**
  * Check if the app received memory warning in the last session.
  *
  * @return Returns YES is the app received memory warning in the last session.
  */
-+ (BOOL)hasReceivedMemoryWarningInLastSession;
+@property(class, nonatomic, assign) BOOL hasReceivedMemoryWarningInLastSession;
 
 /**
  * Provides details about the crash that occurred in the last app session
  */
-+ (nullable MSErrorReport *)lastSessionCrashReport;
+@property(class, nullable, readonly, nonatomic) MSErrorReport *lastSessionCrashReport;
 
 #if TARGET_OS_OSX
 /**
@@ -148,16 +148,14 @@ typedef NS_ENUM(NSUInteger, MSUserConfirmation) {
  *
  * @see MSCrashesDelegate
  */
-+ (void)setDelegate:(_Nullable id<MSCrashesDelegate>)delegate;
+@property(class, nonatomic, weak) id<MSCrashesDelegate> _Nullable delegate;
 
 /**
  * Set a user confirmation handler that is invoked right before processing crash reports to determine whether sending crash reports or not.
  *
- * @param userConfirmationHandler A handler for user confirmation.
- *
  * @see MSUserConfirmationHandler
  */
-+ (void)setUserConfirmationHandler:(_Nullable MSUserConfirmationHandler)userConfirmationHandler;
+@property(class, nonatomic, strong) MSUserConfirmationHandler _Nullable userConfirmationHandler;
 
 /**
  * Notify SDK with a confirmation to handle the crash report.

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.h
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.h
@@ -87,14 +87,14 @@ typedef NS_ENUM(NSUInteger, MSUserConfirmation) {
  *
  * @return Returns YES is the app has crashed in the last session.
  */
-@property(class, nonatomic, assign) BOOL hasCrashedInLastSession;
+@property(class, readonly, nonatomic) BOOL hasCrashedInLastSession;
 
 /**
  * Check if the app received memory warning in the last session.
  *
  * @return Returns YES is the app received memory warning in the last session.
  */
-@property(class, nonatomic, assign) BOOL hasReceivedMemoryWarningInLastSession;
+@property(class, readonly, nonatomic) BOOL hasReceivedMemoryWarningInLastSession;
 
 /**
  * Provides details about the crash that occurred in the last app session

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -198,7 +198,6 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 
 @implementation MSCrashes
 
-@synthesize delegate = _delegate;
 @synthesize channelGroup = _channelGroup;
 @synthesize channelUnitConfiguration = _channelUnitConfiguration;
 
@@ -225,8 +224,20 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
   return [[MSCrashes sharedInstance] didCrashInLastSession];
 }
 
++ (void)setHasCrashedInLastSession:(BOOL)hasCrashedInLastSession {
+  [[MSCrashes sharedInstance] setDidCrashInLastSession:hasCrashedInLastSession];
+}
+
 + (BOOL)hasReceivedMemoryWarningInLastSession {
   return [[MSCrashes sharedInstance] didReceiveMemoryWarningInLastSession];
+}
+
++ (void)setHasReceivedMemoryWarningInLastSession:(BOOL)hasReceivedMemoryWarningInLastSession {
+  [[MSCrashes sharedInstance] setDidReceiveMemoryWarningInLastSession:hasReceivedMemoryWarningInLastSession];
+}
+
++ (_Nullable MSUserConfirmationHandler)userConfirmationHandler {
+  return [[MSCrashes sharedInstance] userConfirmationHandler];
 }
 
 + (void)setUserConfirmationHandler:(_Nullable MSUserConfirmationHandler)userConfirmationHandler {
@@ -266,6 +277,10 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
  */
 + (void)disableMachExceptionHandler {
   [[MSCrashes sharedInstance] setEnableMachExceptionHandler:NO];
+}
+
++ (id<MSCrashesDelegate>)delegate {
+    return [[MSCrashes sharedInstance] delegate];
 }
 
 + (void)setDelegate:(_Nullable id<MSCrashesDelegate>)delegate {

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -224,16 +224,8 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
   return [[MSCrashes sharedInstance] didCrashInLastSession];
 }
 
-+ (void)setHasCrashedInLastSession:(BOOL)hasCrashedInLastSession {
-  [[MSCrashes sharedInstance] setDidCrashInLastSession:hasCrashedInLastSession];
-}
-
 + (BOOL)hasReceivedMemoryWarningInLastSession {
   return [[MSCrashes sharedInstance] didReceiveMemoryWarningInLastSession];
-}
-
-+ (void)setHasReceivedMemoryWarningInLastSession:(BOOL)hasReceivedMemoryWarningInLastSession {
-  [[MSCrashes sharedInstance] setDidReceiveMemoryWarningInLastSession:hasReceivedMemoryWarningInLastSession];
 }
 
 + (_Nullable MSUserConfirmationHandler)userConfirmationHandler {

--- a/AppCenterCrashes/AppCenterCrashes/MSCrashesDelegate.h
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashesDelegate.h
@@ -7,6 +7,8 @@
 @class MSErrorReport;
 @class MSErrorAttachmentLog;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol MSCrashesDelegate <NSObject>
 
 @optional
@@ -63,3 +65,5 @@
 - (NSArray<MSErrorAttachmentLog *> *)attachmentsWithCrashes:(MSCrashes *)crashes forErrorReport:(MSErrorReport *)errorReport;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sasquatch/SasquatchSwift-Extension/ExtensionViewController.swift
+++ b/Sasquatch/SasquatchSwift-Extension/ExtensionViewController.swift
@@ -22,7 +22,7 @@ class ExtensionViewController: UIViewController, NCWidgetProviding, MSCrashesDel
     let dateString = DateFormatter.localizedString(from: Date.init(), dateStyle: DateFormatter.Style.medium, timeStyle: DateFormatter.Style.medium)
     extensionLabel.text = "Run #\(dateString)"
     MSAppCenter.setLogLevel(.verbose)
-    MSCrashes.setDelegate(self)
+    MSCrashes.delegate = self
     MSAppCenter.start("238d7788-8e63-478f-a747-33444bdadbda", withServices: [MSCrashes.self])
   }
   


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR is a stylistic update to make the exposed API a little easier to work with from Swift. This mainly involves converting the headers to vend Objective-C class properties, and annotate them for nullability.

Whereas before, the exposed API for `MSCrashes` appeared like so:

```swift
MSCrashes.setDelegate(self)
```

Now, it will show up as:

```swift
MSCrashes.delegate = self
```

Similarly for `MSCrashesDelegate`:

```swift
func crashes(_ crashes: MSCrashes!, willSend errorReport: MSErrorReport!) { … }
```

Becomes:

```
func crashes(_ crashes: MSCrashes, willSend errorReport: MSErrorReport) { … }
```

## Related PRs or issues

- This PR was borne out of the discussion in #1627.

## Misc

Please note that this is not a comprehensive set of changes, more of an exemplar of what could be done - I wanter to gather some feedback before proceeding.