### PR TITLE
Fix the crash log without userid on SasquatchMacObjC app

### DIFF
--- a/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/AppCenterViewController.swift
@@ -237,7 +237,7 @@ class AppCenterViewController : NSViewController, NSTextFieldDelegate, NSTextVie
       appCenter.setUserId(nil)
       break
     case .alertSecondButtonReturn:
-      let text = textView.string ?? ""
+      let text = textView.string
       UserDefaults.standard.set(text, forKey: kMSUserIdKey)
       appCenter.setUserId(text)
       break

--- a/SasquatchMac/SasquatchMacObjC/AppDelegate.m
+++ b/SasquatchMac/SasquatchMacObjC/AppDelegate.m
@@ -35,12 +35,6 @@ enum StartupMode { appCenter, oneCollector, both, none, skip };
     [MSAppCenter setLogUrl:logUrl];
   }
 
-  // Set user id.
-  NSString *userId = [[NSUserDefaults standardUserDefaults] objectForKey:@"userId"];
-  if (userId) {
-    [MSAppCenter setUserId:userId];
-  }
-
   // Customize services.
   [self setupCrashes];
   [self setupPush];
@@ -83,8 +77,13 @@ enum StartupMode { appCenter, oneCollector, both, none, skip };
     break;
   }
 
+  // Set user id.
+  NSString *userId = [[NSUserDefaults standardUserDefaults] objectForKey:kMSUserIdKey];
+  if (userId) {
+    [MSAppCenter setUserId:userId];
+  }
+    
   [AppCenterProvider shared].appCenter = [[AppCenterDelegateObjC alloc] init];
-
   [self initUI];
   [self overrideCountryCode];
 }


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The setUserId function is called in the wrong order.

## Related PRs or issues

[#78109](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/78109)