### PR TITLE
Remove warning about attachments amount when sending crash report

### DIFF
--- a/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSCrashes.mm
@@ -62,8 +62,6 @@ static NSString *const kMSLogBufferFileExtension = @"mscrasheslogbuffer";
 
 static NSString *const kMSTargetTokenFileExtension = @"targettoken";
 
-static unsigned int kMaxAttachmentsPerCrashReport = 2;
-
 static unsigned int kMaxAttachmentSize = 7 * 1024 * 1024;
 
 /**
@@ -969,7 +967,6 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 - (void)sendErrorAttachments:(NSArray<MSErrorAttachmentLog *> *)errorAttachments withIncidentIdentifier:(NSString *)incidentIdentifier {
 
   // Send attachments log to log manager.
-  unsigned int totalProcessedAttachments = 0;
   for (MSErrorAttachmentLog *attachment in errorAttachments) {
     attachment.errorId = incidentIdentifier;
     if (![MSCrashes validatePropertiesForAttachment:attachment]) {
@@ -982,11 +979,6 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
       continue;
     }
     [self.channelUnit enqueueItem:attachment flags:MSFlagsDefault];
-    ++totalProcessedAttachments;
-  }
-  if (totalProcessedAttachments > kMaxAttachmentsPerCrashReport) {
-    MSLogWarning([MSCrashes logTag], @"A limit of %u attachments per error report / exception might be enforced by server.",
-                 kMaxAttachmentsPerCrashReport);
   }
 }
 

--- a/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSCrashesTests.mm
@@ -34,7 +34,7 @@
 static NSString *const kMSTestAppSecret = @"TestAppSecret";
 static NSString *const kMSFatal = @"fatal";
 static NSString *const kMSTypeHandledError = @"handledError";
-static unsigned int kMaxAttachmentsPerCrashReport = 2;
+static unsigned int kAttachmentsPerCrashReport = 3;
 
 @interface MSCrashes ()
 
@@ -799,44 +799,6 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   XCTAssertTrue([static_cast<NSNumber *>(serializedLog[kMSFatal]) boolValue]);
 }
 
-- (void)testWarningMessageAboutTooManyErrorAttachments {
-
-  NSString *expectedMessage =
-      [NSString stringWithFormat:@"A limit of %u attachments per error report / exception might be enforced by server.",
-                                 kMaxAttachmentsPerCrashReport];
-  __block bool warningMessageHasBeenPrinted = false;
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-parameter"
-  [MSLogger setLogHandler:^(MSLogMessageProvider messageProvider, MSLogLevel logLevel, NSString *tag, const char *file,
-                            const char *function, uint line) {
-    if (warningMessageHasBeenPrinted) {
-      return;
-    }
-    NSString *message = messageProvider();
-    warningMessageHasBeenPrinted = [message isEqualToString:expectedMessage];
-  }];
-#pragma clang diagnostic pop
-
-  // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
-
-  // If
-  self.sut = OCMPartialMock(self.sut);
-  OCMStub([self.sut startDelayedCrashProcessing]).andDo(nil);
-
-  // When
-  assertThatBool([MSCrashesTestUtil copyFixtureCrashReportWithFileName:@"live_report_exception"], isTrue());
-  [self.sut setDelegate:self];
-  [self.sut startWithChannelGroup:OCMProtocolMock(@protocol(MSChannelGroupProtocol))
-                        appSecret:kMSTestAppSecret
-          transmissionTargetToken:nil
-                  fromApplication:YES];
-  [self.sut startCrashProcessing];
-
-  XCTAssertTrue(warningMessageHasBeenPrinted);
-}
-
 #pragma mark - Automatic Processing Tests
 
 - (void)testSendOrAwaitWhenAlwaysSendIsTrue {
@@ -1367,7 +1329,7 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   OCMStub([deviceMock isValid]).andReturn(YES);
 
   NSMutableArray *logs = [NSMutableArray new];
-  for (unsigned int i = 0; i < kMaxAttachmentsPerCrashReport + 1; ++i) {
+  for (unsigned int i = 0; i < kAttachmentsPerCrashReport; ++i) {
     NSString *text = [NSString stringWithFormat:@"%d", i];
     MSErrorAttachmentLog *log = [[MSErrorAttachmentLog alloc] initWithFilename:text attachmentText:text];
     log.timestamp = [NSDate dateWithTimeIntervalSince1970:42];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### App Center Crashes
 
 * **[Improvement]** Update PLCrashReporter to 1.5.1.
+* **[Fix]** Remove the multiple attachments warning as that is now supported by the portal.
 
 ___
 


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR removes warning about attachments count when sending crash.
With that, test which was created to verify this message rendered redundant, and so did constant and local counter.

## Related PRs or issues

[AB#78240](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/78240)