### PR TITLE
Fix crashes occuring when building with swift 5.2

### DIFF
--- a/Sasquatch/Sasquatch/ViewControllers/MSCrashesViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSCrashesViewController.swift
@@ -229,9 +229,10 @@ class MSCrashesViewController: UITableViewController, UIImagePickerControllerDel
   private func pokeAllCrashes() {
     var count = UInt32(0)
     let classList = objc_copyClassList(&count)
+    let classes = UnsafeBufferPointer(start: classList, count: Int(count))
     MSCrash.removeAllCrashes()
     for i in 0..<Int(count){
-      let className: AnyClass = classList![i]
+      let className: AnyClass = classes[i]
       if class_getSuperclass(className) == MSCrash.self && className != MSCrash.self {
         MSCrash.register((className as! MSCrash.Type).init())
       }

--- a/Sasquatch/SasquatchSwift-Extension/ExtensionViewController.swift
+++ b/Sasquatch/SasquatchSwift-Extension/ExtensionViewController.swift
@@ -46,9 +46,10 @@ class ExtensionViewController: UIViewController, NCWidgetProviding, MSCrashesDel
   private func pokeAllCrashes() {
     var count = UInt32(0)
     let classList = objc_copyClassList(&count)
+    let classes = UnsafeBufferPointer(start: classList, count: Int(count))
     MSCrash.removeAllCrashes()
-    for i in 0 ..< Int(count) {
-      let className: AnyClass = classList![i]
+    for i in 0..<Int(count){
+      let className: AnyClass = classes[i]
       if class_getSuperclass(className) == MSCrash.self && className != MSCrash.self {
         MSCrash.register((className as! MSCrash.Type).init())
       }

--- a/SasquatchMac/SasquatchMacSwift/CrashLoader.swift
+++ b/SasquatchMac/SasquatchMacSwift/CrashLoader.swift
@@ -34,14 +34,15 @@ class CrashLoader {
     }
     
     private static func pokeAllCrashes() {
-        var count = UInt32(0)
-        let classList = objc_copyClassList(&count)
-        MSCrash.removeAllCrashes()
-        for i in 0..<Int(count) {
-            let className: AnyClass = classList![i]
-            if class_getSuperclass(className) == MSCrash.self && className != MSCrash.self {
-                MSCrash.register((className as! MSCrash.Type).init())
-            }
+      var count = UInt32(0)
+      let classList = objc_copyClassList(&count)
+      let classes = UnsafeBufferPointer(start: classList, count: Int(count))
+      MSCrash.removeAllCrashes()
+      for i in 0..<Int(count){
+        let className: AnyClass = classes[i]
+        if class_getSuperclass(className) == MSCrash.self && className != MSCrash.self {
+          MSCrash.register((className as! MSCrash.Type).init())
         }
+      }
     }
 }

--- a/SasquatchTV/SasquatchTV/ViewControllers/CrashesViewController.swift
+++ b/SasquatchTV/SasquatchTV/ViewControllers/CrashesViewController.swift
@@ -97,13 +97,14 @@ class CrashesViewController: UITableViewController, AppCenterProtocol {
     }
   }
 
-  private func pokeAllCrashes(){
+  private func pokeAllCrashes() {
     var count = UInt32(0)
     let classList = objc_copyClassList(&count)
+    let classes = UnsafeBufferPointer(start: classList, count: Int(count))
     MSCrash.removeAllCrashes()
     for i in 0..<Int(count){
-      let className: AnyClass = classList![i]
-      if class_getSuperclass(className) == MSCrash.self && className != MSCrash.self{
+      let className: AnyClass = classes[i]
+      if class_getSuperclass(className) == MSCrash.self && className != MSCrash.self {
         MSCrash.register((className as! MSCrash.Type).init())
       }
     }


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Problem appear to be in recent swift changes. To work with classes returned by `objc_copyClassesList` in a way we had, additional `UnsafeBufferPointer` cast seem to be required. 

## Related PRs or issues

[AB#79056](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/79056)