### PR TITLE
Fix event filter in test apps

### DIFF
--- a/AppCenter/AppCenter/MSConstants+Flags.h
+++ b/AppCenter/AppCenter/MSConstants+Flags.h
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifndef MS_CONSTANTS_FLAGS_H
+#define MS_CONSTANTS_FLAGS_H
+
 #import <Foundation/Foundation.h>
 
 typedef NS_OPTIONS(NSUInteger, MSFlags) {
@@ -11,3 +14,5 @@ typedef NS_OPTIONS(NSUInteger, MSFlags) {
   MSFlagsPersistenceCritical DEPRECATED_MSG_ATTRIBUTE("please use MSFlagsCritical") = MSFlagsCritical,
   MSFlagsDefault = MSFlagsNormal
 };
+
+#endif

--- a/Sasquatch/Sasquatch/EventFilter/MSEventFilter.m
+++ b/Sasquatch/Sasquatch/EventFilter/MSEventFilter.m
@@ -57,8 +57,9 @@ static NSString *const kMSEventTypeName = @"event";
 
 - (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup
                     appSecret:(NSString *)appSecret
-      transmissionTargetToken:(NSString *)token {
-  [super startWithChannelGroup:channelGroup appSecret:appSecret transmissionTargetToken:token fromApplication:YES];
+      transmissionTargetToken:(NSString *)token
+              fromApplication:(BOOL)fromApplication {
+  [super startWithChannelGroup:channelGroup appSecret:appSecret transmissionTargetToken:token fromApplication:fromApplication];
   [channelGroup addDelegate:self];
 }
 

--- a/SasquatchMac/SasquatchMac/EventFilter/MSEventFilter.h
+++ b/SasquatchMac/SasquatchMac/EventFilter/MSEventFilter.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Event filtering service.
  */
-@interface MSEventFilter : MSServiceAbstract <MSChannelDelegate>
+@interface MSEventFilter : MSServiceAbstract
 
 /**
  * Get the unique instance.

--- a/SasquatchMac/SasquatchMac/EventFilter/MSEventFilter.m
+++ b/SasquatchMac/SasquatchMac/EventFilter/MSEventFilter.m
@@ -53,9 +53,10 @@ static NSString *const kMSEventTypeName = @"event";
 
 - (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup
                     appSecret:(NSString *)appSecret
-      transmissionTargetToken:(NSString *)token {
-  [super startWithChannelGroup:channelGroup appSecret:appSecret transmissionTargetToken:token fromApplication:YES];
-  [channelGroup addDelegate:self];
+      transmissionTargetToken:(NSString *)token
+              fromApplication:(BOOL)fromApplication {
+  [super startWithChannelGroup:channelGroup appSecret:appSecret transmissionTargetToken:token fromApplication:fromApplication];
+  [channelGroup addDelegate:(id<MSChannelDelegate>)self];
 }
 
 #pragma mark - MSChannelDelegate

--- a/SasquatchMac/SasquatchMac/ViewControllers/EventFilterViewController.swift
+++ b/SasquatchMac/SasquatchMac/ViewControllers/EventFilterViewController.swift
@@ -6,16 +6,20 @@ import Cocoa
 class EventFilterViewController: NSViewController {
 
   var appCenter: AppCenterDelegate = AppCenterProvider.shared().appCenter!
+  private var eventFilterStarted = false
 
   @IBOutlet weak var setEnabledButton: NSButton!
 
   @IBAction func setEnabled(_ sender: NSButton) {
+    if !eventFilterStarted {
+      appCenter.startEventFilterService()
+      eventFilterStarted = true
+    }
     appCenter.setEventFilterEnabled(sender.state == .on)
   }
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    appCenter.startEventFilterService()
     setEnabledButton?.state = appCenter.isEventFilterEnabled() ? .on : .off
   }
 }

--- a/SasquatchTV/SasquatchTV/EventFilter/MSEventFilter.h
+++ b/SasquatchTV/SasquatchTV/EventFilter/MSEventFilter.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Event filtering service.
  */
-@interface MSEventFilter : MSServiceAbstract <MSChannelDelegate>
+@interface MSEventFilter : MSServiceAbstract
 
 /**
  * Get the unique instance.

--- a/SasquatchTV/SasquatchTV/EventFilter/MSEventFilter.m
+++ b/SasquatchTV/SasquatchTV/EventFilter/MSEventFilter.m
@@ -53,9 +53,10 @@ static NSString *const kMSEventTypeName = @"event";
 
 - (void)startWithChannelGroup:(id<MSChannelGroupProtocol>)channelGroup
                     appSecret:(NSString *)appSecret
-      transmissionTargetToken:(NSString *)token {
-  [super startWithChannelGroup:channelGroup appSecret:appSecret transmissionTargetToken:token fromApplication:YES];
-  [channelGroup addDelegate:self];
+      transmissionTargetToken:(NSString *)token
+              fromApplication:(BOOL)fromApplication {
+  [super startWithChannelGroup:channelGroup appSecret:appSecret transmissionTargetToken:token fromApplication:fromApplication];
+  [channelGroup addDelegate:(id<MSChannelDelegate>)self];
 }
 
 #pragma mark - MSChannelDelegate


### PR DESCRIPTION
* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Event filter didn't work because of signature change. Also, fix compilation error in Xcode 11

The change in `MSConstants+Flags.h` is required to include private header (but it is not finally required for `MSEventFilter`)

## Related PRs or issues

[AB#79201](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/79201)
