### PR TITLE
Add CrachLibWatch  as adependency in watch os targets

### DIFF
--- a/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
+++ b/Sasquatch/Sasquatch.xcodeproj/project.pbxproj
@@ -313,6 +313,34 @@
 			remoteGlobalIDString = 84226C461E88FF4A00798417;
 			remoteInfo = SasquatchObjC;
 		};
+		840B18DE244DC7D400BD8B92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 84D067B0244864DC000B708B;
+			remoteInfo = CrashLibWatch;
+		};
+		840B190D244DC7DD00BD8B92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 84D067B0244864DC000B708B;
+			remoteInfo = CrashLibWatch;
+		};
+		8439244B244DC0940039D94B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 84D067B0244864DC000B708B;
+			remoteInfo = CrashLibWatch;
+		};
+		8439247B244DC09F0039D94B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 84D067B0244864DC000B708B;
+			remoteInfo = CrashLibWatch;
+		};
 		84D067FA24486B22000B708B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
@@ -621,20 +649,6 @@
 			remoteGlobalIDString = B21A71DA1DD2A38C0044BB1C;
 			remoteInfo = CrashLibIOS;
 		};
-		C2F156D72338C30400798480 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = B21A71DA1DD2A38C0044BB1C;
-			remoteInfo = CrashLibIOS;
-		};
-		C2F156DC2338C30C00798480 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = B21A71DA1DD2A38C0044BB1C;
-			remoteInfo = CrashLibIOS;
-		};
 		C2F156E32338C31E00798480 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
@@ -643,20 +657,6 @@
 			remoteInfo = CrashLibIOS;
 		};
 		C2F156E82338C32C00798480 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = B21A71DA1DD2A38C0044BB1C;
-			remoteInfo = CrashLibIOS;
-		};
-		C2F156EC2338C33100798480 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = B21A71DA1DD2A38C0044BB1C;
-			remoteInfo = CrashLibIOS;
-		};
-		C2F156F12338C33600798480 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C2F156A32338C26A00798480 /* CrashLib.xcodeproj */;
 			proxyType = 1;
@@ -1884,8 +1884,8 @@
 			buildRules = (
 			);
 			dependencies = (
+				840B18DF244DC7D400BD8B92 /* PBXTargetDependency */,
 				D31EF9381E9517B600450162 /* PBXTargetDependency */,
-				C2F156F22338C33600798480 /* PBXTargetDependency */,
 			);
 			name = SasquatchWatchObjC;
 			productName = SasquatchWatchObjC;
@@ -1904,7 +1904,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				C2F156ED2338C33100798480 /* PBXTargetDependency */,
+				840B190E244DC7DD00BD8B92 /* PBXTargetDependency */,
 			);
 			name = "SasquatchWatchObjC Extension";
 			productName = "SasquatchWatchObjC Extension";
@@ -1924,8 +1924,8 @@
 			buildRules = (
 			);
 			dependencies = (
+				8439244C244DC0940039D94B /* PBXTargetDependency */,
 				D31EF9631E9517C600450162 /* PBXTargetDependency */,
-				C2F156DD2338C30C00798480 /* PBXTargetDependency */,
 			);
 			name = SasquatchWatchSwift;
 			productName = SasquatchWatchSwift;
@@ -1944,7 +1944,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				C2F156D82338C30400798480 /* PBXTargetDependency */,
+				8439247C244DC09F0039D94B /* PBXTargetDependency */,
 			);
 			name = "SasquatchWatchSwift Extension";
 			productName = "SasquatchWatchSwift Extension";
@@ -2957,6 +2957,26 @@
 			target = 84226C461E88FF4A00798417 /* SasquatchObjC */;
 			targetProxy = 5CE2588C1EA5F62400DA8FB9 /* PBXContainerItemProxy */;
 		};
+		840B18DF244DC7D400BD8B92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibWatch;
+			targetProxy = 840B18DE244DC7D400BD8B92 /* PBXContainerItemProxy */;
+		};
+		840B190E244DC7DD00BD8B92 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibWatch;
+			targetProxy = 840B190D244DC7DD00BD8B92 /* PBXContainerItemProxy */;
+		};
+		8439244C244DC0940039D94B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibWatch;
+			targetProxy = 8439244B244DC0940039D94B /* PBXContainerItemProxy */;
+		};
+		8439247C244DC09F0039D94B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CrashLibWatch;
+			targetProxy = 8439247B244DC09F0039D94B /* PBXContainerItemProxy */;
+		};
 		B2A888A42102A407001ACFDF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = AppCenterDistributeResources;
@@ -3032,16 +3052,6 @@
 			name = CrashLibIOS;
 			targetProxy = C2F156D32338C2FC00798480 /* PBXContainerItemProxy */;
 		};
-		C2F156D82338C30400798480 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CrashLibIOS;
-			targetProxy = C2F156D72338C30400798480 /* PBXContainerItemProxy */;
-		};
-		C2F156DD2338C30C00798480 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CrashLibIOS;
-			targetProxy = C2F156DC2338C30C00798480 /* PBXContainerItemProxy */;
-		};
 		C2F156E42338C31E00798480 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CrashLibIOS;
@@ -3051,16 +3061,6 @@
 			isa = PBXTargetDependency;
 			name = CrashLibIOS;
 			targetProxy = C2F156E82338C32C00798480 /* PBXContainerItemProxy */;
-		};
-		C2F156ED2338C33100798480 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CrashLibIOS;
-			targetProxy = C2F156EC2338C33100798480 /* PBXContainerItemProxy */;
-		};
-		C2F156F22338C33600798480 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CrashLibIOS;
-			targetProxy = C2F156F12338C33600798480 /* PBXContainerItemProxy */;
 		};
 		C2F156F82338C34500798480 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;


### PR DESCRIPTION
Things to consider before you submit the PR:

* ~~[ ] Has `CHANGELOG.md` been updated?~~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~~[ ] Did you add unit tests?~~
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Add CrachLibWatch as a dependency for SasquatchWatch(ObjC/Swift), to say xcode to compile CrachLibWatch when we compile SasquatchWatch target

## Related PRs or issues

This is a fix for [this](https://github.com/microsoft/appcenter-sdk-apple/pull/2029) PR

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
