### PR TITLE
Hide Core module from Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,6 @@ let package = Package(
     name: "App Center",
     products: [
         .library(
-            name: "AppCenter",
-            targets: ["AppCenter"]),
-        .library(
             name: "AppCenterAnalytics",
             targets: ["AppCenterAnalytics"])
     ],


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

We don't need to expose our Core module for Swift Package Manager users, it will be included as an implicit dependency of other modules (Analytics at the moment).


## Related PRs or issues

[Original thread](https://github.com/MicrosoftDocs/appcenter-docs-pr/pull/1858#discussion_r416200953)

## Misc

Before:
<img width="729" alt="Screenshot 2020-04-27 at 12 21 44" src="https://user-images.githubusercontent.com/10907757/80568525-3910df80-8a08-11ea-9302-7f9888f5811e.png">

After:
<img width="733" alt="Screenshot 2020-04-29 at 10 51 32" src="https://user-images.githubusercontent.com/10907757/80568586-5e055280-8a08-11ea-9666-5dd2e8e9b0d3.png">
