### PR TITLE
Add distributeWillClose to MSDistributeDelegate

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistribute.m
@@ -1097,6 +1097,11 @@ static dispatch_once_t onceToken;
 }
 
 - (void)closeApp __attribute__((noreturn)) {
+  id<MSDistributeDelegate> delegate = self.delegate;
+  if ([delegate respondsToSelector:@selector(distributeWillClose:)])
+  {
+    [delegate distributeWillClose:self];
+  }
   exit(0);
 }
 

--- a/AppCenterDistribute/AppCenterDistribute/MSDistributeDelegate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributeDelegate.h
@@ -21,4 +21,11 @@
  */
 - (BOOL)distribute:(MSDistribute *)distribute releaseAvailableWithDetails:(MSReleaseDetails *)details;
 
+/**
+ * Optionally add any clean up operations that need to be done before MSDistribute terminates application for update.
+ *
+ * @param distribute The instance of MSDistribute.
+ */
+- (void)distributeWillClose:(MSDistribute *)distribute;
+
 @end


### PR DESCRIPTION

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [X] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

AppCenter SDK (MSDistribute module) when performing an in-app update, performs an- exit(0); operation. This immediately kills the application and isn't recommended by Apple. We need to provide Applications with a clean up facility before calling the exit(0).

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-apple/issues/2093

