### PR TITLE
Fix start App Center with startup mode "both" in demo app

### DIFF
--- a/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -152,7 +152,7 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
     [MSAppCenter start:[NSString stringWithFormat:@"target=%@", kMSObjCTargetToken] withServices:services];
     break;
   case BOTH:
-    [MSAppCenter start:[NSString stringWithFormat:@"appsecret=%@;target=%@", appSecret, kMSObjCTargetToken] withServices:services];
+    [MSAppCenter start:[NSString stringWithFormat:@"%@;target=%@", appSecret, kMSObjCTargetToken] withServices:services];
     break;
   case NONE:
     [MSAppCenter startWithServices:services];

--- a/Sasquatch/SasquatchSwift/AppDelegate.swift
+++ b/Sasquatch/SasquatchSwift/AppDelegate.swift
@@ -106,7 +106,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MSCrashesDelegate, UNUser
       MSAppCenter.start("target=\(kMSSwiftTargetToken)", withServices: services)
       break
     case .BOTH:
-      MSAppCenter.start("appsecret=\(appSecret);target=\(kMSSwiftTargetToken)", withServices: services)
+      MSAppCenter.start("\(appSecret);target=\(kMSSwiftTargetToken)", withServices: services)
       break
     case .NONE:
       MSAppCenter.start(withServices: services)


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [ ] ~Are tests passing locally?Z
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests?~
* [ ] ~Did you check UI tests on the sample app? They are not executed on CI.~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

When change startup mode to "both", click the crash and send report, the AC portal can't receive the crash report.
