### PR TITLE
Fix release notes script

### DIFF
--- a/Scripts/get-release-notes.sh
+++ b/Scripts/get-release-notes.sh
@@ -16,7 +16,7 @@ while IFS='' read -r line || -n "$line" ]]; do
 if $change_log_found; then
 
   # If it reads end of change log for the version
-  if [[ "$line" =~ "___" ]]; then
+  if [[ "$line" == "___" ]]; then
     break
 
   # Append the line


### PR DESCRIPTION
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?

## Description

Things like `___llvm_profile_runtime` in changelog break "contains" logic. Use strict match instead.

