### PR TITLE
Use only standard architectures in one test application

### DIFF
--- a/Sasquatch/Config/Sasquatch ObjC.xcconfig
+++ b/Sasquatch/Config/Sasquatch ObjC.xcconfig
@@ -4,3 +4,6 @@ GCC_PREPROCESSOR_DEFINITIONS = $(inherited) GCC_PREPROCESSOR_MACRO_SASQUATCH_OBJ
 CLANG_ENABLE_MODULES = NO
 OTHER_LDFLAGS = $(OTHER_LDFLAGS) -framework UserNotifications
 OTHER_LDFLAGS = $(OTHER_LDFLAGS) -framework SafariServices
+
+// Use only standard achitectures in ObjC test application
+ARCHS[sdk=iphoneos*] = $(ARCHS_STANDARD)


### PR DESCRIPTION
* ~[ ] Has `CHANGELOG.md` been updated?~
* ~[ ] Are tests passing locally?~
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests?~
* ~[ ] Did you check UI tests on the sample app? They are not executed on CI.~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

arm64e architecture removed from iOS test app.

## Related PRs or issues

[AB#81581](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/81581)
