### PR TITLE
Fix logs sent inside applicationWillTerminate

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -214,8 +214,7 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application {
-  
-  dispatch_semaphore_wait(self.delayedProcessingSemaphore, 2);
+  dispatch_semaphore_wait(self.delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC));
   
   // Block logs queue so that it isn't killed before app termination.
   dispatch_async(self.logsDispatchQueue, ^{

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -220,7 +220,7 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 }
 
 #if !TARGET_OS_OSX
-- (void)applicationWillTerminate:(UIApplication *)application {
+- (void)applicationWillTerminate:(__unused UIApplication *)application {
 
   // Block logs queue so that it isn't killed before app termination.
   dispatch_async(self.logsDispatchQueue, ^{

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -13,7 +13,11 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 
 @implementation MSChannelGroupDefault
 
+#if !TARGET_OS_OSX
+
 @synthesize delayedProcessingSemaphore = _delayedProcessingSemaphore;
+
+#endif
 
 #pragma mark - Initialization
 
@@ -34,7 +38,9 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
     if (ingestion) {
       _ingestion = ingestion;
     }
+#if !TARGET_OS_OSX
     _delayedProcessingSemaphore = dispatch_semaphore_create(0);
+#endif
   }
   return self;
 }
@@ -213,6 +219,7 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
    */
 }
 
+#if !TARGET_OS_OSX
 - (void)applicationWillTerminate:(UIApplication *)application {
 
   // Block logs queue so that it isn't killed before app termination.
@@ -221,6 +228,7 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
   });
   dispatch_semaphore_wait(self.delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC));
 }
+#endif
 
 #pragma mark - Pause / Resume
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -183,14 +183,14 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 #if !TARGET_OS_OSX
   if (isEnabled) {
     [MS_NOTIFICATION_CENTER addObserver:self
-    selector:@selector(applicationWillTerminate:)
-        name:UIApplicationWillTerminateNotification
-      object:nil];
+                               selector:@selector(applicationWillTerminate:)
+                                   name:UIApplicationWillTerminateNotification
+                                 object:nil];
   } else {
     [MS_NOTIFICATION_CENTER removeObserver:self];
   }
 #endif
-  
+
   // Propagate to ingestion.
   [self.ingestion setEnabled:isEnabled andDeleteDataOnDisabled:deleteData];
 
@@ -214,12 +214,12 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application {
-  dispatch_semaphore_wait(self.delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC));
-  
+
   // Block logs queue so that it isn't killed before app termination.
   dispatch_async(self.logsDispatchQueue, ^{
     dispatch_semaphore_signal(self.delayedProcessingSemaphore);
   });
+  dispatch_semaphore_wait(self.delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC));
 }
 
 #pragma mark - Pause / Resume

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
@@ -18,6 +18,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithIngestion:(nullable MSAppCenterIngestion *)ingestion;
 
+/**
+* Semaphore for exclusion with "startDelayedCrashProcessing" method.
+*/
+@property dispatch_semaphore_t delayedProcessingSemaphore;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
@@ -18,10 +18,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithIngestion:(nullable MSAppCenterIngestion *)ingestion;
 
+#if !TARGET_OS_OSX
 /**
-* Semaphore for blocking logs queue on applicationWillTerminate.
-*/
+ * Semaphore for blocking logs queue on applicationWillTerminate.
+ */
 @property dispatch_semaphore_t delayedProcessingSemaphore;
+
+#endif
 
 @end
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithIngestion:(nullable MSAppCenterIngestion *)ingestion;
 
 /**
-* Semaphore for exclusion with "startDelayedCrashProcessing" method.
+* Semaphore for blocking logs queue on applicationWillTerminate.
 */
 @property dispatch_semaphore_t delayedProcessingSemaphore;
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
@@ -24,6 +24,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property dispatch_semaphore_t delayedProcessingSemaphore;
 
+/**
+ * Called when applciation is terminating.
+ */
+- (void)applicationWillTerminate:(__unused UIApplication *)application;
+
 #endif
 
 @end

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -89,6 +89,7 @@
   
   // Then
   self.sut.logsDispatchQueue = nil;
+  OCMVerifyAll(sut);
   [sut stopMocking];
 }
 #endif

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -61,6 +61,26 @@
   [super tearDown];
 }
 
+#if !TARGET_OS_OSX
+- (void)testAppIsKilled {
+
+  // If
+  [self.sut setEnabled:YES andDeleteDataOnDisabled:YES];
+  id sut = OCMPartialMock(self.sut);
+
+  // When
+  [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillTerminateNotification object:sut];
+
+  // Then
+  OCMVerify([sut applicationWillTerminate:OCMOCK_ANY]);
+  XCTAssertNotNil(self.sut.logsDispatchQueue);
+  [self.sut setEnabled:NO andDeleteDataOnDisabled:YES];
+  [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillTerminateNotification object:sut];
+  OCMReject([sut applicationWillTerminate:OCMOCK_ANY]);
+  self.sut.logsDispatchQueue = nil;
+}
+#endif
+
 #pragma mark - Tests
 
 - (void)testNewInstanceWasInitialisedCorrectly {

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if !TARGET_OS_OSX
-#import <UIKit/UIKit.h>
-#endif
-
 #import "MSAbstractLogInternal.h"
 #import "MSAppCenterIngestion.h"
 #import "MSChannelDelegate.h"
@@ -65,7 +61,7 @@
   [super tearDown];
 }
 
-#if !TARGET_OS_OSX
+#if TARGET_OS_IPHONE
 - (void)testAppIsKilled {
 
   // If

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#if !TARGET_OS_OSX
+#import <UIKit/UIKit.h>
+#endif
+
 #import "MSAbstractLogInternal.h"
 #import "MSAppCenterIngestion.h"
 #import "MSChannelDelegate.h"

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#import "TargetConditionals.h"
+#if !TARGET_OS_OSX
+#import <UIKit/UIKit.h>
+#endif
+
 #import "MSAbstractLogInternal.h"
 #import "MSAppCenterIngestion.h"
 #import "MSChannelDelegate.h"
@@ -61,7 +66,7 @@
   [super tearDown];
 }
 
-#if TARGET_OS_IPHONE
+#if !TARGET_OS_OSX
 - (void)testAppIsKilled {
 
   // If

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -79,10 +79,17 @@
   // Then
   OCMVerify([sut applicationWillTerminate:OCMOCK_ANY]);
   XCTAssertNotNil(self.sut.logsDispatchQueue);
+  
+  // If
   [self.sut setEnabled:NO andDeleteDataOnDisabled:YES];
-  [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillTerminateNotification object:sut];
   OCMReject([sut applicationWillTerminate:OCMOCK_ANY]);
+  
+  // When
+  [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillTerminateNotification object:sut];
+  
+  // Then
   self.sut.logsDispatchQueue = nil;
+  [sut stopMocking];
 }
 #endif
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * **[Fix]** Fix compatibility with Xcode 12 beta when integrating SDK from sources.
 
+### App Center Analytics
+
+* **[Fix]** Fix sending logs from `applicationWillTerminate`.
+
 ___
 
 ## Version 3.3.2


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [x] Did you add unit tests?
* [X] Did you check UI tests on the sample app? They are not executed on CI.
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Logs sent from `applicationWillTerminate` were not being saved because of `dispatch_async` call. 
To fix this, we add a task to the logsQueue and wait for it inside `applicationWillTerminate` event.

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-apple/issues/2123/

## Misc

[AB#81803](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/81803)

TODO: unit tests
