### PR TITLE
Fix logs sent inside applicaitonWillTerminate

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -215,8 +215,10 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 - (void)applicationWillTerminate:(__unused UIApplication *)application {
 
   // Block logs queue so that it isn't killed before app termination.
-  [MSDispatcherUtil dispatchSyncWithTimeout:1 onQueue:self.logsDispatchQueue withBlock: ^{
-  }];
+  [MSDispatcherUtil dispatchSyncWithTimeout:1
+                                    onQueue:self.logsDispatchQueue
+                                  withBlock:^{
+                                  }];
 }
 #endif
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -13,6 +13,12 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 
 @implementation MSChannelGroupDefault
 
+#if !TARGET_OS_OSX
+
+@synthesize delayedProcessingSemaphore = _delayedProcessingSemaphore;
+
+#endif
+
 #pragma mark - Initialization
 
 - (instancetype)initWithHttpClient:(id<MSHttpClientProtocol>)httpClient installId:(NSUUID *)installId logUrl:(NSString *)logUrl {
@@ -32,6 +38,9 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
     if (ingestion) {
       _ingestion = ingestion;
     }
+#if !TARGET_OS_OSX
+    _delayedProcessingSemaphore = dispatch_semaphore_create(0);
+#endif
   }
   return self;
 }
@@ -177,6 +186,17 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 
 - (void)setEnabled:(BOOL)isEnabled andDeleteDataOnDisabled:(BOOL)deleteData {
 
+#if !TARGET_OS_OSX
+  if (isEnabled) {
+    [MS_NOTIFICATION_CENTER addObserver:self
+                               selector:@selector(applicationWillTerminate:)
+                                   name:UIApplicationWillTerminateNotification
+                                 object:nil];
+  } else {
+    [MS_NOTIFICATION_CENTER removeObserver:self];
+  }
+#endif
+
   // Propagate to ingestion.
   [self.ingestion setEnabled:isEnabled andDeleteDataOnDisabled:deleteData];
 
@@ -198,6 +218,17 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
    * Note that this is an unlikely scenario. Solving this issue is more of a proactive measure.
    */
 }
+
+#if !TARGET_OS_OSX
+- (void)applicationWillTerminate:(__unused UIApplication *)application {
+
+  // Block logs queue so that it isn't killed before app termination.
+  dispatch_async(self.logsDispatchQueue, ^{
+    dispatch_semaphore_signal(self.delayedProcessingSemaphore);
+  });
+  dispatch_semaphore_wait(self.delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC));
+}
+#endif
 
 #pragma mark - Pause / Resume
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -7,17 +7,12 @@
 #import "MSChannelGroupDefaultPrivate.h"
 #import "MSChannelUnitConfiguration.h"
 #import "MSChannelUnitDefault.h"
+#import "MSDispatcherUtil.h"
 #import "MSLogDBStorage.h"
 
 static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQueue";
 
 @implementation MSChannelGroupDefault
-
-#if !TARGET_OS_OSX
-
-@synthesize delayedProcessingSemaphore = _delayedProcessingSemaphore;
-
-#endif
 
 #pragma mark - Initialization
 
@@ -38,9 +33,6 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
     if (ingestion) {
       _ingestion = ingestion;
     }
-#if !TARGET_OS_OSX
-    _delayedProcessingSemaphore = dispatch_semaphore_create(0);
-#endif
   }
   return self;
 }
@@ -223,10 +215,7 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 - (void)applicationWillTerminate:(__unused UIApplication *)application {
 
   // Block logs queue so that it isn't killed before app termination.
-  dispatch_async(self.logsDispatchQueue, ^{
-    dispatch_semaphore_signal(self.delayedProcessingSemaphore);
-  });
-  dispatch_semaphore_wait(self.delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC));
+  [MSDispatcherUtil blockQueue:self.logsDispatchQueue];
 }
 #endif
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -215,7 +215,7 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 - (void)applicationWillTerminate:(__unused UIApplication *)application {
 
   // Block logs queue so that it isn't killed before app termination.
-  [MSDispatcherUtil blockQueue:self.logsDispatchQueue];
+  [MSDispatcherUtil dispatchAsyncWithTimeout:1 onQueue:self.logsDispatchQueue];
 }
 #endif
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefault.m
@@ -215,7 +215,8 @@ static char *const kMSLogsDispatchQueue = "com.microsoft.appcenter.ChannelGroupQ
 - (void)applicationWillTerminate:(__unused UIApplication *)application {
 
   // Block logs queue so that it isn't killed before app termination.
-  [MSDispatcherUtil dispatchAsyncWithTimeout:1 onQueue:self.logsDispatchQueue];
+  [MSDispatcherUtil dispatchSyncWithTimeout:1 onQueue:self.logsDispatchQueue withBlock: ^{
+  }];
 }
 #endif
 

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
@@ -18,6 +18,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (instancetype)initWithIngestion:(nullable MSAppCenterIngestion *)ingestion;
 
+#if !TARGET_OS_OSX
+/**
+ * Semaphore for blocking logs queue on applicationWillTerminate.
+ */
+@property dispatch_semaphore_t delayedProcessingSemaphore;
+
+/**
+ * Called when applciation is terminating.
+ */
+- (void)applicationWillTerminate:(__unused UIApplication *)application;
+
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
+++ b/AppCenter/AppCenter/Internals/Channel/MSChannelGroupDefaultPrivate.h
@@ -6,6 +6,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class MSAppCenterIngestion;
+@class UIApplication;
 
 @interface MSChannelGroupDefault () <MSChannelDelegate>
 
@@ -19,15 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithIngestion:(nullable MSAppCenterIngestion *)ingestion;
 
 #if !TARGET_OS_OSX
-/**
- * Semaphore for blocking logs queue on applicationWillTerminate.
- */
-@property dispatch_semaphore_t delayedProcessingSemaphore;
 
 /**
  * Called when applciation is terminating.
  */
-- (void)applicationWillTerminate:(__unused UIApplication *)application;
+- (void)applicationWillTerminate:(UIApplication *)application;
 
 #endif
 

--- a/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
+++ b/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
@@ -14,6 +14,11 @@
 
 + (void)performBlockOnMainThread:(void (^)(void))block;
 
-+ (void)blockQueue:(dispatch_queue_t)dispatchQueue;
+/**
+ * Adds a dispatch_async block to the provided queue and waits for its execution.
+ * @param timeout timeout for waiting in seconds.
+ * @param dispatchQueue the queue to perform block on.
+ */
++ (void)dispatchAsyncWithTimeout:(int)timeout onQueue:(dispatch_queue_t)dispatchQueue;
 
 @end

--- a/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
+++ b/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
@@ -16,9 +16,9 @@
 
 /**
  * Adds a dispatch_async block to the provided queue and waits for its execution.
- * @param timeout timeout for waiting in seconds.
- * @param dispatchQueue the queue to perform block on.
- * @param block the block to be executed.
+ * @param timeout Timeout for waiting in seconds.
+ * @param dispatchQueue The queue to perform a block on.
+ * @param block The block to be executed.
  */
 + (void)dispatchSyncWithTimeout:(NSTimeInterval)timeout onQueue:(dispatch_queue_t)dispatchQueue withBlock:(dispatch_block_t)block;
 

--- a/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
+++ b/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
@@ -20,6 +20,6 @@
  * @param dispatchQueue the queue to perform block on.
  * @param block the block to be executed.
  */
-+ (void)dispatchSyncWithTimeout:(float)timeout onQueue:(dispatch_queue_t)dispatchQueue withBlock:(dispatch_block_t)block;
++ (void)dispatchSyncWithTimeout:(NSTimeInterval)timeout onQueue:(dispatch_queue_t)dispatchQueue withBlock:(dispatch_block_t)block;
 
 @end

--- a/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
+++ b/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
@@ -14,4 +14,6 @@
 
 + (void)performBlockOnMainThread:(void (^)(void))block;
 
++ (void)blockQueue:(dispatch_queue_t)dispatchQueue;
+
 @end

--- a/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
+++ b/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
@@ -18,7 +18,8 @@
  * Adds a dispatch_async block to the provided queue and waits for its execution.
  * @param timeout timeout for waiting in seconds.
  * @param dispatchQueue the queue to perform block on.
+ * @param block the block to be executed.
  */
-+ (void)dispatchAsyncWithTimeout:(int)timeout onQueue:(dispatch_queue_t)dispatchQueue;
++ (void)dispatchSyncWithTimeout:(int)timeout onQueue:(dispatch_queue_t)dispatchQueue withBlock:(dispatch_block_t)block;
 
 @end

--- a/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
+++ b/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.h
@@ -20,6 +20,6 @@
  * @param dispatchQueue the queue to perform block on.
  * @param block the block to be executed.
  */
-+ (void)dispatchSyncWithTimeout:(int)timeout onQueue:(dispatch_queue_t)dispatchQueue withBlock:(dispatch_block_t)block;
++ (void)dispatchSyncWithTimeout:(float)timeout onQueue:(dispatch_queue_t)dispatchQueue withBlock:(dispatch_block_t)block;
 
 @end

--- a/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.m
+++ b/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.m
@@ -23,11 +23,11 @@
   block();
 }
 
-+ (void)blockQueue:(dispatch_queue_t)dispatchQueue {
++ (void)dispatchAsyncWithTimeout:(int)timeout onQueue:(dispatch_queue_t)dispatchQueue {
   dispatch_semaphore_t delayedProcessingSemaphore = dispatch_semaphore_create(0);
   dispatch_async(dispatchQueue, ^{
     dispatch_semaphore_signal(delayedProcessingSemaphore);
   });
-  dispatch_semaphore_wait(delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC));
+  dispatch_semaphore_wait(delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, timeout * NSEC_PER_SEC));
 }
 @end

--- a/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.m
+++ b/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.m
@@ -23,4 +23,11 @@
   block();
 }
 
++ (void)blockQueue:(dispatch_queue_t)dispatchQueue {
+  dispatch_semaphore_t delayedProcessingSemaphore = dispatch_semaphore_create(0);
+  dispatch_async(dispatchQueue, ^{
+    dispatch_semaphore_signal(delayedProcessingSemaphore);
+  });
+  dispatch_semaphore_wait(delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC));
+}
 @end

--- a/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.m
+++ b/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.m
@@ -23,9 +23,10 @@
   block();
 }
 
-+ (void)dispatchAsyncWithTimeout:(int)timeout onQueue:(dispatch_queue_t)dispatchQueue {
++ (void)dispatchSyncWithTimeout:(int)timeout onQueue:(dispatch_queue_t)dispatchQueue withBlock:(dispatch_block_t)block {
   dispatch_semaphore_t delayedProcessingSemaphore = dispatch_semaphore_create(0);
   dispatch_async(dispatchQueue, ^{
+    block();
     dispatch_semaphore_signal(delayedProcessingSemaphore);
   });
   dispatch_semaphore_wait(delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, timeout * NSEC_PER_SEC));

--- a/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.m
+++ b/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.m
@@ -23,12 +23,12 @@
   block();
 }
 
-+ (void)dispatchSyncWithTimeout:(int)timeout onQueue:(dispatch_queue_t)dispatchQueue withBlock:(dispatch_block_t)block {
++ (void)dispatchSyncWithTimeout:(float)timeout onQueue:(dispatch_queue_t)dispatchQueue withBlock:(dispatch_block_t)block {
   dispatch_semaphore_t delayedProcessingSemaphore = dispatch_semaphore_create(0);
   dispatch_async(dispatchQueue, ^{
     block();
     dispatch_semaphore_signal(delayedProcessingSemaphore);
   });
-  dispatch_semaphore_wait(delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, timeout * NSEC_PER_SEC));
+  dispatch_semaphore_wait(delayedProcessingSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC)));
 }
 @end

--- a/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.m
+++ b/AppCenter/AppCenter/Internals/Util/MSDispatcherUtil.m
@@ -23,7 +23,7 @@
   block();
 }
 
-+ (void)dispatchSyncWithTimeout:(float)timeout onQueue:(dispatch_queue_t)dispatchQueue withBlock:(dispatch_block_t)block {
++ (void)dispatchSyncWithTimeout:(NSTimeInterval)timeout onQueue:(dispatch_queue_t)dispatchQueue withBlock:(dispatch_block_t)block {
   dispatch_semaphore_t delayedProcessingSemaphore = dispatch_semaphore_create(0);
   dispatch_async(dispatchQueue, ^{
     block();

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -1,11 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#import "TargetConditionals.h"
-#if !TARGET_OS_OSX
-#import <UIKit/UIKit.h>
-#endif
-
 #import "MSAbstractLogInternal.h"
 #import "MSAppCenterIngestion.h"
 #import "MSChannelDelegate.h"

--- a/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSChannelGroupDefaultTests.m
@@ -79,14 +79,14 @@
   // Then
   OCMVerify([sut applicationWillTerminate:OCMOCK_ANY]);
   XCTAssertNotNil(self.sut.logsDispatchQueue);
-  
+
   // If
   [self.sut setEnabled:NO andDeleteDataOnDisabled:YES];
   OCMReject([sut applicationWillTerminate:OCMOCK_ANY]);
-  
+
   // When
   [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillTerminateNotification object:sut];
-  
+
   // Then
   self.sut.logsDispatchQueue = nil;
   OCMVerifyAll(sut);

--- a/AppCenter/AppCenterTests/MSUtilityTests.m
+++ b/AppCenter/AppCenterTests/MSUtilityTests.m
@@ -1014,6 +1014,53 @@ static NSTimeInterval const kMSTestTimeout = 1.0;
                                }];
 }
 
+- (void)testDispatchSyncWithTimeoutDoesNotWait {
+
+  // If
+  XCTestExpectation *expectation = [self expectationWithDescription:@"block not called."];
+  [expectation setInverted:YES];
+  dispatch_queue_t serialQueue = dispatch_queue_create("test", DISPATCH_QUEUE_SERIAL);
+
+  // When
+  [MSDispatcherUtil dispatchSyncWithTimeout:1
+                                    onQueue:serialQueue
+                                  withBlock:^{
+                                    [NSThread sleepForTimeInterval:4.000];
+                                    [expectation fulfill];
+                                  }];
+
+  // Then
+  [self waitForExpectationsWithTimeout:kMSTestTimeout
+                               handler:^(NSError *error) {
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                               }];
+}
+
+- (void)testDispatchSyncWithTimeoutWaitsForBlock {
+
+  // If
+  XCTestExpectation *expectation = [self expectationWithDescription:@"block called."];
+  dispatch_queue_t serialQueue = dispatch_queue_create("test", DISPATCH_QUEUE_SERIAL);
+
+  // When
+  [MSDispatcherUtil dispatchSyncWithTimeout:3
+                                    onQueue:serialQueue
+                                  withBlock:^{
+                                    [NSThread sleepForTimeInterval:2.000];
+                                    [expectation fulfill];
+                                  }];
+
+  // Then
+  [self waitForExpectationsWithTimeout:kMSTestTimeout
+                               handler:^(NSError *error) {
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                               }];
+}
+
 - (void)testPerformBlockOnMainThreadFromBackground {
 
   // If

--- a/AppCenter/AppCenterTests/MSUtilityTests.m
+++ b/AppCenter/AppCenterTests/MSUtilityTests.m
@@ -1017,20 +1017,21 @@ static NSTimeInterval const kMSTestTimeout = 1.0;
 - (void)testDispatchSyncWithTimeoutDoesNotWait {
 
   // If
+  NSTimeInterval blockTimeout = 0.1;
   XCTestExpectation *expectation = [self expectationWithDescription:@"block not called."];
   [expectation setInverted:YES];
   dispatch_queue_t serialQueue = dispatch_queue_create("test", DISPATCH_QUEUE_SERIAL);
 
   // When
-  [MSDispatcherUtil dispatchSyncWithTimeout:1
+  [MSDispatcherUtil dispatchSyncWithTimeout:blockTimeout
                                     onQueue:serialQueue
                                   withBlock:^{
-                                    [NSThread sleepForTimeInterval:4.000];
+                                    [NSThread sleepForTimeInterval:blockTimeout * 2];
                                     [expectation fulfill];
                                   }];
 
   // Then
-  [self waitForExpectationsWithTimeout:kMSTestTimeout
+  [self waitForExpectationsWithTimeout:0
                                handler:^(NSError *error) {
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
@@ -1041,19 +1042,20 @@ static NSTimeInterval const kMSTestTimeout = 1.0;
 - (void)testDispatchSyncWithTimeoutWaitsForBlock {
 
   // If
+  NSTimeInterval blockTimeout = 0.5;
   XCTestExpectation *expectation = [self expectationWithDescription:@"block called."];
   dispatch_queue_t serialQueue = dispatch_queue_create("test", DISPATCH_QUEUE_SERIAL);
 
   // When
-  [MSDispatcherUtil dispatchSyncWithTimeout:3
+  [MSDispatcherUtil dispatchSyncWithTimeout:blockTimeout
                                     onQueue:serialQueue
                                   withBlock:^{
-                                    [NSThread sleepForTimeInterval:2.000];
+                                    [NSThread sleepForTimeInterval:blockTimeout / 2];
                                     [expectation fulfill];
                                   }];
 
   // Then
-  [self waitForExpectationsWithTimeout:kMSTestTimeout
+  [self waitForExpectationsWithTimeout:0
                                handler:^(NSError *error) {
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * **[Fix]** Fix compatibility with Xcode 12 beta when integrating SDK from sources.
 
+### App Center Analytics
+
+* **[Fix]** Fix sending logs from `applicationWillTerminate`.
+
 ___
 
 ## Version 3.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### App Center Analytics
 
-* **[Fix]** Fix sending logs from `applicationWillTerminate`.
+* **[Fix]** Fix processing logs (e.g., events) emitted from the `applicationWillTerminate` application delegate method.
 
 ___
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [X] Are tests passing locally?
* [X] Are the files formatted correctly?
* [x] Did you add unit tests?
* [X] Did you check UI tests on the sample app? They are not executed on CI.
* [X] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Logs sent from `applicationWillTerminate` were not being saved because of `dispatch_async` call. 
To fix this, we add a task to the logsQueue and wait for it inside `applicationWillTerminate` event.

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-apple/issues/2123/

## Misc

[AB#81803](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/81803)
