### PR TITLE
Fix checkForUpdate if it's called before applicationDidBecomeActive

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSDistributePrivate.h
@@ -340,10 +340,8 @@ static NSString *const kMSTesterAppUpdateSetupFailedKey = @"TesterAppUpdateSetup
 
 /**
  * Start update workflow.
- *
- * @param onStart A flag that indicates whether it is called when Distribute is started or not.
  */
-- (void)startUpdateOnStart:(BOOL)onStart;
+- (void)startUpdate;
 
 /**
  * Start download for the given details.

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeCheckForUpdateTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeCheckForUpdateTests.m
@@ -64,7 +64,7 @@ static NSString *const kMSTestAppSecret = @"IAMSECRET";
   OCMStub([distributeMock canBeUsed]).andReturn(YES);
   OCMStub([distributeMock isEnabled]).andReturn(NO);
   [self.settingsMock removeObjectForKey:kMSUpdateTokenRequestIdKey];
-  OCMReject([distributeMock startUpdateOnStart:OCMOCK_ANY]);
+  OCMReject([distributeMock startUpdate]);
 
   // When
   [MSDistribute checkForUpdate];
@@ -83,7 +83,7 @@ static NSString *const kMSTestAppSecret = @"IAMSECRET";
   OCMStub([distributeMock canBeUsed]).andReturn(NO);
   OCMStub([distributeMock isEnabled]).andReturn(YES);
   [self.settingsMock removeObjectForKey:kMSUpdateTokenRequestIdKey];
-  OCMReject([distributeMock startUpdateOnStart:OCMOCK_ANY]);
+  OCMReject([distributeMock startUpdate]);
 
   // When
   [MSDistribute checkForUpdate];
@@ -102,7 +102,7 @@ static NSString *const kMSTestAppSecret = @"IAMSECRET";
   OCMStub([distributeMock canBeUsed]).andReturn(YES);
   OCMStub([distributeMock isEnabled]).andReturn(YES);
   [self.settingsMock setObject:@"testToken" forKey:kMSUpdateTokenRequestIdKey];
-  OCMReject([distributeMock startUpdateOnStart:OCMOCK_ANY]);
+  OCMReject([distributeMock startUpdate]);
 
   // When
   [MSDistribute checkForUpdate];
@@ -173,7 +173,7 @@ static NSString *const kMSTestAppSecret = @"IAMSECRET";
   [self waitForExpectationsWithTimeout:1
                                handler:^(NSError *error) {
                                  // Then
-                                 OCMVerify([distributeMock startUpdateOnStart:NO]);
+                                 OCMVerify([distributeMock startUpdate]);
                                  OCMVerify([distributeMock openUrlInAuthenticationSessionOrSafari:OCMOCK_ANY]);
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
@@ -219,7 +219,7 @@ static NSString *const kMSTestAppSecret = @"IAMSECRET";
   [self waitForExpectationsWithTimeout:1
                                handler:^(NSError *error) {
                                  // Then
-                                 OCMVerify([distributeMock startUpdateOnStart:NO]);
+                                 OCMVerify([distributeMock startUpdate]);
                                  OCMVerify([distributeMock checkLatestRelease:OCMOCK_ANY
                                                           distributionGroupId:OCMOCK_ANY
                                                                   releaseHash:OCMOCK_ANY]);

--- a/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
+++ b/AppCenterDistribute/AppCenterDistributeTests/MSDistributeTests.m
@@ -1643,7 +1643,7 @@ static NSURL *sfURL;
 
   // When
   [self.sut applyEnabledState:YES];
-  [self.sut startUpdateOnStart:NO];
+  [self.sut startUpdate];
   dispatch_async(dispatch_get_main_queue(), ^{
     [expectation fulfill];
   });
@@ -2078,7 +2078,7 @@ static NSURL *sfURL;
   MSDistribute *distribute = [MSDistribute new];
   id distributeMock = OCMPartialMock(distribute);
   __block int startUpdateCounter = 0;
-  OCMStub([distributeMock startUpdateOnStart:OCMOCK_ANY]).andDo(^(__attribute((unused)) NSInvocation *invocation) {
+  OCMStub([distributeMock startUpdate]).andDo(^(__attribute((unused)) NSInvocation *invocation) {
     startUpdateCounter++;
   });
 
@@ -2576,7 +2576,7 @@ static NSURL *sfURL;
   [self.settingsMock setObject:kMSTestDownloadedDistributionGroupId forKey:kMSDownloadedDistributionGroupIdKey];
 
   // When
-  [self.sut startUpdateOnStart:NO];
+  [self.sut startUpdate];
 
   // Then
   OCMVerify([distributeMock changeDistributionGroupIdAfterAppUpdateIfNeeded:kMSTestReleaseHash]);
@@ -2603,7 +2603,7 @@ static NSURL *sfURL;
   OCMReject([distributeMock checkLatestRelease:OCMOCK_ANY distributionGroupId:OCMOCK_ANY releaseHash:OCMOCK_ANY]);
 
   // When
-  [self.sut startUpdateOnStart:NO];
+  [self.sut startUpdate];
 
   // Then
   XCTAssertFalse(self.sut.updateFlowInProgress);
@@ -2629,7 +2629,7 @@ static NSURL *sfURL;
   [self.settingsMock setObject:kMSTestDownloadedDistributionGroupId forKey:kMSDownloadedDistributionGroupIdKey];
 
   // When
-  [self.sut startUpdateOnStart:NO];
+  [self.sut startUpdate];
 
   // Then
   XCTAssertTrue(checkLatestReleaseCalled);
@@ -2651,7 +2651,7 @@ static NSURL *sfURL;
   [self.settingsMock setObject:kMSTestDownloadedDistributionGroupId forKey:kMSDownloadedDistributionGroupIdKey];
 
   // When
-  [self.sut startUpdateOnStart:NO];
+  [self.sut startUpdate];
 
   // Then
   OCMVerify([distributeMock changeDistributionGroupIdAfterAppUpdateIfNeeded:kMSTestReleaseHash]);
@@ -2675,7 +2675,7 @@ static NSURL *sfURL;
   [self.settingsMock setObject:kMSTestDistributionGroupId forKey:kMSDownloadedDistributionGroupIdKey];
 
   // When
-  [self.sut startUpdateOnStart:NO];
+  [self.sut startUpdate];
 
   // Then
   OCMVerify([distributeMock changeDistributionGroupIdAfterAppUpdateIfNeeded:kMSTestReleaseHash]);
@@ -2699,7 +2699,7 @@ static NSURL *sfURL;
   [self.settingsMock removeObjectForKey:kMSDownloadedDistributionGroupIdKey];
 
   // When
-  [self.sut startUpdateOnStart:NO];
+  [self.sut startUpdate];
 
   // Then
   OCMVerify([distributeMock changeDistributionGroupIdAfterAppUpdateIfNeeded:kMSTestReleaseHash]);
@@ -2722,7 +2722,7 @@ static NSURL *sfURL;
   [self.settingsMock removeObjectForKey:kMSDownloadedDistributionGroupIdKey];
 
   // When
-  [self.sut startUpdateOnStart:NO];
+  [self.sut startUpdate];
 
   // Then
   OCMVerify([distributeMock changeDistributionGroupIdAfterAppUpdateIfNeeded:kMSTestReleaseHash]);
@@ -2805,7 +2805,7 @@ static NSURL *sfURL;
   OCMStub([notificationCenterMock defaultCenter]).andReturn(notificationCenterMock);
   MSDistribute *distribute = [MSDistribute new];
   id distributeMock = OCMPartialMock(distribute);
-  OCMReject([distributeMock startUpdateOnStart:OCMOCK_ANY]);
+  OCMReject([distributeMock startUpdate]);
 
   // When
   [distribute setEnabled:YES];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 3.3.4 (Under development)
 
+### App Center Distribute
+
+* **[Fix]** Fix manually checking for updates before `applicationDidBecomeActive` event.
+
 ___
 
 ## Version 3.3.3


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

`applicationDidBecomeActive` incorrectly resets `updateFlowInProgress` flag so, customers get
`There is no update flow in progress. Ignore the request.`
message instead of installing a new version.

## Related PRs or issues

[AB#82640](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/82640)
