### PR TITLE
Fix problem with timeouts while testing dispatchSyncWithTimeout function.

### DIFF
--- a/AppCenter/AppCenterTests/MSUtilityTests.m
+++ b/AppCenter/AppCenterTests/MSUtilityTests.m
@@ -1019,6 +1019,8 @@ static NSTimeInterval const kMSTestTimeout = 1.0;
   // If
   NSTimeInterval blockTimeout = 0.1;
   XCTestExpectation *expectation = [self expectationWithDescription:@"block not called."];
+    
+  // Should be pass if `[expectation fulfill]` will be called later than `waitForExpectationsWithTimeout`.
   [expectation setInverted:YES];
   dispatch_queue_t serialQueue = dispatch_queue_create("test", DISPATCH_QUEUE_SERIAL);
   __block dispatch_semaphore_t delayedSemaphore = dispatch_semaphore_create(0);

--- a/AppCenter/AppCenterTests/MSUtilityTests.m
+++ b/AppCenter/AppCenterTests/MSUtilityTests.m
@@ -1027,7 +1027,7 @@ static NSTimeInterval const kMSTestTimeout = 1.0;
   [MSDispatcherUtil dispatchSyncWithTimeout:blockTimeout
                                     onQueue:serialQueue
                                   withBlock:^{
-                                    dispatch_semaphore_wait(delayedSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10000 * NSEC_PER_SEC)));
+                                    dispatch_semaphore_wait(delayedSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_SEC)));
                                     [expectation fulfill];
                                   }];
 

--- a/AppCenter/AppCenterTests/MSUtilityTests.m
+++ b/AppCenter/AppCenterTests/MSUtilityTests.m
@@ -1021,21 +1021,20 @@ static NSTimeInterval const kMSTestTimeout = 1.0;
   XCTestExpectation *expectation = [self expectationWithDescription:@"block not called."];
   [expectation setInverted:YES];
   dispatch_queue_t serialQueue = dispatch_queue_create("test", DISPATCH_QUEUE_SERIAL);
-
   __block dispatch_semaphore_t delayedSemaphore = dispatch_semaphore_create(0);
     
   // When
   [MSDispatcherUtil dispatchSyncWithTimeout:blockTimeout
                                     onQueue:serialQueue
                                   withBlock:^{
-                                    dispatch_semaphore_wait(delayedSemaphore, DISPATCH_TIME_FOREVER);
+                                    dispatch_semaphore_wait(delayedSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10000 * NSEC_PER_SEC)));
                                     [expectation fulfill];
                                   }];
 
   // Then
   [self waitForExpectationsWithTimeout:0
                                handler:^(NSError *error) {
-                                dispatch_semaphore_signal(delayedSemaphore);
+                                 dispatch_semaphore_signal(delayedSemaphore);
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }

--- a/AppCenter/AppCenterTests/MSUtilityTests.m
+++ b/AppCenter/AppCenterTests/MSUtilityTests.m
@@ -1026,7 +1026,7 @@ static NSTimeInterval const kMSTestTimeout = 1.0;
   [MSDispatcherUtil dispatchSyncWithTimeout:blockTimeout
                                     onQueue:serialQueue
                                   withBlock:^{
-                                    [NSThread sleepForTimeInterval:blockTimeout * 2];
+                                    [NSThread sleepForTimeInterval:blockTimeout * 4];
                                     [expectation fulfill];
                                   }];
 

--- a/AppCenter/AppCenterTests/MSUtilityTests.m
+++ b/AppCenter/AppCenterTests/MSUtilityTests.m
@@ -1022,17 +1022,20 @@ static NSTimeInterval const kMSTestTimeout = 1.0;
   [expectation setInverted:YES];
   dispatch_queue_t serialQueue = dispatch_queue_create("test", DISPATCH_QUEUE_SERIAL);
 
+  __block dispatch_semaphore_t delayedSemaphore = dispatch_semaphore_create(0);
+    
   // When
   [MSDispatcherUtil dispatchSyncWithTimeout:blockTimeout
                                     onQueue:serialQueue
                                   withBlock:^{
-                                    [NSThread sleepForTimeInterval:blockTimeout * 4];
+                                    dispatch_semaphore_wait(delayedSemaphore, DISPATCH_TIME_FOREVER);
                                     [expectation fulfill];
                                   }];
 
   // Then
   [self waitForExpectationsWithTimeout:0
                                handler:^(NSError *error) {
+                                dispatch_semaphore_signal(delayedSemaphore);
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }


### PR DESCRIPTION
Things to consider before you submit the PR:

* [ ] ~~Has `CHANGELOG.md` been updated?~~ (Only the test is fixed)
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] ~~Did you add unit tests?~~ (Only the  test is fixed)
* [ ] ~~Did you check UI tests on the sample app? They are not executed on CI.~~ (Only the  test is fixed)
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Test faults were caused by checking expectation, before setting it to done. Fix failing test by increasing the timeout difference between fulfilling expectations and checking it. Before there was a 0.1-second difference and now it is 0.3 seconds. 

## Related PRs or issues

[AB#82663](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/82663)

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
