### PR TITLE
[#2162] Fix NSInvalidArgumentException in MSAppCenterUserDefaults

### DIFF
--- a/AppCenter/AppCenter/Internals/Model/Util/MSAppCenterUserDefaults.m
+++ b/AppCenter/AppCenter/Internals/Model/Util/MSAppCenterUserDefaults.m
@@ -47,7 +47,7 @@ static dispatch_once_t onceToken;
       NSString *oldKeyPrefix = ((MSUserDefaultsPrefixKey *)oldKey).keyPrefix;
       NSArray *userDefaultsDictionary = [[[NSUserDefaults standardUserDefaults] dictionaryRepresentation] allKeys];
       for (NSString *userDefaultsKey in userDefaultsDictionary) {
-        if ([userDefaultsKey hasPrefix:oldKeyPrefix]) {
+        if ([userDefaultsKey isKindOfClass:[NSString class]] && [userDefaultsKey hasPrefix:oldKeyPrefix]) {
           NSString *suffix = [userDefaultsKey substringFromIndex:[oldKeyPrefix length]];
           NSString *newKeyWithSuffix = [newKeyString stringByAppendingString:suffix];
           id value = [[NSUserDefaults standardUserDefaults] objectForKey:userDefaultsKey];

--- a/AppCenter/AppCenterTests/MSUserDefaultsTests.m
+++ b/AppCenter/AppCenterTests/MSUserDefaultsTests.m
@@ -4,9 +4,9 @@
 #import "MSAppCenterUserDefaults.h"
 #import "MSAppCenterUserDefaultsPrivate.h"
 #import "MSLoggerInternal.h"
-#import "MSTestFrameworks.h"
 #import "MSUtility.h"
 #import "MSWrapperLogger.h"
+#import <XCTest/XCTest.h>
 
 @interface MSUserDefaultsTests : XCTestCase
 
@@ -119,6 +119,19 @@ static NSString *const kMSAppCenterUserDefaultsMigratedKey = @"MSAppCenter310App
     }
     XCTAssertFalse([userDefaultKeys containsObject:oldKey]);
   }
+}
+
+- (void)testUnexpectedKeyTypeInMigrateUserDefaultSettings {
+
+  // If
+  NSDictionary *keys = @{@"MSAppCenterKeyTest1" : @"okeyTest1"};
+  MSAppCenterUserDefaults *userDefaults = [MSAppCenterUserDefaults shared];
+
+  // When
+  [[NSUserDefaults standardUserDefaults] setObject:@"Test 1" forKey:kCFBooleanTrue];
+
+  // Then
+  XCTAssertNoThrow([userDefaults migrateKeys:keys forService:@"AppCenter"]);
 }
 
 @end

--- a/AppCenter/AppCenterTests/MSUserDefaultsTests.m
+++ b/AppCenter/AppCenterTests/MSUserDefaultsTests.m
@@ -4,9 +4,9 @@
 #import "MSAppCenterUserDefaults.h"
 #import "MSAppCenterUserDefaultsPrivate.h"
 #import "MSLoggerInternal.h"
+#import "MSTestFrameworks.h"
 #import "MSUtility.h"
 #import "MSWrapperLogger.h"
-#import <XCTest/XCTest.h>
 
 @interface MSUserDefaultsTests : XCTestCase
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 3.3.5 (Under development)
 
+### App Center
+
+* **[Fix]** Fix `NSInvalidArgumentException` when using `__NSCFBoolean` as a key in `NSUserDefaults`.
+
 ___
 
 ## Version 3.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center
 
-* **[Fix]** Fix `NSInvalidArgumentException` when using `__NSCFBoolean` as a key in `NSUserDefaults`.
+* **[Fix]** Fix `NSInvalidArgumentException` when using non-string object as a key in `NSUserDefaults`.
 
 ___
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR addresses edge case in `MSAppCenterUserDefaults` when `__NSCFBoolean` is used instead of `NSString` as a key in `NSUserDefaults.dictionaryRepresentation`.

## Related PRs or issues
https://github.com/microsoft/appcenter-sdk-apple/issues/2162

[AB#82990](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/82990)