### PR TITLE
Keep macOS x64 binary that was built on Xcode 11

### DIFF
--- a/.azure-pipelines/build-apple-silicon-framework-template.yml
+++ b/.azure-pipelines/build-apple-silicon-framework-template.yml
@@ -12,7 +12,7 @@ steps:
         scheme: '${{ module }} macOS Framework'
         xcodeVersion: specifyPath
         xcodeDeveloperDir: '$(APPLE_SILICON_XCODE_PATH)'
-        args: 'SYMROOT="$(Build.BinariesDirectory)"'
+        args: 'SYMROOT="$(Build.BinariesDirectory)" ONLY_ACTIVE_ARCH=NO ARCHS=arm64'
 
     - task: Xcode@5
       displayName: ${{ format('Build {0} Mac Catalyst for Apple Silicon', module) }}
@@ -49,26 +49,22 @@ steps:
       args: 'SYMROOT="$(Build.BinariesDirectory)" ONLY_ACTIVE_ARCH=NO ARCHS=arm64'
 
   - bash: |
-      if [ -e "AppCenter-SDK-Apple/macOS/${{ module }}.framework" ]; then
-        rm -rf "AppCenter-SDK-Apple/macOS/${{ module }}.framework"
-        cp -R "$BUILD_BINARIESDIRECTORY/Release/${{ module }}.framework" "AppCenter-SDK-Apple/macOS"
-        lipo -info "AppCenter-SDK-Apple/macOS/${{ module }}.framework/${{ module }}"
-        rm -rf "$BUILD_BINARIESDIRECTORY/Release-xcframework/${{ module }}.xcframework/macos-x86_64/${{ module }}.framework"
-        cp -R "$BUILD_BINARIESDIRECTORY/Release/${{ module }}.framework" "$BUILD_BINARIESDIRECTORY/Release-xcframework/${{ module }}.xcframework/macos-x86_64"
-      fi
-
-      append_to_xcframework() {
-        if [ ! -e "$BUILD_BINARIESDIRECTORY/Release-$2/${{ module }}.framework" ]; then
+      append_to_framework() {
+        if [ ! -e "$1" ]; then
           return 1
         fi
-        local framework="$BUILD_BINARIESDIRECTORY/Release-xcframework/${{ module }}.xcframework/$1/${{ module }}.framework"
-        local binary="$framework/Versions/A/${{ module }}"
-        [[ ! -e "$binary" ]] && binary="$framework/${{ module }}"
-        lipo "$binary" \
-          "$BUILD_BINARIESDIRECTORY/Release-$2/${{ module }}.framework/${{ module }}" \
-          -create -output "$binary"
+        local binary="$1/Versions/A/${{ module }}"
+        [[ ! -e "$binary" ]] && binary="$1/${{ module }}"
+        lipo "$binary" "$2/${{ module }}" -create -output "$binary"
         lipo -info "$binary"
       }
+      append_to_xcframework() {
+        append_to_framework \
+          "$BUILD_BINARIESDIRECTORY/Release-xcframework/${{ module }}.xcframework/$1/${{ module }}.framework" \
+          "$BUILD_BINARIESDIRECTORY/Release-$2/${{ module }}.framework"
+      }
+      append_to_framework "AppCenter-SDK-Apple/macOS/${{ module }}.framework" "$BUILD_BINARIESDIRECTORY/Release/${{ module }}.framework"
+      append_to_framework "$BUILD_BINARIESDIRECTORY/Release-xcframework/${{ module }}.xcframework/macos-x86_64/${{ module }}.framework" "$BUILD_BINARIESDIRECTORY/Release/${{ module }}.framework"
       append_to_xcframework ios-i386_x86_64-simulator iphonesimulator
       append_to_xcframework ios-x86_64-maccatalyst maccatalyst
       append_to_xcframework tvos-x86_64-simulator appletvsimulator


### PR DESCRIPTION
## Description

Fix generating dsym for macOS apps on Xcode 11

```
Command GenerateDSYMFile failed with a nonzero exit code
```


## Related PRs or issues

[AB#83637](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/83637)