### PR TITLE
Fix files selection in the test app

### DIFF
--- a/Sasquatch/Sasquatch/ViewControllers/MSCrashesViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSCrashesViewController.swift
@@ -185,9 +185,11 @@ class MSCrashesViewController: UITableViewController, UIImagePickerControllerDel
 #if !targetEnvironment(macCatalyst)
         PHPhotoLibrary.requestAuthorization({ (status: PHAuthorizationStatus) -> Void in ()
           if PHPhotoLibrary.authorizationStatus() == PHAuthorizationStatus.authorized {
-            let picker = UIImagePickerController()
-            picker.delegate = self
-            self.present(picker, animated: true)
+            DispatchQueue.main.async {
+                let picker = UIImagePickerController()
+                picker.delegate = self
+                self.present(picker, animated: true)
+              }
           }
         })
 #else


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests?~
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

In the Sasquatch demo app on an iOS 14.1 device the application is crashed after clicking `Binary Attachment` button on the Crashes module page.