### PR TITLE
Add Distribute module for Swift Package Manager

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/Internals/MSACDistributeInternal.h
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/MSACDistributeInternal.h
@@ -9,7 +9,7 @@
 #import "MSACReleaseDetailsPrivate.h"
 #import "MSACServiceInternal.h"
 
-#define APP_CENTER_DISTRIBUTE_BUNDLE @"AppCenterDistributeResources.bundle"
+#define APP_CENTER_DISTRIBUTE_BUNDLE_NAME @"AppCenterDistributeResources"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AppCenterDistribute/AppCenterDistribute/Internals/MSACDistributeInternal.h
+++ b/AppCenterDistribute/AppCenterDistribute/Internals/MSACDistributeInternal.h
@@ -9,7 +9,14 @@
 #import "MSACReleaseDetailsPrivate.h"
 #import "MSACServiceInternal.h"
 
+/**
+ * For Swift Package Manager the name of the bundle resource consists of [Package name]_[Resource name].
+ */
+#ifdef SWIFTPM_MODULE_BUNDLE
+#define APP_CENTER_DISTRIBUTE_BUNDLE_NAME @"App Center_AppCenterDistribute"
+#else
 #define APP_CENTER_DISTRIBUTE_BUNDLE_NAME @"AppCenterDistributeResources"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AppCenterDistribute/AppCenterDistribute/MSACDistributeUtil.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistributeUtil.m
@@ -13,12 +13,13 @@ NSBundle *MSACDistributeBundle(void) {
   static NSBundle *bundle = nil;
   static dispatch_once_t predicate;
   dispatch_once(&predicate, ^{
-    // The resource bundle is part of the main app bundle, e.g. .../Puppet.app/AppCenterDistribute.bundle
+  // The resource bundle is part of the main app bundle, e.g. .../Puppet.app/AppCenterDistribute.bundle
 #ifdef SWIFTPM_MODULE_BUNDLE
-    NSBundle *mainBundle = SWIFTPM_MODULE_BUNDLE;
+    NSBundle *mainBundle = [NSBundle mainBundle];
 #else
     NSBundle *mainBundle = [NSBundle bundleForClass:[MSACDistribute class]];
 #endif
+
     NSURL *url = [mainBundle URLForResource:APP_CENTER_DISTRIBUTE_BUNDLE_NAME withExtension:@"bundle"];
     if (url) {
       bundle = [NSBundle bundleWithURL:url];

--- a/AppCenterDistribute/AppCenterDistribute/MSACDistributeUtil.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistributeUtil.m
@@ -14,9 +14,15 @@ NSBundle *MSACDistributeBundle(void) {
   static dispatch_once_t predicate;
   dispatch_once(&predicate, ^{
     // The resource bundle is part of the main app bundle, e.g. .../Puppet.app/AppCenterDistribute.bundle
-    NSString *mainBundlePath = [[NSBundle bundleForClass:[MSACDistribute class]] resourcePath];
-    NSString *frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:APP_CENTER_DISTRIBUTE_BUNDLE];
-    bundle = [NSBundle bundleWithPath:frameworkBundlePath];
+#ifdef SWIFTPM_MODULE_BUNDLE
+    NSBundle *mainBundle = SWIFTPM_MODULE_BUNDLE;
+#else
+    NSBundle *mainBundle = [NSBundle bundleForClass:[MSACDistribute class]];
+#endif
+    NSURL *url = [mainBundle URLForResource:APP_CENTER_DISTRIBUTE_BUNDLE_NAME withExtension:@"bundle"];
+    if (url) {
+      bundle = [NSBundle bundleWithURL:url];
+    }
 
     // Log to console in case the bundle is nil.
     if (!bundle) {

--- a/AppCenterDistribute/AppCenterDistribute/include/AppCenterDistribute.h
+++ b/AppCenterDistribute/AppCenterDistribute/include/AppCenterDistribute.h
@@ -1,0 +1,1 @@
+../AppCenterDistribute.h

--- a/AppCenterDistribute/AppCenterDistribute/include/MSACDistribute.h
+++ b/AppCenterDistribute/AppCenterDistribute/include/MSACDistribute.h
@@ -1,0 +1,1 @@
+../MSACDistribute.h

--- a/AppCenterDistribute/AppCenterDistribute/include/MSACDistributeDelegate.h
+++ b/AppCenterDistribute/AppCenterDistribute/include/MSACDistributeDelegate.h
@@ -1,0 +1,1 @@
+../MSACDistributeDelegate.h

--- a/AppCenterDistribute/AppCenterDistribute/include/MSACReleaseDetails.h
+++ b/AppCenterDistribute/AppCenterDistribute/include/MSACReleaseDetails.h
@@ -1,0 +1,1 @@
+../Model/MSACReleaseDetails.h

--- a/AppCenterDistribute/AppCenterDistribute/include/MSACService.h
+++ b/AppCenterDistribute/AppCenterDistribute/include/MSACService.h
@@ -1,0 +1,1 @@
+../../../AppCenter/AppCenter/MSACService.h

--- a/AppCenterDistribute/AppCenterDistribute/include/MSACServiceAbstract.h
+++ b/AppCenterDistribute/AppCenterDistribute/include/MSACServiceAbstract.h
@@ -1,0 +1,1 @@
+../../../AppCenter/AppCenter/MSACServiceAbstract.h

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Distribute
 
-* **[Feature]** Support Swift Package Manager (5.3)
+* **[Feature]** Add the Distribute module to Swift Package Manager. Please note that due to additional resources bundle, it requires Swift 5.3 (Xcode 12 and higher).
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 4.0.1 (Under development)
 
+### App Center Distribute
+
+* **[Feature]** Support Swift Package Manager (5.3)
+
 ___
 
 ## Version 4.0.0

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -89,7 +89,7 @@ let package = Package(
             path: "AppCenterDistribute/AppCenterDistribute",
             exclude: ["Support"],
             resources: [
-                .copy("AppCenterDistributeResources.bundle"),
+                .process("Resources/AppCenterDistribute.strings"),
             ],
             cSettings: [
                 .headerSearchPath("**"),
@@ -97,8 +97,8 @@ let package = Package(
             ],
             linkerSettings: [
                 .linkedFramework("Foundation"),
-                .linkedFramework("SafariServices"),
-                .linkedFramework("UIKit"),
+                .linkedFramework("SafariServices", .when(platforms: [.iOS])),
+                .linkedFramework("UIKit", .when(platforms: [.iOS])),
             ]
         )
     ]

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -1,0 +1,105 @@
+// swift-tools-version:5.3
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import PackageDescription
+
+let package = Package(
+    name: "App Center",
+    defaultLocalization: "en",
+    platforms: [
+        .iOS(.v9),
+        .macOS(.v10_10),
+        .tvOS(.v11)
+    ],
+    products: [
+        .library(
+            name: "AppCenterAnalytics",
+            type: .static,
+            targets: ["AppCenterAnalytics"]),
+        .library(
+            name: "AppCenterCrashes",
+            type: .static,
+            targets: ["AppCenterCrashes"]),
+        .library(
+            name: "AppCenterDistribute",
+            type: .static,
+            targets: ["AppCenterDistribute"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/microsoft/PLCrashReporter.git", .upToNextMinor(from: "1.8.0")),
+    ],
+    targets: [
+        .target(
+            name: "AppCenter",
+            path: "AppCenter/AppCenter",
+            exclude: ["Support"],
+            cSettings: [
+                .define("APP_CENTER_C_VERSION", to:"\"4.0.1\""),
+                .define("APP_CENTER_C_BUILD", to:"\"1\""),
+                .headerSearchPath("**"),
+            ],
+            linkerSettings: [
+                .linkedLibrary("z"),
+                .linkedLibrary("sqlite3"),
+                .linkedFramework("Foundation"),
+                .linkedFramework("SystemConfiguration"),
+                .linkedFramework("AppKit", .when(platforms: [.macOS])),
+                .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
+                .linkedFramework("CoreTelephony", .when(platforms: [.iOS, .macOS])),
+            ]
+        ),
+        .target(
+            name: "AppCenterAnalytics",
+            dependencies: ["AppCenter"],
+            path: "AppCenterAnalytics/AppCenterAnalytics",
+            exclude: ["Support"],
+            cSettings: [
+                .headerSearchPath("**"),
+                .headerSearchPath("../../AppCenter/AppCenter/**"),
+            ],
+            linkerSettings: [
+                .linkedFramework("Foundation"),
+                .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
+                .linkedFramework("AppKit", .when(platforms: [.macOS])),
+            ]
+        ),
+        .target(
+            name: "AppCenterCrashes",
+            dependencies: [
+                "AppCenter",
+                .product(name: "CrashReporter", package: "PLCrashReporter"),
+            ],
+            path: "AppCenterCrashes/AppCenterCrashes",
+            exclude: ["Support", "Internals/MSACCrashesBufferedLog.hpp"],
+            cSettings: [
+                .headerSearchPath("**"),
+                .headerSearchPath("../../AppCenter/AppCenter/**"),
+            ],
+            linkerSettings: [
+                .linkedFramework("Foundation"),
+                .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
+                .linkedFramework("AppKit", .when(platforms: [.macOS])),
+            ]
+        ),
+        .target(
+            name: "AppCenterDistribute",
+            dependencies: ["AppCenter"],
+            path: "AppCenterDistribute/AppCenterDistribute",
+            exclude: ["Support"],
+            resources: [
+                .copy("AppCenterDistributeResources.bundle"),
+            ],
+            cSettings: [
+                .headerSearchPath("**"),
+                .headerSearchPath("../../AppCenter/AppCenter/**"),
+            ],
+            linkerSettings: [
+                .linkedFramework("Foundation"),
+                .linkedFramework("SafariServices"),
+                .linkedFramework("UIKit"),
+            ]
+        )
+    ]
+)


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests?~
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Add Distribute module for Swift Package Manager.

## Related PRs or issues

[AB#83647](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/83647)

## Misc

Because the API for adding resources to Swift Package Manager was added in Swift 5.3 the Distribute module can be available since Xcode 12 and higher.
