### PR TITLE
Zero page_size was took into account

### DIFF
--- a/AppCenter/AppCenter/Internals/Storage/MSACDBStorage.m
+++ b/AppCenter/AppCenter/Internals/Storage/MSACDBStorage.m
@@ -66,6 +66,11 @@ static int sqliteConfigurationResult = SQLITE_ERROR;
     return result;
   }
   self.pageSize = [MSACDBStorage getPageSizeInOpenedDatabase:db];
+  if (self.pageSize <= 0) {
+    MSACLogError([MSACAppCenter logTag], @"Failed to get storage page size.");
+    sqlite3_close(db);
+    return SQLITE_ERROR;
+  }
   NSUInteger databaseVersion = [MSACDBStorage versionInOpenedDatabase:db result:&result];
   if (result != SQLITE_OK) {
     sqlite3_close(db);
@@ -101,7 +106,12 @@ static int sqliteConfigurationResult = SQLITE_ERROR;
   if (!db) {
     return result;
   }
-
+  if (self.pageSize <= 0) {
+    MSACLogError([MSACAppCenter logTag], @"Probably storage was not configured.");
+    sqlite3_close(db);
+    return SQLITE_ERROR;
+  }
+    
   // The value is stored as part of the database connection and must be reset every time the database is opened.
   long maxPageCount = self.maxSizeInBytes / self.pageSize;
   result = [MSACDBStorage setMaxPageCount:maxPageCount inOpenedDatabase:db];

--- a/AppCenter/AppCenter/Internals/Storage/MSACDBStorage.m
+++ b/AppCenter/AppCenter/Internals/Storage/MSACDBStorage.m
@@ -66,7 +66,7 @@ static int sqliteConfigurationResult = SQLITE_ERROR;
     return result;
   }
   self.pageSize = [MSACDBStorage getPageSizeInOpenedDatabase:db];
-  if (self.pageSize <= 0) {
+  if (self.pageSize == 0) {
     MSACLogError([MSACAppCenter logTag], @"Failed to get storage page size.");
     sqlite3_close(db);
     return SQLITE_ERROR;
@@ -106,8 +106,8 @@ static int sqliteConfigurationResult = SQLITE_ERROR;
   if (!db) {
     return result;
   }
-  if (self.pageSize <= 0) {
-    MSACLogError([MSACAppCenter logTag], @"Probably storage was not configured.");
+  if (self.pageSize == 0) {
+    MSACLogError([MSACAppCenter logTag], @"The database was not configured correctly. The page size is expected to be non zero.");
     sqlite3_close(db);
     return SQLITE_ERROR;
   }
@@ -441,6 +441,14 @@ static int sqliteConfigurationResult = SQLITE_ERROR;
   BOOL success;
   sqlite3 *db = [MSACDBStorage openDatabaseAtFileURL:self.dbFileURL withResult:&result];
   if (!db) {
+    return;
+  }
+  if (self.pageSize == 0) {
+    MSACLogError([MSACAppCenter logTag], @"The database was not configured correctly. The page size is expected to be non zero.");
+    sqlite3_close(db);
+    if (completionHandler) {
+      completionHandler(NO);
+    }
     return;
   }
 

--- a/AppCenter/AppCenterTests/MSACDBStorageTests.m
+++ b/AppCenter/AppCenterTests/MSACDBStorageTests.m
@@ -241,6 +241,17 @@ static const long kMSACTestStorageSizeMinimumUpperLimitInBytes = 40 * 1024;
   assertThatLong(counter, equalToLong(0));
 }
 
+- (void)testInitWithZeroPageSize {
+    id dbStorageMock = OCMClassMock([MSACDBStorage class]);
+    OCMStub([dbStorageMock getPageSizeInOpenedDatabase: [OCMArg anyPointer]]).andReturn(0);
+    self.sut = [[MSACDBStorage alloc] initWithSchema:self.schema version:1 filename:kMSACTestDBFileName];
+    int result = [self.sut executeQueryUsingBlock:^int(void *_Nonnull __unused db) {
+      return SQLITE_OK;
+    }];
+    XCTAssertEqual(SQLITE_ERROR, result);
+    [dbStorageMock stopMocking];
+}
+
 - (void)testGetPageSizeInOpenedDatabaseReturnsZeroWhenQueryFails {
 
   // If

--- a/AppCenter/AppCenterTests/MSACDBStorageTests.m
+++ b/AppCenter/AppCenterTests/MSACDBStorageTests.m
@@ -252,6 +252,26 @@ static const long kMSACTestStorageSizeMinimumUpperLimitInBytes = 40 * 1024;
     [dbStorageMock stopMocking];
 }
 
+- (void)testMaxStorageSizeWithZeroPageSize {
+    id dbStorageMock = OCMClassMock([MSACDBStorage class]);
+    OCMStub([dbStorageMock getPageSizeInOpenedDatabase: [OCMArg anyPointer]]).andReturn(0);
+    self.sut = [[MSACDBStorage alloc] initWithSchema:self.schema version:1 filename:kMSACTestDBFileName];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler invoked."];
+    long maxCapacityInBytes = kMSACTestStorageSizeMinimumUpperLimitInBytes + 4 * 1024;
+    [self.sut setMaxStorageSize:maxCapacityInBytes
+                           completionHandler:^(BOOL success){
+                             XCTAssertFalse(success);
+                             [expectation fulfill];
+                           }];
+    [self waitForExpectationsWithTimeout:1
+                                 handler:^(NSError *_Nullable error) {
+                                   if (error) {
+                                     XCTFail(@"Expectation Failed with error: %@", error);
+                                   }
+                                 }];
+    [dbStorageMock stopMocking];
+}
+
 - (void)testGetPageSizeInOpenedDatabaseReturnsZeroWhenQueryFails {
 
   // If

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### App Center
 
 * **[Fix]** Fix `double-quoted` warnings in Xcode 12.
+* **[Fix]** Fix possible exception because of storage pageSize property zero value.
 
 ### App Center Distribute
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### App Center
 
 * **[Fix]** Fix `double-quoted` warnings in Xcode 12.
-* **[Fix]** Fix possible exception because of storage pageSize property zero value.
+* **[Fix]** Fix a crash when SQLite returns zero for `page_size`.
 
 ### App Center Distribute
 


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

In some cases storage _pageSize_ property could be 0. The main possible cause of this behavior - query failed. In this case we can't say that storage was configured correctly and configuration method should return error.

## Related PRs or issues

[AB#83894](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/83894)
https://github.com/microsoft/appcenter-sdk-apple/issues/2225/
