### PR TITLE
Fix SasquatchMacSwift build linker error

### DIFF
--- a/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
+++ b/SasquatchMac/SasquatchMac.xcodeproj/project.pbxproj
@@ -108,6 +108,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		322992BB25782F1D0028AC7E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2AFD286247D630F007E6EE1 /* AppCenter.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = C229D8AB2546E7E5001909F3;
+			remoteInfo = AppCenter;
+		};
+		322992E425782F270028AC7E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2AFD26A247D630F007E6EE1 /* AppCenterCrashes.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 324F3C1B25478C780006E223;
+			remoteInfo = AppCenterCrashes;
+		};
 		324F3F1D2548705B0006E223 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C2AFD286247D630F007E6EE1 /* AppCenter.xcodeproj */;
@@ -875,6 +889,8 @@
 			buildRules = (
 			);
 			dependencies = (
+				322992E525782F270028AC7E /* PBXTargetDependency */,
+				322992BC25782F1D0028AC7E /* PBXTargetDependency */,
 				C2F157592338E5D300798480 /* PBXTargetDependency */,
 			);
 			name = "SasquatchMacSwift-Extension";
@@ -1399,6 +1415,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		322992BC25782F1D0028AC7E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AppCenter;
+			targetProxy = 322992BB25782F1D0028AC7E /* PBXContainerItemProxy */;
+		};
+		322992E525782F270028AC7E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AppCenterCrashes;
+			targetProxy = 322992E425782F270028AC7E /* PBXContainerItemProxy */;
+		};
 		324F3F1E2548705B0006E223 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = AppCenter;


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* ~[ ] Has `CHANGELOG.md` been updated?~
* [x] Are tests passing locally?
* ~[ ] Are the files formatted correctly?~
* ~[ ] Did you add unit tests?~
* ~[ ] Did you check UI tests on the sample app? They are not executed on CI.~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

SasquatchMacSwift build failed because the required dependencies (AppCenter and AppCenterCrashes) were missing in the SasquatchMacSwift-Extension target. The error message was "Module 'AppCenterCrashes' not found".

For some reason, it was only reproducing on an apple silicon machine.

## Related PRs or issues

[AB#83835](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/83835)
