### PR TITLE
Update version script doesn't work for Package@swift-5.3

### DIFF
--- a/Scripts/update-version.sh
+++ b/Scripts/update-version.sh
@@ -33,6 +33,7 @@ PROJECT_DIR="$(dirname "$0")/.."
 DOCUMENT_DIR="$PROJECT_DIR/Documentation"
 PODSPEC_FILE="$PROJECT_DIR/AppCenter.podspec"
 SWIFTPM_FILE="$PROJECT_DIR/Package.swift"
+SWIFTPM_5_3_FILE="$PROJECT_DIR/Package@swift-5.3.swift"
 
 # Update framework version
 $(dirname "$0")/framework-version.sh $new_version
@@ -46,4 +47,8 @@ done
 sed -i '' "s/\(\.version[[:space:]]*= \)\'.*\'$/\1'$new_version'/1" $PODSPEC_FILE
 
 # Update SwiftPM version
-sed -i '' 's/\(define("APP_CENTER_C_VERSION",[[:space:]]*to:*\).*/\1''"\\"'$new_version'\\""),''/g' $SWIFTPM_FILE
+updateSwiftPMVersion() {
+  sed -i '' 's/\(define("APP_CENTER_C_VERSION",[[:space:]]*to:*\).*/\1''"\\"'$new_version'\\""),''/g' $1
+}
+updateSwiftPMVersion $SWIFTPM_FILE
+updateSwiftPMVersion $SWIFTPM_5_3_FILE


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [ ] ~Are tests passing locally?~
* [x] Are the files formatted correctly?
* [ ] ~Did you add unit tests?~
* [ ] ~Did you check UI tests on the sample app? They are not executed on CI.~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Command `./Scripts/update-version.sh -v <new version>` doesn't modify the version number in the file `Package@swift-5.3.swift`

## Related PRs or issues

[AB#84312](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/84312)
