### PR TITLE
Fix the kMSACUpdateTokenRequestIdKey never gets removed

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
@@ -144,6 +144,12 @@ static dispatch_once_t onceToken;
 
     // Init the distribute info tracker.
     _distributeInfoTracker = [[MSACDistributeInfoTracker alloc] init];
+
+    // In case we never finished removing this key. Which will result in
+    // update flow never gets processed again
+    if ([MSAC_APP_CENTER_USER_DEFAULTS objectForKey:kMSACUpdateTokenRequestIdKey]) {
+      [MSAC_APP_CENTER_USER_DEFAULTS removeObjectForKey:kMSACUpdateTokenRequestIdKey];
+    }
   }
   return self;
 }

--- a/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
@@ -145,8 +145,10 @@ static dispatch_once_t onceToken;
     // Init the distribute info tracker.
     _distributeInfoTracker = [[MSACDistributeInfoTracker alloc] init];
 
-    // In case we never finished removing this key. Which will result in
-    // update flow never gets processed again
+    /*
+     * In case we never finished removing this key. Which will result in
+     * update flow never gets processed again.
+     */
     if ([MSAC_APP_CENTER_USER_DEFAULTS objectForKey:kMSACUpdateTokenRequestIdKey]) {
       [MSAC_APP_CENTER_USER_DEFAULTS removeObjectForKey:kMSACUpdateTokenRequestIdKey];
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Version 4.1.1 (Under development)
 
-___
+### App Center Distribute
+
+* **[Fix]** Fix `kMSACUpdateTokenRequestIdKey` never gets removed.
 
 ## Version 4.1.0
 
@@ -11,7 +13,6 @@ ___
 * **[Fix]** Fix `double-quoted` warnings in Xcode 12.
 * **[Fix]** Fix a crash when SQLite returns zero for `page_size`.
 * **[Feature]** Use XCFramework format for the binary distribution via CocoaPods. CocoaPods version 1.9+ is a requirement now.
-* **[Fix]** Fix `kMSACUpdateTokenRequestIdKey` never gets removed.
 
 ### App Center Crashes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ___
 * **[Fix]** Fix `double-quoted` warnings in Xcode 12.
 * **[Fix]** Fix a crash when SQLite returns zero for `page_size`.
 * **[Feature]** Use XCFramework format for the binary distribution via CocoaPods. CocoaPods version 1.9+ is a requirement now.
+* **[Fix]** Fix `kMSACUpdateTokenRequestIdKey` never gets removed.
 
 ### App Center Crashes
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

I'm from Outlook iOS team, we met an issue that the update flow will never gets called. The root cause is somehow the key is not removed (maybe crashed before the removing logic). Removing the key fixes it. Also it seems every time in `init` we remove this key is safe. We've been testing for our app for several months, and it seems went well.

You can directly ping me on Teams, I'm Peter Guan

## Related PRs or issues

List related PRs and other issues.

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
