### PR TITLE
Fix exitting function in test app

### DIFF
--- a/Sasquatch/Sasquatch/Base.lproj/Main.storyboard
+++ b/Sasquatch/Sasquatch/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="5VQ-Mp-xic">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="5VQ-Mp-xic">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -782,23 +782,6 @@
                                                         <action selector="customizedSwitchUpdated:" destination="axH-Yn-1RM" eventType="valueChanged" id="2IM-Ma-jnH"/>
                                                     </connections>
                                                 </switch>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="2bR-1Z-0bG" style="IBUITableViewCellStyleDefault" id="aQR-LA-nFC">
-                                        <rect key="frame" x="0.0" y="447.5" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="aQR-LA-nFC" id="GuC-xZ-BCA">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Imitate Closing App for Update" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2bR-1Z-0bG">
-                                                    <rect key="frame" x="16" y="0.0" width="343" height="44"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -1994,24 +1977,6 @@
         <image name="dials" width="23" height="23"/>
         <image name="distribute" width="23" height="23"/>
         <image name="fuel" width="23" height="23"/>
-        <systemColor name="groupTableViewBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="groupTableViewBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="groupTableViewBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="groupTableViewBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="groupTableViewBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="groupTableViewBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/Sasquatch/Sasquatch/ViewControllers/MSDistributeViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSDistributeViewController.swift
@@ -96,7 +96,7 @@ class MSDistributeViewController: UITableViewController, AppCenterProtocol {
       case 1:
         appCenter.showDistributeDisabledAlert()
       case 3:
-        appCenter.closeApp()
+        distributeWillExitApp()
       default: ()
       }
     default: ()
@@ -105,5 +105,18 @@ class MSDistributeViewController: UITableViewController, AppCenterProtocol {
 
   @IBAction func customizedSwitchUpdated(_ sender: UISwitch) {
     UserDefaults.standard.set(sender.isOn, forKey: kSASCustomizedUpdateAlertKey)
+  }
+    
+  func distributeWillExitApp() {
+    print("distributeWillExitApp callback invoked");
+    let alertController = UIAlertController(title: NSLocalizedString("distribute_alert_willExit_title", tableName: "Sasquatch", comment: ""),
+            message: NSLocalizedString("distribute_alert_willExit_message", tableName: "Sasquatch", comment: ""),
+            preferredStyle: .alert)
+
+    // Show alert saying that the app is closing
+    self.present(alertController, animated: true)
+    DispatchQueue.main.asyncAfter(deadline: .now() + 7.0) {
+      self.appCenter.closeApp()
+    }
   }
 }

--- a/Sasquatch/Sasquatch/ViewControllers/MSDistributeViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSDistributeViewController.swift
@@ -95,8 +95,6 @@ class MSDistributeViewController: UITableViewController, AppCenterProtocol {
         }
       case 1:
         appCenter.showDistributeDisabledAlert()
-      case 3:
-        exitWithSimulateUpdate()
       default: ()
       }
     default: ()
@@ -105,19 +103,5 @@ class MSDistributeViewController: UITableViewController, AppCenterProtocol {
 
   @IBAction func customizedSwitchUpdated(_ sender: UISwitch) {
     UserDefaults.standard.set(sender.isOn, forKey: kSASCustomizedUpdateAlertKey)
-  }
-    
-  func exitWithSimulateUpdate() {
-    let UPDATE_SIMUATION_TIMEOUT = 7.0
-    print("distributeWillExitApp callback invoked");
-    let alertController = UIAlertController(title: NSLocalizedString("distribute_alert_willExit_title", tableName: "Sasquatch", comment: ""),
-            message: NSLocalizedString("distribute_alert_willExit_message", tableName: "Sasquatch", comment: ""),
-            preferredStyle: .alert)
-
-    // Show alert saying that the app is closing
-    self.present(alertController, animated: true)
-    DispatchQueue.main.asyncAfter(deadline: .now() + UPDATE_SIMUATION_TIMEOUT) {
-      exit(0)
-    }
   }
 }

--- a/Sasquatch/Sasquatch/ViewControllers/MSDistributeViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSDistributeViewController.swift
@@ -108,6 +108,7 @@ class MSDistributeViewController: UITableViewController, AppCenterProtocol {
   }
     
   func exitWithSimulateUpdate() {
+    let UPDATE_SIMUATION_TIMEOUT = 7.0
     print("distributeWillExitApp callback invoked");
     let alertController = UIAlertController(title: NSLocalizedString("distribute_alert_willExit_title", tableName: "Sasquatch", comment: ""),
             message: NSLocalizedString("distribute_alert_willExit_message", tableName: "Sasquatch", comment: ""),
@@ -115,7 +116,7 @@ class MSDistributeViewController: UITableViewController, AppCenterProtocol {
 
     // Show alert saying that the app is closing
     self.present(alertController, animated: true)
-    DispatchQueue.main.asyncAfter(deadline: .now() + 7.0) {
+    DispatchQueue.main.asyncAfter(deadline: .now() + UPDATE_SIMUATION_TIMEOUT) {
       exit(0)
     }
   }

--- a/Sasquatch/Sasquatch/ViewControllers/MSDistributeViewController.swift
+++ b/Sasquatch/Sasquatch/ViewControllers/MSDistributeViewController.swift
@@ -96,7 +96,7 @@ class MSDistributeViewController: UITableViewController, AppCenterProtocol {
       case 1:
         appCenter.showDistributeDisabledAlert()
       case 3:
-        distributeWillExitApp()
+        exitWithSimulateUpdate()
       default: ()
       }
     default: ()
@@ -107,7 +107,7 @@ class MSDistributeViewController: UITableViewController, AppCenterProtocol {
     UserDefaults.standard.set(sender.isOn, forKey: kSASCustomizedUpdateAlertKey)
   }
     
-  func distributeWillExitApp() {
+  func exitWithSimulateUpdate() {
     print("distributeWillExitApp callback invoked");
     let alertController = UIAlertController(title: NSLocalizedString("distribute_alert_willExit_title", tableName: "Sasquatch", comment: ""),
             message: NSLocalizedString("distribute_alert_willExit_message", tableName: "Sasquatch", comment: ""),
@@ -116,7 +116,7 @@ class MSDistributeViewController: UITableViewController, AppCenterProtocol {
     // Show alert saying that the app is closing
     self.present(alertController, animated: true)
     DispatchQueue.main.asyncAfter(deadline: .now() + 7.0) {
-      self.appCenter.closeApp()
+      exit(0)
     }
   }
 }

--- a/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -397,13 +397,7 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
 }
 
 - (void)distributeWillExitApp:(MSACDistribute *)distribute {
-  dispatch_async(dispatch_get_main_queue(), ^{
-    UIAlertController *alertController =
-        [UIAlertController alertControllerWithTitle:NSLocalizedStringFromTable(@"distribute_alert_willExit_title", @"Sasquatch", @"")
-                                            message:NSLocalizedStringFromTable(@"distribute_alert_willExit_message", @"Sasquatch", @"")
-                                     preferredStyle:UIAlertControllerStyleAlert];
-    [self.window.rootViewController presentViewController:alertController animated:YES completion:nil];
-  });
+    NSLog(@"distributeWillExitApp callback invoked");
 }
 
 #endif

--- a/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -395,6 +395,17 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
   [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:nil]];
   [self.window.rootViewController presentViewController:alert animated:YES completion:nil];
 }
+
+- (void)distributeWillExitApp:(MSACDistribute *)distribute {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    UIAlertController *alertController =
+        [UIAlertController alertControllerWithTitle:NSLocalizedStringFromTable(@"distribute_alert_willExit_title", @"Sasquatch", @"")
+                                            message:NSLocalizedStringFromTable(@"distribute_alert_willExit_message", @"Sasquatch", @"")
+                                     preferredStyle:UIAlertControllerStyleAlert];
+    [self.window.rootViewController presentViewController:alertController animated:YES completion:nil];
+  });
+}
+
 #endif
 
 #pragma mark - CLLocationManagerDelegate

--- a/Sasquatch/SasquatchObjC/AppDelegate.m
+++ b/Sasquatch/SasquatchObjC/AppDelegate.m
@@ -395,18 +395,6 @@ enum StartupMode { APPCENTER, ONECOLLECTOR, BOTH, NONE, SKIP };
   [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:nil]];
   [self.window.rootViewController presentViewController:alert animated:YES completion:nil];
 }
-
-- (void)distributeWillExitApp:(MSACDistribute *)distribute {
-  dispatch_async(dispatch_get_main_queue(), ^{
-    UIAlertController *alertController =
-        [UIAlertController alertControllerWithTitle:NSLocalizedStringFromTable(@"distribute_alert_willExit_title", @"Sasquatch", @"")
-                                            message:NSLocalizedStringFromTable(@"distribute_alert_willExit_message", @"Sasquatch", @"")
-                                     preferredStyle:UIAlertControllerStyleAlert];
-    [self.window.rootViewController presentViewController:alertController animated:YES completion:nil];
-  });
-  sleep(7);
-}
-
 #endif
 
 #pragma mark - CLLocationManagerDelegate

--- a/Sasquatch/SasquatchSwift/AppDelegate.swift
+++ b/Sasquatch/SasquatchSwift/AppDelegate.swift
@@ -322,6 +322,18 @@ extension AppDelegate: DistributeDelegate {
     alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
     self.window?.rootViewController?.present(alert, animated: true)
   }
+
+  func distributeWillExitApp(_ distribute: Distribute) {
+    print("distributeWillExitApp callback invoked");
+    DispatchQueue.main.async {
+      let alertController = UIAlertController(title: NSLocalizedString("distribute_alert_willExit_title", tableName: "Sasquatch", comment: ""),
+              message: NSLocalizedString("distribute_alert_willExit_message", tableName: "Sasquatch", comment: ""),
+              preferredStyle: .alert)
+
+      // Show alert saying that the app is closing
+      self.window?.rootViewController?.present(alertController, animated: true)
+    }
+  }
 }
 
 #endif

--- a/Sasquatch/SasquatchSwift/AppDelegate.swift
+++ b/Sasquatch/SasquatchSwift/AppDelegate.swift
@@ -322,20 +322,6 @@ extension AppDelegate: DistributeDelegate {
     alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
     self.window?.rootViewController?.present(alert, animated: true)
   }
-
-  func distributeWillExitApp(_ distribute: Distribute) {
-    print("distributeWillExitApp callback invoked");
-    DispatchQueue.main.async {
-      let alertController = UIAlertController(title: NSLocalizedString("distribute_alert_willExit_title", tableName: "Sasquatch", comment: ""),
-              message: NSLocalizedString("distribute_alert_willExit_message", tableName: "Sasquatch", comment: ""),
-              preferredStyle: .alert)
-
-      // Show alert saying that the app is closing
-      self.window?.rootViewController?.present(alertController, animated: true)
-    }
-
-    sleep(7)
-  }
 }
 
 #endif

--- a/Sasquatch/SasquatchSwift/AppDelegate.swift
+++ b/Sasquatch/SasquatchSwift/AppDelegate.swift
@@ -325,14 +325,6 @@ extension AppDelegate: DistributeDelegate {
 
   func distributeWillExitApp(_ distribute: Distribute) {
     print("distributeWillExitApp callback invoked");
-    DispatchQueue.main.async {
-      let alertController = UIAlertController(title: NSLocalizedString("distribute_alert_willExit_title", tableName: "Sasquatch", comment: ""),
-              message: NSLocalizedString("distribute_alert_willExit_message", tableName: "Sasquatch", comment: ""),
-              preferredStyle: .alert)
-
-      // Show alert saying that the app is closing
-      self.window?.rootViewController?.present(alertController, animated: true)
-    }
   }
 }
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* ~[ ] Has `CHANGELOG.md` been updated?~(These are changes in the test app)
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests?~ (These are changes in the test app)
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Sasquatch app implements the distributeWillExitApp delegate callback wrongly. It delays the thread for 7 seconds before it allows app to exit. Delay is now moved into the view controller code.

## Related PRs or issues

[AB#84300](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/84300)

## Misc

Add what's missing, notes on what you tested, additional thoughts or questions.
