### PR TITLE
Fixes build warning by removing duplicate key in dictionary

### DIFF
--- a/AppCenter/AppCenter/MSACAppCenter.m
+++ b/AppCenter/AppCenter/MSACAppCenter.m
@@ -292,7 +292,6 @@ static const long kMSACMinUpperSizeLimitInBytes = 24 * 1024;
     @"MSUserIdHistoryInfo" : MSACUserIdHistoryInfo.self,
     @"MSLogWithProperties" : MSACLogWithProperties.self,
     @"MSLogContainer" : MSACLogContainer.self,
-    @"MSLogWithProperties" : MSACLogWithProperties.self,
     @"MSWrapperSdk" : MSACWrapperSdk.self,
     @"MSAbstractLog" : MSACAbstractLog.self,
   }];


### PR DESCRIPTION
Just a simple one-liner to fix the build warning  ```warning: duplicate key in dictionary literal``` when building with the ``` [-Wobjc-dictionary-duplicate-keys]``` flag in Xcode 12.5 beta