### PR TITLE
Fix Xcode 12.5 warning regarding umbrella headers

### DIFF
--- a/AppCenterAnalytics/AppCenterAnalytics/include/MSACAbstractLog.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/include/MSACAbstractLog.h
@@ -1,1 +1,0 @@
-../../../AppCenter/AppCenter/Model/MSACAbstractLog.h

--- a/AppCenterAnalytics/AppCenterAnalytics/include/MSACLogWithProperties.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/include/MSACLogWithProperties.h
@@ -1,1 +1,0 @@
-../../../AppCenter/AppCenter/Model/MSACLogWithProperties.h

--- a/AppCenterAnalytics/AppCenterAnalytics/include/MSACService.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/include/MSACService.h
@@ -1,1 +1,0 @@
-../../../AppCenter/AppCenter/MSACService.h

--- a/AppCenterAnalytics/AppCenterAnalytics/include/MSACServiceAbstract.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/include/MSACServiceAbstract.h
@@ -1,1 +1,0 @@
-../../../AppCenter/AppCenter/MSACServiceAbstract.h

--- a/AppCenterCrashes/AppCenterCrashes/include/MSACAbstractLog.h
+++ b/AppCenterCrashes/AppCenterCrashes/include/MSACAbstractLog.h
@@ -1,1 +1,0 @@
-../../../AppCenter/AppCenter/Model/MSACAbstractLog.h

--- a/AppCenterCrashes/AppCenterCrashes/include/MSACService.h
+++ b/AppCenterCrashes/AppCenterCrashes/include/MSACService.h
@@ -1,1 +1,0 @@
-../../../AppCenter/AppCenter/MSACService.h

--- a/AppCenterCrashes/AppCenterCrashes/include/MSACServiceAbstract.h
+++ b/AppCenterCrashes/AppCenterCrashes/include/MSACServiceAbstract.h
@@ -1,1 +1,0 @@
-../../../AppCenter/AppCenter/MSACServiceAbstract.h

--- a/AppCenterDistribute/AppCenterDistribute/include/MSACService.h
+++ b/AppCenterDistribute/AppCenterDistribute/include/MSACService.h
@@ -1,1 +1,0 @@
-../../../AppCenter/AppCenter/MSACService.h

--- a/AppCenterDistribute/AppCenterDistribute/include/MSACServiceAbstract.h
+++ b/AppCenterDistribute/AppCenterDistribute/include/MSACServiceAbstract.h
@@ -1,1 +1,0 @@
-../../../AppCenter/AppCenter/MSACServiceAbstract.h


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* ~[ ] Are the files formatted correctly?~
* ~[ ] Did you add unit tests?~
* ~[ ] Did you check UI tests on the sample app? They are not executed on CI.~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes Xcode 12.5b3 warnings "Umbrella header for module 'AppCenterAnalytics' does not include header 'full-path-to/MSACService.h'" when integrating App Center SDK via Swift Package Manager.

Previously an empty project would not compile with `Treat Warnings as Errors` set to `Yes`.

## Related PRs or issues

#2274
[AB#85847](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/85847)