### PR TITLE
Fix Xcode autocompletion issue for Analytics module

### DIFF
--- a/AppCenterAnalytics/AppCenterAnalytics/include/MSACConstants+Flags.h
+++ b/AppCenterAnalytics/AppCenterAnalytics/include/MSACConstants+Flags.h
@@ -1,1 +1,0 @@
-../../../AppCenter/AppCenter/MSACConstants+Flags.h

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 4.1.2 (Under development)
 
+### App Center
+
+* **[Fix]** Fix umbrella header warnings in Xcode 12.5b3
+
 ### App Center Crashes
 
 * **[Fix]** Fix error nullability in crashes delegate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center
 
-* **[Fix]** Fix umbrella header warnings in Xcode 12.5b3
+* **[Fix]** Fix umbrella header warnings in Xcode 12.5
 
 ### App Center Crashes
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* ~[ ] Are tests passing locally?~
* ~[ ] Are the files formatted correctly?~
* ~[ ] Did you add unit tests?~
* ~[ ] Did you check UI tests on the sample app? They are not executed on CI.~
* ~[ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?~

## Description

This PR is an addition to https://github.com/microsoft/appcenter-sdk-apple/pull/2287.
It updates Changelog and removes file `MSACConstants+Flags.h` from `AppCenterAnalytics/include` which caused autocompletion issues in Xcode 12.5b3.

## Related PRs or issues

#2274
[AB#85847](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/85847)