### PR TITLE
Fix building Distribute module on Xcode 12.5

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
@@ -687,7 +687,12 @@ static dispatch_once_t onceToken;
   UIApplication *sharedApp = [MSACUtility sharedApp];
 #pragma clang diagnostic push
 
-// Ignore "cast to smaller integer type 'BOOL' (aka 'signed char') from 'id'" for Xcode 12.5.
+// The performSelector method only supports methods that return nothing or an object,
+// so cast to BOOL produces "-Wpointer-to-int-cast".
+// The reason why it works is to do with the way values are returned by methods.
+// Integer-like values (NSInteger, BOOL and object pointers) are returned in a general purpose register.
+// The compiler will always load the result from the register used for returning `id` values,
+// and then perform any action required by the cast. For integer and boolean values the cast is a no-op.
 #pragma clang diagnostic ignored "-Wpointer-to-int-cast"
 
   return (BOOL)[sharedApp performSelector:@selector(openURL:) withObject:url];

--- a/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
@@ -685,7 +685,15 @@ static dispatch_once_t onceToken;
 
 - (BOOL)openUrlUsingSharedApp:(NSURL *)url {
   UIApplication *sharedApp = [MSACUtility sharedApp];
+
+#pragma clang diagnostic push
+
+// Ignore "cast to smaller integer type 'BOOL' (aka 'signed char') from 'id'" for Xcode 12.5.
+#pragma clang diagnostic ignored "-Wpointer-to-int-cast"
+
   return (BOOL)[sharedApp performSelector:@selector(openURL:) withObject:url];
+#pragma clang diagnostic pop
+
 }
 
 - (void)openUrlInAuthenticationSessionOrSafari:(NSURL *)url {

--- a/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
@@ -685,7 +685,6 @@ static dispatch_once_t onceToken;
 
 - (BOOL)openUrlUsingSharedApp:(NSURL *)url {
   UIApplication *sharedApp = [MSACUtility sharedApp];
-
 #pragma clang diagnostic push
 
 // Ignore "cast to smaller integer type 'BOOL' (aka 'signed char') from 'id'" for Xcode 12.5.
@@ -693,7 +692,6 @@ static dispatch_once_t onceToken;
 
   return (BOOL)[sharedApp performSelector:@selector(openURL:) withObject:url];
 #pragma clang diagnostic pop
-
 }
 
 - (void)openUrlInAuthenticationSessionOrSafari:(NSURL *)url {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### App Center Distribute
 
 * **[Fix]** Fix linking framework `AuthenticationServices`.
+* **[Fix]** Fix compiling Distribute module on Xcode 12.5.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### App Center Distribute
 
 * **[Fix]** Fix linking framework `AuthenticationServices`.
-* **[Fix]** Fix compiling Distribute module on Xcode 12.5.
+* **[Fix]** Fix a warning in Distribute module that prevented using SDK as a source code on Xcode 12.5.
 
 ___
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests?~
* ~[ ] Did you check UI tests on the sample app? They are not executed on CI.~
* ~[ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?~

## Description

Xcode 12.5 started to report "-Wpointer-to-int-cast" error while building the Distribute code.
Fixed by suppressing the error.

## Related PRs or issues

[AB#86427](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/86427)