### PR TITLE
Use an available device information from the PLCR crash report

### DIFF
--- a/AppCenterCrashes/AppCenterCrashes/Internals/Util/MSACErrorLogFormatter.m
+++ b/AppCenterCrashes/AppCenterCrashes/Internals/Util/MSACErrorLogFormatter.m
@@ -738,14 +738,18 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
   MSACDevice *device = [[MSACDeviceTracker sharedInstance] deviceForTimestamp:timestamp];
   MSACDevice *alteredDevice = [MSACDevice new];
 
-  // Merge PLCR system information with our device information as the PLCR report
+  // Merge PLCR system information with the SDK`s device information as the PLCR report
   // is more relevant in cases when the time on the device has been manually changed.
-  alteredDevice.osVersion = report.systemInfo.operatingSystemVersion ? report.systemInfo.operatingSystemVersion : device.osVersion;
-  alteredDevice.osBuild = report.systemInfo.operatingSystemBuild ? report.systemInfo.operatingSystemBuild : device.osBuild;
-  alteredDevice.model = report.machineInfo.modelName ? report.machineInfo.modelName : device.model;
-  alteredDevice.appBuild = report.applicationInfo.applicationVersion ? report.applicationInfo.applicationVersion : device.appBuild;
-  alteredDevice.appVersion = report.applicationInfo.applicationMarketingVersion ? report.applicationInfo.applicationMarketingVersion : device.appVersion;
-  alteredDevice.appNamespace = report.applicationInfo.applicationIdentifier ? report.applicationInfo.applicationIdentifier : device.appNamespace;
+  // These fields are expected not to be empty:
+  // https://github.com/microsoft/plcrashreporter/blob/b7b88ee14bbc25ce408ae05464cb6f1cdd747948/Source/PLCrashReport.m#L135
+  // https://github.com/microsoft/plcrashreporter/blob/b7b88ee14bbc25ce408ae05464cb6f1cdd747948/Source/PLCrashReport.m#L475
+  // but still adding a fallback in case if it changes in the future.
+  alteredDevice.osVersion = report.systemInfo.operatingSystemVersion ?: device.osVersion;
+  alteredDevice.osBuild = report.systemInfo.operatingSystemBuild ?: device.osBuild;
+  alteredDevice.model = report.machineInfo.modelName ?: device.model;
+  alteredDevice.appBuild = report.applicationInfo.applicationVersion ?: device.appBuild;
+  alteredDevice.appVersion = report.applicationInfo.applicationMarketingVersion ?: device.appVersion;
+  alteredDevice.appNamespace = report.applicationInfo.applicationIdentifier ?: device.appNamespace;
 
   // Use the remaining fields from the found device information.
   alteredDevice.sdkName = device.sdkName;

--- a/AppCenterCrashes/AppCenterCrashes/Internals/Util/MSACErrorLogFormatter.m
+++ b/AppCenterCrashes/AppCenterCrashes/Internals/Util/MSACErrorLogFormatter.m
@@ -740,12 +740,12 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
 
   // Merge PLCR system information with our device information as the PLCR report
   // is more relevant in cases when the time on the device has been manually changed.
-  alteredDevice.osVersion = report.systemInfo.operatingSystemVersion;
-  alteredDevice.osBuild = report.systemInfo.operatingSystemBuild;
-  alteredDevice.model = report.machineInfo.modelName;
-  alteredDevice.appBuild = report.applicationInfo.applicationVersion;
-  alteredDevice.appVersion = report.applicationInfo.applicationMarketingVersion;
-  alteredDevice.appNamespace = report.applicationInfo.applicationIdentifier;
+  alteredDevice.osVersion = report.systemInfo.operatingSystemVersion ? report.systemInfo.operatingSystemVersion : device.osVersion;
+  alteredDevice.osBuild = report.systemInfo.operatingSystemBuild ? report.systemInfo.operatingSystemBuild : device.osBuild;
+  alteredDevice.model = report.machineInfo.modelName ? report.machineInfo.modelName : device.model;
+  alteredDevice.appBuild = report.applicationInfo.applicationVersion ? report.applicationInfo.applicationVersion : device.appBuild;
+  alteredDevice.appVersion = report.applicationInfo.applicationMarketingVersion ? report.applicationInfo.applicationMarketingVersion : device.appVersion;
+  alteredDevice.appNamespace = report.applicationInfo.applicationIdentifier ? report.applicationInfo.applicationIdentifier : device.appNamespace;
 
   // Use the remaining fields from the found device information.
   alteredDevice.sdkName = device.sdkName;

--- a/AppCenterCrashes/AppCenterCrashes/Internals/Util/MSACErrorLogFormatter.m
+++ b/AppCenterCrashes/AppCenterCrashes/Internals/Util/MSACErrorLogFormatter.m
@@ -765,7 +765,7 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
   alteredDevice.liveUpdatePackageHash = device.liveUpdatePackageHash;
   alteredDevice.liveUpdateReleaseLabel = device.liveUpdateReleaseLabel;
   alteredDevice.liveUpdateDeploymentKey = device.liveUpdateDeploymentKey;
-  return device;
+  return alteredDevice;
 }
 
 + (BOOL)isCodeType64bit:(uint64_t)type {

--- a/AppCenterCrashes/AppCenterCrashes/Internals/Util/MSACErrorLogFormatter.m
+++ b/AppCenterCrashes/AppCenterCrashes/Internals/Util/MSACErrorLogFormatter.m
@@ -734,8 +734,7 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
 
 #pragma mark - Helpers
 
-+ (MSACDevice *)deviceForTimestamp:(NSDate *)timestamp
-                       crashReport:(PLCrashReport *)report {
++ (MSACDevice *)deviceForTimestamp:(NSDate *)timestamp crashReport:(PLCrashReport *)report {
   MSACDevice *device = [[MSACDeviceTracker sharedInstance] deviceForTimestamp:timestamp];
   MSACDevice *alteredDevice = [MSACDevice new];
 

--- a/AppCenterCrashes/AppCenterCrashes/MSACCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSACCrashes.mm
@@ -1304,6 +1304,13 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSACC
     id<MSACCrashesDelegate> delegate = self.delegate;
     if ([delegate respondsToSelector:@selector(attachmentsWithCrashes:forErrorReport:)]) {
       attachments = [delegate attachmentsWithCrashes:self forErrorReport:report];
+      
+      // Use the device information from the error log, otherwise the current device information will be used.
+      for (MSACErrorAttachmentLog *attachment in attachments) {
+        if (attachment && !attachment.device) {
+          attachment.device = log.device;
+        }
+      }
     } else {
       MSACLogDebug([MSACCrashes logTag], @"attachmentsWithCrashes is not implemented");
     }

--- a/AppCenterCrashes/AppCenterCrashes/MSACCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSACCrashes.mm
@@ -1307,7 +1307,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSACC
 
       // Use the device information from the error log, otherwise the current device information will be used.
       for (MSACErrorAttachmentLog *attachment in attachments) {
-        if (attachment && !attachment.device) {
+        if (attachment != nil && attachment.device == nil) {
           attachment.device = log.device;
         }
       }

--- a/AppCenterCrashes/AppCenterCrashes/MSACCrashes.mm
+++ b/AppCenterCrashes/AppCenterCrashes/MSACCrashes.mm
@@ -1304,7 +1304,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSACC
     id<MSACCrashesDelegate> delegate = self.delegate;
     if ([delegate respondsToSelector:@selector(attachmentsWithCrashes:forErrorReport:)]) {
       attachments = [delegate attachmentsWithCrashes:self forErrorReport:report];
-      
+
       // Use the device information from the error log, otherwise the current device information will be used.
       for (MSACErrorAttachmentLog *attachment in attachments) {
         if (attachment && !attachment.device) {

--- a/AppCenterCrashes/AppCenterCrashesTests/MSACCrashesTests.mm
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSACCrashesTests.mm
@@ -417,6 +417,9 @@ static unsigned int kAttachmentsPerCrashReport = 3;
   // If
   self.sut = OCMPartialMock(self.sut);
   OCMStub([self.sut startDelayedCrashProcessing]).andDo(nil);
+  MSACDevice *device = [MSACDevice new];
+  device.sdkVersion = @"4.1.0";
+  OCMStub([self.deviceTrackerMock deviceForTimestamp:OCMOCK_ANY]).andReturn(device);
 
   // When
   id channelGroupMock = OCMProtocolMock(@protocol(MSACChannelGroupProtocol));
@@ -454,6 +457,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
   // Then
   OCMExpect([channelUnitMock enqueueItem:validLog flags:MSACFlagsDefault]);
   [self.sut startCrashProcessing];
+  XCTAssertEqual(validLog.device.sdkVersion, device.sdkVersion);
   OCMVerifyAll(channelUnitMock);
   OCMVerify([self.deviceTrackerMock clearDevices]);
   OCMVerify([self.sessionContextMock clearSessionHistoryAndKeepCurrentSession:YES]);

--- a/AppCenterCrashes/AppCenterCrashesTests/MSACErrorLogFormatterTests.mm
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSACErrorLogFormatterTests.mm
@@ -97,7 +97,6 @@ static NSArray *kMacOSCrashReportsParameters = @[
   XCTAssertEqual([errorReport.appErrorTime timeIntervalSince1970], [crashReport.systemInfo.timestamp timeIntervalSince1970] + 0.999);
   assertThat(errorReport.appStartTime, equalTo(crashReport.processInfo.processStartTime));
 
-  XCTAssertEqualObjects(errorReport.device, self.deviceMock);
   XCTAssertEqual(errorReport.appProcessIdentifier, crashReport.processInfo.processID);
 
   crashData = [MSACCrashesTestUtil dataOfFixtureCrashReportWithFileName:@"live_report_exception"];
@@ -116,7 +115,6 @@ static NSArray *kMacOSCrashReportsParameters = @[
   // FIXME: PLCrashReporter doesn't support millisecond precision, here is a workaround to fill 999 for its millisecond.
   XCTAssertEqual([errorReport.appErrorTime timeIntervalSince1970], [crashReport.systemInfo.timestamp timeIntervalSince1970] + 0.999);
   assertThat(errorReport.appStartTime, equalTo(crashReport.processInfo.processStartTime));
-  XCTAssertEqualObjects(errorReport.device, self.deviceMock);
   XCTAssertEqual(errorReport.appProcessIdentifier, crashReport.processInfo.processID);
   [defaults stopMocking];
 }
@@ -470,6 +468,79 @@ static NSArray *kMacOSCrashReportsParameters = @[
 
   // Then
   XCTAssertEqualObjects(errorLog.device.wrapperSdkName, @"Wrapper SDK for iOS");
+  [defaults stopMocking];
+}
+
+- (void)testErrorLogDeviceInfoFromPLCR {
+
+  // If
+  MSACMockUserDefaults *defaults = [MSACMockUserDefaults new];
+
+  // When
+  NSData *crashData = [MSACCrashesTestUtil dataOfFixtureCrashReportWithFileName:@"live_report_exception_marketing"];
+
+  // Then
+  XCTAssertNotNil(crashData);
+
+  // If
+  NSError *error = nil;
+  PLCrashReport *report = [[PLCrashReport alloc] initWithData:crashData error:&error];
+  MSACDevice *device = self.deviceMock;
+  device.appBuild = @"445";
+  device.appNamespace = @"com.microsoft.appcenter.native.ios.puppet";
+  device.model = @"x86_64";
+  device.osBuild = @"20e241";
+  device.osVersion = @"14.4";
+
+  // Properties copied from the SDKs device information
+  device.sdkName = @"appcenter.ios";
+  device.sdkVersion = @"4.1.0";
+  device.oemName = @"Apple";
+  device.osName = @"iOS";
+  device.timeZoneOffset = [NSNumber numberWithInt:400];
+  device.screenSize = @"1792x828";
+  device.carrierCountry = @"countryCode";
+  device.carrierName = @"carrierName";
+  device.locale = @"en";
+  device.wrapperSdkVersion = @"10.11.12";
+  device.wrapperSdkName = @"Wrapper SDK for iOS";
+  device.wrapperRuntimeVersion = @"13.14";
+  device.liveUpdateReleaseLabel = @"Release Label";
+  device.liveUpdateDeploymentKey = @"Deployment Key";
+  device.liveUpdatePackageHash = @"Package Hash";
+
+  // When
+  MSACAppleErrorLog *errorLog = [MSACErrorLogFormatter errorLogFromCrashReport:report];
+
+  // Then
+  XCTAssertNotNil(errorLog.device.appBuild);
+  XCTAssertNotNil(errorLog.device.appVersion);
+  XCTAssertNotNil(errorLog.device.appNamespace);
+  XCTAssertNotNil(errorLog.device.osBuild);
+  XCTAssertNotNil(errorLog.device.osVersion);
+  XCTAssertNotNil(errorLog.device.model);
+  XCTAssertNotEqual(errorLog.device.appBuild, device.appBuild);
+  XCTAssertNotEqual(errorLog.device.appVersion, device.appVersion);
+  XCTAssertNotEqual(errorLog.device.appNamespace, device.appNamespace);
+  XCTAssertNotEqual(errorLog.device.osBuild, device.osBuild);
+  XCTAssertNotEqual(errorLog.device.osVersion, device.osVersion);
+  XCTAssertNotEqual(errorLog.device.model, device.model);
+  XCTAssertEqual(errorLog.device.sdkName, device.sdkName);
+  XCTAssertEqual(errorLog.device.sdkVersion, device.sdkVersion);
+  XCTAssertEqual(errorLog.device.oemName, device.oemName);
+  XCTAssertEqual(errorLog.device.osName, device.osName);
+  XCTAssertEqual(errorLog.device.timeZoneOffset, device.timeZoneOffset);
+  XCTAssertEqual(errorLog.device.screenSize, device.screenSize);
+  XCTAssertEqual(errorLog.device.carrierCountry, device.carrierCountry);
+  XCTAssertEqual(errorLog.device.carrierName, device.carrierName);
+  XCTAssertEqual(errorLog.device.locale, device.locale);
+  XCTAssertEqual(errorLog.device.osApiLevel, device.osApiLevel);
+  XCTAssertEqual(errorLog.device.wrapperSdkName, device.wrapperSdkName);
+  XCTAssertEqual(errorLog.device.wrapperSdkVersion, device.wrapperSdkVersion);
+  XCTAssertEqual(errorLog.device.wrapperRuntimeVersion, device.wrapperRuntimeVersion);
+  XCTAssertEqual(errorLog.device.liveUpdatePackageHash, device.liveUpdatePackageHash);
+  XCTAssertEqual(errorLog.device.liveUpdateReleaseLabel, device.liveUpdateReleaseLabel);
+  XCTAssertEqual(errorLog.device.liveUpdateDeploymentKey, device.liveUpdateDeploymentKey);
   [defaults stopMocking];
 }
 

--- a/AppCenterCrashes/AppCenterCrashesTests/MSACErrorLogFormatterTests.mm
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSACErrorLogFormatterTests.mm
@@ -487,6 +487,7 @@ static NSArray *kMacOSCrashReportsParameters = @[
   PLCrashReport *report = [[PLCrashReport alloc] initWithData:crashData error:&error];
   MSACDevice *device = self.deviceMock;
   device.appBuild = @"445";
+  device.appVersion = @"1.1.1";
   device.appNamespace = @"com.microsoft.appcenter.native.ios.puppet";
   device.model = @"x86_64";
   device.osBuild = @"20e241";
@@ -513,18 +514,15 @@ static NSArray *kMacOSCrashReportsParameters = @[
   MSACAppleErrorLog *errorLog = [MSACErrorLogFormatter errorLogFromCrashReport:report];
 
   // Then
-  XCTAssertNotNil(errorLog.device.appBuild);
-  XCTAssertNotNil(errorLog.device.appVersion);
-  XCTAssertNotNil(errorLog.device.appNamespace);
-  XCTAssertNotNil(errorLog.device.osBuild);
-  XCTAssertNotNil(errorLog.device.osVersion);
-  XCTAssertNotNil(errorLog.device.model);
-  XCTAssertNotEqual(errorLog.device.appBuild, device.appBuild);
-  XCTAssertNotEqual(errorLog.device.appVersion, device.appVersion);
-  XCTAssertNotEqual(errorLog.device.appNamespace, device.appNamespace);
-  XCTAssertNotEqual(errorLog.device.osBuild, device.osBuild);
-  XCTAssertNotEqual(errorLog.device.osVersion, device.osVersion);
-  XCTAssertNotEqual(errorLog.device.model, device.model);
+  // Fields received from the PLCR crash report
+  XCTAssertEqual(errorLog.device.appBuild, report.applicationInfo.applicationVersion);
+  XCTAssertEqual(errorLog.device.appVersion, report.applicationInfo.applicationMarketingVersion);
+  XCTAssertEqual(errorLog.device.appNamespace, report.applicationInfo.applicationIdentifier);
+  XCTAssertEqual(errorLog.device.osBuild, report.systemInfo.operatingSystemBuild);
+  XCTAssertEqual(errorLog.device.osVersion, report.systemInfo.operatingSystemVersion);
+  XCTAssertEqual(errorLog.device.model, report.machineInfo.modelName);
+
+  // Fields received from the SDK's device info
   XCTAssertEqual(errorLog.device.sdkName, device.sdkName);
   XCTAssertEqual(errorLog.device.sdkVersion, device.sdkVersion);
   XCTAssertEqual(errorLog.device.oemName, device.oemName);
@@ -541,6 +539,17 @@ static NSArray *kMacOSCrashReportsParameters = @[
   XCTAssertEqual(errorLog.device.liveUpdatePackageHash, device.liveUpdatePackageHash);
   XCTAssertEqual(errorLog.device.liveUpdateReleaseLabel, device.liveUpdateReleaseLabel);
   XCTAssertEqual(errorLog.device.liveUpdateDeploymentKey, device.liveUpdateDeploymentKey);
+
+  // When
+  MSACAppleErrorLog *errorLog2 = [MSACErrorLogFormatter errorLogFromCrashReport:nil];
+
+  // Then fallback to the original device properties
+  XCTAssertEqual(errorLog2.device.appBuild, device.appBuild);
+  XCTAssertEqual(errorLog2.device.appVersion, device.appVersion);
+  XCTAssertEqual(errorLog2.device.appNamespace, device.appNamespace);
+  XCTAssertEqual(errorLog2.device.osBuild, device.osBuild);
+  XCTAssertEqual(errorLog2.device.osVersion, device.osVersion);
+  XCTAssertEqual(errorLog2.device.model, device.model);
   [defaults stopMocking];
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### App Center Crashes
 
 * **[Fix]** Fix error nullability in crashes delegate.
-* **[Fix]** Fix the reported application information when the device time has been manually changed.
+* **[Fix]** Merge the device information from the crash report with the SDK's device information in order to fix some time sensitive cases where the reported application information was incorrect.
 
 ### App Center Distribute
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@
 ### App Center
 
 * **[Feature]** Add a `AppCenter.networkRequestsAllowed` API to block any network requests without disabling the SDK.
-* **[Fix]** Fix umbrella header warnings in Xcode 12.5
+* **[Fix]** Fix umbrella header warnings in Xcode 12.5.
 
 ### App Center Crashes
 
 * **[Fix]** Fix error nullability in crashes delegate.
+* **[Fix]** Fix the reported application information when the device time has been manually changed.
 
 ### App Center Distribute
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] ~~Did you check UI tests on the sample app? They are not executed on CI.~~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes some cases where the reported application information is incorrect due to a manually changed time on the device.

## Related PRs or issues

[AB#86579](https://msmobilecenter.visualstudio.com/Mobile-Center/_boards/board/t/Mobile%20SDK/Backlog%20Items/?workitem=86579)
