### PR TITLE
Remove unnecessary resources section from AppCenterDistribute Swift Package target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center Distribute
 
-- **[Fix]** Remove unnecessary resources section from Swift Package. This resolves a warning within Xcode about a missing localized strings file 'Resources/AppCenterDistribute.strings'.
+- **[Fix]** Fix a warning `'Resources/AppCenterDistribute.strings': file not found` when resolving swift packages using Swift 5.5.
 
 ## Version 4.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # App Center SDK for iOS, macOS and tvOS Change Log
 
+## Version 4.2.1
+
+### App Center Distribute
+
+- **[Fix]** Remove unnecessary resources section from Swift Package. This resolves a warning within Xcode about a missing localized strings file 'Resources/AppCenterDistribute.strings'.
+
 ## Version 4.2.0
 
 ### App Center

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -88,9 +88,6 @@ let package = Package(
             dependencies: ["AppCenter"],
             path: "AppCenterDistribute/AppCenterDistribute",
             exclude: ["Support"],
-            resources: [
-                .process("Resources/AppCenterDistribute.strings"),
-            ],
             cSettings: [
                 .headerSearchPath("**"),
                 .headerSearchPath("../../AppCenter/AppCenter/**"),


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

According to Apple's documentation on [localizing package resources](https://developer.apple.com/documentation/swift_packages/localizing_package_resources), as long as the Resources directory of your module is setup correctly, the localization will happen automatically.

## Related PRs or issues

#2318