### PR TITLE
Fix build error "Multiple commands produce"

### DIFF
--- a/AppCenter/AppCenter.xcodeproj/project.pbxproj
+++ b/AppCenter/AppCenter.xcodeproj/project.pbxproj
@@ -2881,7 +2881,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-iphoneos/AppCenter.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2901,7 +2900,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-iphonesimulator/AppCenter.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2943,7 +2941,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-appletvos/AppCenter.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2963,7 +2960,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-appletvsimulator/AppCenter.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -3081,7 +3077,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-maccatalyst/AppCenter.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/AppCenterAnalytics/AppCenterAnalytics.xcodeproj/project.pbxproj
+++ b/AppCenterAnalytics/AppCenterAnalytics.xcodeproj/project.pbxproj
@@ -1327,7 +1327,6 @@
 			);
 			name = "Build tvOS Device Framework";
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-appletvos/AppCenterAnalytics.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1377,7 +1376,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-iphonesimulator/AppCenterAnalytics.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1438,7 +1436,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-appletvsimulator/AppCenterAnalytics.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1558,7 +1555,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-maccatalyst/AppCenterAnalytics.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1574,7 +1570,6 @@
 			);
 			name = "Build iOS Device Framework";
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-iphoneos/AppCenterAnalytics.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/AppCenterCrashes/AppCenterCrashes.xcodeproj/project.pbxproj
+++ b/AppCenterCrashes/AppCenterCrashes.xcodeproj/project.pbxproj
@@ -2069,7 +2069,6 @@
 			);
 			name = "Build tvOS Device Framework";
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-appletvos/AppCenterCrashes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2119,7 +2118,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-iphonesimulator/AppCenterCrashes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2180,7 +2178,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-appletvsimulator/AppCenterCrashes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2218,7 +2215,6 @@
 			);
 			name = "Build iOS Device Framework";
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-iphoneos/AppCenterCrashes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2333,7 +2329,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-maccatalyst/AppCenterCrashes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
+++ b/AppCenterDistribute/AppCenterDistribute.xcodeproj/project.pbxproj
@@ -1036,7 +1036,6 @@
 			);
 			name = "Build iOS Device Framework";
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-iphoneos/AppCenterDistribute.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1071,7 +1070,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$BUILD_DIR/$CONFIGURATION-iphonesimulator/AppCenterDistribute.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
Things to consider before you submit the PR:

* ~[ ] Has `CHANGELOG.md` been updated?~
* ~[ ] Are tests passing locally?~
* ~[ ] Are the files formatted correctly?~
* ~[ ] Did you add unit tests?~
* ~[ ] Did you check UI tests on the sample app? They are not executed on CI.~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The error happened on Xcode 12.5 on attempt to rebuild an already built project to a different device or using another build scheme.

While the changes fix most of such cases, it is still possible to reproduce such error:
1. Build sasquatch app
2. Build puppet app

`Product -> Clean Build Folder` helps.

Log:
```
Showing All Messages
Multiple commands produce '~/Library/Developer/Xcode/DerivedData/AppCenter-bivvshbspxukvgejehyrwmzvrowb/Build/Products/Debug-iphonesimulator/AppCenterDistribute.framework':
1) Command: ProcessXCFramework appcenter-sdk-apple/AppCenter-SDK-Apple/XCFramework/AppCenterDistribute.xcframework ~/Library/Developer/Xcode/DerivedData/AppCenter-bivvshbspxukvgejehyrwmzvrowb/Build/Products/Debug-iphonesimulator/AppCenterDistribute.framework ios simulator
2) Target 'AppCenterDistribute iOS Framework' has create directory command with output '~/Library/Developer/Xcode/DerivedData/AppCenter-bivvshbspxukvgejehyrwmzvrowb/Build/Products/Debug-iphonesimulator/AppCenterDistribute.framework'
```

## Related PRs or issues

[AB#86648](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/86648)