### PR TITLE
Fix Xcode13 Completion handler build error

### DIFF
--- a/AppCenter/AppCenter/Internals/HttpClient/MSACHttpCall.m
+++ b/AppCenter/AppCenter/Internals/HttpClient/MSACHttpCall.m
@@ -14,6 +14,9 @@
                        data:(NSData *)data
              retryIntervals:(NSArray *)retryIntervals
          compressionEnabled:(BOOL)compressionEnabled
+#pragma clang diagnostic push
+// Ignore warning '-Wcompletion-handler'" for XCode 13 and above
+#pragma clang diagnostic ignored "-Wcompletion-handler"
           completionHandler:(MSACHttpRequestCompletionHandler)completionHandler {
   if ((self = [super init])) {
     _url = url;
@@ -39,6 +42,7 @@
   }
   return self;
 }
+#pragma clang diagnostic pop
 
 - (BOOL)hasReachedMaxRetries {
   @synchronized(self) {

--- a/AppCenter/AppCenter/Internals/HttpClient/MSACHttpCall.m
+++ b/AppCenter/AppCenter/Internals/HttpClient/MSACHttpCall.m
@@ -14,10 +14,11 @@
                        data:(NSData *)data
              retryIntervals:(NSArray *)retryIntervals
          compressionEnabled:(BOOL)compressionEnabled
-#pragma clang diagnostic push
-// Ignore warning '-Wcompletion-handler'" for XCode 13 and above
-#pragma clang diagnostic ignored "-Wcompletion-handler"
-          completionHandler:(MSACHttpRequestCompletionHandler)completionHandler {
+          completionHandler:(MSACHttpRequestCompletionHandler)completionHandler
+#if defined(__IPHONE_15_0)
+NS_SWIFT_DISABLE_ASYNC
+#endif
+{
   if ((self = [super init])) {
     _url = url;
     _method = method;
@@ -42,7 +43,6 @@
   }
   return self;
 }
-#pragma clang diagnostic pop
 
 - (BOOL)hasReachedMaxRetries {
   @synchronized(self) {

--- a/AppCenter/AppCenter/Internals/Ingestion/MSACAppCenterIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSACAppCenterIngestion.m
@@ -30,6 +30,10 @@ static NSString *const kMSACPartialURLComponentsName[] = {@"scheme", @"user", @"
   return self.appSecret != nil;
 }
 
+
+#pragma clang diagnostic push
+// Ignore warning '-Wcompletion-handler'" for XCode 13 and above
+#pragma clang diagnostic ignored "-Wcompletion-handler"
 - (void)sendAsync:(NSObject *)data completionHandler:(MSACSendAsyncCompletionHandler)handler {
   MSACLogContainer *container = (MSACLogContainer *)data;
   NSString *batchId = container.batchId;
@@ -58,6 +62,7 @@ static NSString *const kMSACPartialURLComponentsName[] = {@"scheme", @"user", @"
         handler(batchId, response, responseBody, error);
       }];
 }
+#pragma clang diagnostic pop
 
 - (NSDictionary *)getHeadersWithData:(nullable NSObject *__unused)data eTag:(nullable NSString *__unused)eTag {
   NSMutableDictionary *httpHeaders = [self.httpHeaders mutableCopy];

--- a/AppCenter/AppCenter/Internals/Ingestion/MSACAppCenterIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSACAppCenterIngestion.m
@@ -30,11 +30,11 @@ static NSString *const kMSACPartialURLComponentsName[] = {@"scheme", @"user", @"
   return self.appSecret != nil;
 }
 
-
-#pragma clang diagnostic push
-// Ignore warning '-Wcompletion-handler'" for XCode 13 and above
-#pragma clang diagnostic ignored "-Wcompletion-handler"
-- (void)sendAsync:(NSObject *)data completionHandler:(MSACSendAsyncCompletionHandler)handler {
+- (void)sendAsync:(NSObject *)data completionHandler:(MSACSendAsyncCompletionHandler)handler
+#if defined(__IPHONE_15_0)
+NS_SWIFT_DISABLE_ASYNC
+#endif
+{
   MSACLogContainer *container = (MSACLogContainer *)data;
   NSString *batchId = container.batchId;
 
@@ -62,7 +62,6 @@ static NSString *const kMSACPartialURLComponentsName[] = {@"scheme", @"user", @"
         handler(batchId, response, responseBody, error);
       }];
 }
-#pragma clang diagnostic pop
 
 - (NSDictionary *)getHeadersWithData:(nullable NSObject *__unused)data eTag:(nullable NSString *__unused)eTag {
   NSMutableDictionary *httpHeaders = [self.httpHeaders mutableCopy];

--- a/AppCenter/AppCenter/Internals/Storage/MSACDBStorage.m
+++ b/AppCenter/AppCenter/Internals/Storage/MSACDBStorage.m
@@ -436,10 +436,11 @@ static int sqliteConfigurationResult = SQLITE_ERROR;
 - (void)migrateDatabase:(void *)__unused db fromVersion:(NSUInteger)__unused version {
 }
 
-#pragma clang diagnostic push
-// Ignore warning '-Wcompletion-handler'" for XCode 13 and above
-#pragma clang diagnostic ignored "-Wcompletion-handler"
-- (void)setMaxStorageSize:(long)sizeInBytes completionHandler:(nullable void (^)(BOOL))completionHandler {
+- (void)setMaxStorageSize:(long)sizeInBytes completionHandler:(nullable void (^)(BOOL))completionHandler
+#if defined(__IPHONE_15_0)
+NS_SWIFT_DISABLE_ASYNC
+#endif
+{
   int result;
   BOOL success;
   sqlite3 *db = [MSACDBStorage openDatabaseAtFileURL:self.dbFileURL withResult:&result];
@@ -454,7 +455,6 @@ static int sqliteConfigurationResult = SQLITE_ERROR;
     }
     return;
   }
-#pragma clang diagnostic pop
     
   // Check the current number of pages in the database to determine whether the requested size will shrink the database.
   long currentPageCount = [MSACDBStorage getPageCountInOpenedDatabase:db];

--- a/AppCenter/AppCenter/Internals/Storage/MSACDBStorage.m
+++ b/AppCenter/AppCenter/Internals/Storage/MSACDBStorage.m
@@ -436,6 +436,9 @@ static int sqliteConfigurationResult = SQLITE_ERROR;
 - (void)migrateDatabase:(void *)__unused db fromVersion:(NSUInteger)__unused version {
 }
 
+#pragma clang diagnostic push
+// Ignore warning '-Wcompletion-handler'" for XCode 13 and above
+#pragma clang diagnostic ignored "-Wcompletion-handler"
 - (void)setMaxStorageSize:(long)sizeInBytes completionHandler:(nullable void (^)(BOOL))completionHandler {
   int result;
   BOOL success;
@@ -451,7 +454,8 @@ static int sqliteConfigurationResult = SQLITE_ERROR;
     }
     return;
   }
-
+#pragma clang diagnostic pop
+    
   // Check the current number of pages in the database to determine whether the requested size will shrink the database.
   long currentPageCount = [MSACDBStorage getPageCountInOpenedDatabase:db];
   MSACLogDebug([MSACAppCenter logTag], @"Found %ld pages in the database.", currentPageCount);

--- a/AppCenter/AppCenter/MSACAppCenter.m
+++ b/AppCenter/AppCenter/MSACAppCenter.m
@@ -524,6 +524,9 @@ static const long kMSACMinUpperSizeLimitInBytes = 24 * 1024;
   }
 }
 
+#pragma clang diagnostic push
+// Ignore warning '-Wcompletion-handler'" for XCode 13 and above
+#pragma clang diagnostic ignored "-Wcompletion-handler"
 - (void)setMaxStorageSize:(long)sizeInBytes completionHandler:(void (^)(BOOL))completionHandler {
 
   // Check if sizeInBytes is greater than minimum size.
@@ -560,6 +563,7 @@ static const long kMSACMinUpperSizeLimitInBytes = 24 * 1024;
     completionHandler(NO);
   }
 }
+#pragma clang diagnostic pop
 
 - (void)setUserId:(NSString *)userId {
   if (!self.configuredFromApplication) {

--- a/AppCenter/AppCenter/MSACAppCenter.m
+++ b/AppCenter/AppCenter/MSACAppCenter.m
@@ -524,10 +524,11 @@ static const long kMSACMinUpperSizeLimitInBytes = 24 * 1024;
   }
 }
 
-#pragma clang diagnostic push
-// Ignore warning '-Wcompletion-handler'" for XCode 13 and above
-#pragma clang diagnostic ignored "-Wcompletion-handler"
-- (void)setMaxStorageSize:(long)sizeInBytes completionHandler:(void (^)(BOOL))completionHandler {
+- (void)setMaxStorageSize:(long)sizeInBytes completionHandler:(void (^)(BOOL))completionHandler
+#if defined(__IPHONE_15_0)
+NS_SWIFT_DISABLE_ASYNC
+#endif
+{
 
   // Check if sizeInBytes is greater than minimum size.
   if (sizeInBytes < kMSACMinUpperSizeLimitInBytes) {
@@ -563,7 +564,6 @@ static const long kMSACMinUpperSizeLimitInBytes = 24 * 1024;
     completionHandler(NO);
   }
 }
-#pragma clang diagnostic pop
 
 - (void)setUserId:(NSString *)userId {
   if (!self.configuredFromApplication) {

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSACAnalyticsAuthenticationProvider.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSACAnalyticsAuthenticationProvider.m
@@ -54,6 +54,9 @@ static int kMSRefreshThreshold = 10 * 60;
   }
 }
 
+#pragma clang diagnostic push
+// Ignore warning '-Wcompletion-handler'" for XCode 13 and above
+#pragma clang diagnostic ignored "-Wcompletion-handler"
 - (void)handleTokenUpdateWithToken:(NSString *)token
                         expiryDate:(NSDate *)expiryDate
              withCompletionHandler:(MSACAnalyticsAuthenticationProviderCompletionBlock)completionHandler {
@@ -83,6 +86,7 @@ static int kMSRefreshThreshold = 10 * 60;
     }
   }
 }
+#pragma clang diagnostic pop
 
 - (void)checkTokenExpiry {
   @synchronized(self) {

--- a/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSACAnalyticsAuthenticationProvider.m
+++ b/AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget/MSACAnalyticsAuthenticationProvider.m
@@ -54,12 +54,13 @@ static int kMSRefreshThreshold = 10 * 60;
   }
 }
 
-#pragma clang diagnostic push
-// Ignore warning '-Wcompletion-handler'" for XCode 13 and above
-#pragma clang diagnostic ignored "-Wcompletion-handler"
 - (void)handleTokenUpdateWithToken:(NSString *)token
                         expiryDate:(NSDate *)expiryDate
-             withCompletionHandler:(MSACAnalyticsAuthenticationProviderCompletionBlock)completionHandler {
+             withCompletionHandler:(MSACAnalyticsAuthenticationProviderCompletionBlock)completionHandler
+#if defined(__IPHONE_15_0)
+NS_SWIFT_DISABLE_ASYNC
+#endif
+{
   @synchronized(self) {
     if (self.completionHandler == completionHandler) {
       self.completionHandler = nil;
@@ -86,7 +87,6 @@ static int kMSRefreshThreshold = 10 * 60;
     }
   }
 }
-#pragma clang diagnostic pop
 
 - (void)checkTokenExpiry {
   @synchronized(self) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### App Center Crashes
 
 * **[Feature]** Add support for tracking handled errors with `Crashes.trackError` and `Crashes.trackException` APIs.
+* **[Fix]** Fix build failure on Xcode 13, because of warning `completion handler is never used`. Only observable when SDK is integrated as source code. Workaround: Set `Treat Warnings as Errors` to `No` in target's build settings.
 
 ### App Center Distribute
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests?~
* ~[ ] Did you check UI tests on the sample app? They are not executed on CI.~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Fixed issue with `completion handler is never used when taking false branch [-Werror,-Wcompletion-handler]` error message during building project in Xcode 13.

According official [Xcode 13 Beta Release Notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes) attribute `NS_SWIFT_DISABLE_ASYNC` has been added in affected methods. There is no way to check iOS version via `__IPHONE_OS_VERSION_MAX_ALLOWED` as it fails with `__IPHONE_OS_VERSION_MAX_ALLOWED is not defined in Xcode 13` , so this check is performed as `#if defined(__IPHONE_15_0)`.

Moved from https://github.com/microsoft/appcenter-sdk-apple/pull/2343