### PR TITLE
[CI] Return CodeCov tool

### DIFF
--- a/.azure-pipelines/analyze-and-test-template.yml
+++ b/.azure-pipelines/analyze-and-test-template.yml
@@ -55,3 +55,7 @@ jobs:
         PathtoPublish: /Users/runner/Library/Logs/DiagnosticReports
         ArtifactName: 'Test Diagnostic Reports'
       condition: failed()
+
+    - bash: 'bash <(curl -s https://codecov.io/bash) -X gcov -cF ${{ parameters.platform }}'
+      displayName: 'Upload Coverage Report to Codecov'
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Coverage Status](https://codecov.io/gh/microsoft/appcenter-sdk-apple/branch/develop/graph/badge.svg?token=6dlCB5riVi)](https://codecov.io/gh/microsoft/appcenter-sdk-apple)
 [![GitHub Release](https://img.shields.io/github/release/microsoft/appcenter-sdk-apple.svg)](https://github.com/microsoft/appcenter-sdk-apple/releases/latest)
 [![CocoaPods](https://img.shields.io/cocoapods/v/AppCenter.svg)](https://cocoapods.org/pods/AppCenter)
 [![license](https://img.shields.io/badge/license-MIT%20License-00AAAA.svg)](https://github.com/microsoft/appcenter-sdk-apple/blob/master/LICENSE)


### PR DESCRIPTION
We removed CodeCov tasks from our pipelines due to the vulnerability in CodeCov upload script.
The issue was that attacker could replace the content of CodeCov script with a line that catches all environment variables and sends to the attacker servers.
 
Since then, CodeCov team has fixed this security issue and took steps to prevent such cases in future.
Link to the CodeCov report about the incident: https://about.codecov.io/security-update/.

As such, I'm reverting the CodeCov removal in this PR.

Reverts microsoft/appcenter-sdk-apple#2291

Related work item: [AB#88106](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/88106)