### PR TITLE
Fix integration via Cocoapods v1.11.*

### DIFF
--- a/AppCenter.podspec
+++ b/AppCenter.podspec
@@ -65,8 +65,7 @@ Pod::Spec.new do |s|
     ss.dependency 'AppCenter/Core'
     ss.frameworks = 'Foundation'
     ss.ios.frameworks = 'UIKit'
-    ss.ios.weak_frameworks = 'AuthenticationServices'
-    ss.ios.weak_frameworks = 'SafariServices'
+    ss.ios.weak_frameworks = 'SafariServices', 'AuthenticationServices'
     ss.ios.resource_bundle = { 'AppCenterDistributeResources' => ['AppCenter-SDK-Apple/AppCenterDistributeResources.bundle/*.lproj'] }
     ss.ios.vendored_frameworks = "AppCenter-SDK-Apple/AppCenterDistribute.xcframework"
  end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - **[Fix]** Fix a warning `'Resources/AppCenterDistribute.strings': file not found` when resolving swift packages using Swift 5.5.
 - **[Fix]** Fix the part of the script which is responsible for cleanup the resource bundles inside the xcframework.
+- **[Fix]** Fix `Undefined symbols for architecture x86_64` for `ASWebAuthenticationSession` for Cocoapods (v 1.11) integration.
 
 ___
 


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* ~[ ] Are tests passing locally?~
* ~[ ] Are the files formatted correctly?~
* ~[ ] Did you add unit tests?~
* ~[ ] Did you check UI tests on the sample app? They are not executed on CI.~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes integration via Cocoapods starting from v1.11.0.
The `weak_frameworks` should be set as a list of frameworks, instead of defining another copy of `weak_frameworks` property.

## Related PRs or issues

[AB#88278](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/88278)