### PR TITLE
Exclude CoreTelephony from MacCatalyst build

### DIFF
--- a/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTracker.m
+++ b/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTracker.m
@@ -155,7 +155,7 @@ static MSACDeviceTracker *sharedInstance = nil;
 - (MSACDevice *)updatedDevice {
   @synchronized(self) {
     MSACDevice *newDevice = [MSACDevice new];
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     CTTelephonyNetworkInfo *telephonyNetworkInfo = [CTTelephonyNetworkInfo new];
     CTCarrier *carrier;
 
@@ -198,7 +198,7 @@ static MSACDeviceTracker *sharedInstance = nil;
     newDevice.timeZoneOffset = [self timeZoneOffset:[NSTimeZone localTimeZone]];
     newDevice.screenSize = [self screenSize];
     newDevice.appVersion = [self appVersion:MSAC_APP_MAIN_BUNDLE];
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
     newDevice.carrierCountry = [self carrierCountry:carrier] ?: overriddenCountryCode;
     newDevice.carrierName = [self carrierName:carrier];
 #else
@@ -414,7 +414,7 @@ static MSACDeviceTracker *sharedInstance = nil;
 #endif
 }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (NSString *)carrierName:(CTCarrier *)carrier {
   return [self isValidCarrierName:carrier.carrierName] ? carrier.carrierName : nil;
 }

--- a/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTrackerPrivate.h
+++ b/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTrackerPrivate.h
@@ -4,7 +4,7 @@
 #ifndef MSAC_DEVICE_TRACKER_PRIVATE_H
 #define MSAC_DEVICE_TRACKER_PRIVATE_H
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 #import <CoreTelephony/CTCarrier.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
 #endif
@@ -114,7 +114,7 @@ static NSString *const kMSACPastDevicesKey = @"PastDevices";
  */
 - (NSString *)screenSize;
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 /**
  * Get the network carrier name.
  *

--- a/AppCenter/AppCenterTests/MSACDeviceTrackerTests.m
+++ b/AppCenter/AppCenterTests/MSACDeviceTrackerTests.m
@@ -213,7 +213,7 @@ static NSString *const kMSACDeviceManufacturerTest = @"Apple";
   assertThatInteger([screenSize length], greaterThan(@(0)));
 }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (void)testCarrierName {
 
   // If
@@ -230,7 +230,7 @@ static NSString *const kMSACDeviceManufacturerTest = @"Apple";
 }
 #endif
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (void)testNoCarrierName {
 
   // If
@@ -246,7 +246,7 @@ static NSString *const kMSACDeviceManufacturerTest = @"Apple";
 }
 #endif
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (void)testNonValidCarrierName {
 
   // If
@@ -262,7 +262,7 @@ static NSString *const kMSACDeviceManufacturerTest = @"Apple";
 }
 #endif
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (void)testCarrierCountry {
 
   // If
@@ -279,7 +279,7 @@ static NSString *const kMSACDeviceManufacturerTest = @"Apple";
 }
 #endif
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (void)testNoCarrierCountry {
 
   // If
@@ -295,7 +295,7 @@ static NSString *const kMSACDeviceManufacturerTest = @"Apple";
 }
 #endif
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (void)testCarrierCountryNotOverridden {
 
   // If

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 4.3.1 (Under development)
 
+### App Center 
+
+* **[Fix]** Fix `Undefined symbol: OBJC_CLASS$_CTTelephonyNetworkInfo` error for Mac Catalyst platform when integrating the SDK via Swift Package Manager with Swift 5.5 and higher.
+
 ### App Center Crashes
 
 * **[Feature]** Add `(NSString *)description` method to convert `MSACErrorReport` to a string and additional useful information about sending error.

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
                 .linkedFramework("SystemConfiguration"),
                 .linkedFramework("AppKit", .when(platforms: [.macOS])),
                 .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
-                .linkedFramework("CoreTelephony", .when(platforms: [.iOS, .macOS])),
+                .linkedFramework("CoreTelephony", .when(platforms: [.iOS])),
             ]
         ),
         .target(

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -47,7 +47,7 @@ let package = Package(
                 .linkedFramework("SystemConfiguration"),
                 .linkedFramework("AppKit", .when(platforms: [.macOS])),
                 .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
-                .linkedFramework("CoreTelephony", .when(platforms: [.iOS, .macOS])),
+                .linkedFramework("CoreTelephony", .when(platforms: [.iOS])),
             ]
         ),
         .target(


### PR DESCRIPTION
Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests?~
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes the build failure when building for macCatalyst with Swift 5.5:
```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_CTTelephonyNetworkInfo", referenced from:
      objc-class-ref in AppCenter.o
ld: symbol(s) not found for architecture x86_64
```

This error breaks a SPM integration in Xcode 13 for Mac Catalyst platform.

## Related PRs or issues

[AB#88386](https://msmobilecenter.visualstudio.com/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/88386)
#2359
