### PR TITLE
Add a new property isOneCollectorEnabled to startService log

### DIFF
--- a/AppCenter/AppCenter/Internals/Model/MSACStartServiceLog.h
+++ b/AppCenter/AppCenter/Internals/Model/MSACStartServiceLog.h
@@ -9,8 +9,13 @@
 @interface MSACStartServiceLog : MSACAbstractLog <MSACNoAutoAssignSessionIdLog>
 
 /**
- * Services which started with SDK
+ * Services which started with SDK.
  */
 @property(nonatomic) NSArray<NSString *> *services;
+
+/**
+ * OneCollector usage status.
+ */
+@property(nonatomic) BOOL isOneCollectorEnabled;
 
 @end

--- a/AppCenter/AppCenter/Internals/Model/MSACStartServiceLog.m
+++ b/AppCenter/AppCenter/Internals/Model/MSACStartServiceLog.m
@@ -5,10 +5,12 @@
 
 static NSString *const kMSACStartService = @"startService";
 static NSString *const kMSACServices = @"services";
+static NSString *const kMSACIsOneCollectorEnabled = @"isOneCollectorEnabled";
 
 @implementation MSACStartServiceLog
 
 @synthesize services = _services;
+@synthesize isOneCollectorEnabled = _isOneCollectorEnabled;
 
 - (instancetype)init {
   if ((self = [super init])) {
@@ -31,6 +33,7 @@ static NSString *const kMSACServices = @"services";
   NSMutableDictionary *dict = [super serializeToDictionary];
   if (self.services) {
     dict[kMSACServices] = self.services;
+    dict[kMSACIsOneCollectorEnabled] = @(self.isOneCollectorEnabled);
   }
   return dict;
 }
@@ -40,6 +43,7 @@ static NSString *const kMSACServices = @"services";
 - (instancetype)initWithCoder:(NSCoder *)coder {
   if ((self = [super initWithCoder:coder])) {
     self.services = [coder decodeObjectForKey:kMSACServices];
+    self.isOneCollectorEnabled = [coder decodeBoolForKey:kMSACIsOneCollectorEnabled];
   }
   return self;
 }
@@ -47,6 +51,7 @@ static NSString *const kMSACServices = @"services";
 - (void)encodeWithCoder:(NSCoder *)coder {
   [super encodeWithCoder:coder];
   [coder encodeObject:self.services forKey:kMSACServices];
+  [coder encodeBool:self.isOneCollectorEnabled forKey:kMSACIsOneCollectorEnabled];
 }
 
 @end

--- a/AppCenter/AppCenter/MSACAppCenter.m
+++ b/AppCenter/AppCenter/MSACAppCenter.m
@@ -748,6 +748,7 @@ static const long kMSACMinUpperSizeLimitInBytes = 24 * 1024;
     if (self.isEnabled) {
       MSACStartServiceLog *serviceLog = [MSACStartServiceLog new];
       serviceLog.services = servicesNames;
+      serviceLog.isOneCollectorEnabled = self.defaultTransmissionTargetToken != nil;
       [self.channelUnit enqueueItem:serviceLog flags:MSACFlagsDefault];
     } else {
       if (self.startedServiceNames == nil) {

--- a/AppCenter/AppCenterTests/MSACAppCenterTests.m
+++ b/AppCenter/AppCenterTests/MSACAppCenterTests.m
@@ -657,6 +657,38 @@ static NSString *const kMSACNullifiedInstallIdString = @"00000000-0000-0000-0000
   OCMVerify([self.channelGroupMock setEnabled:NO andDeleteDataOnDisabled:YES]);
 }
 
+- (void)testStartServiceLogDisabledWithOneCollector {
+
+  // If
+  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSACStartServiceLog class]] flags:MSACFlagsDefault])
+      .andDo(^(NSInvocation *invocation) {
+        MSACStartServiceLog *log = nil;
+        [invocation getArgument:&log atIndex:2];
+
+        // Then.
+        XCTAssertFalse(log.isOneCollectorEnabled);
+      });
+
+  // When
+  [MSACAppCenter start:MSAC_UUID_STRING withServices:@[ MSACMockService.class ]];
+}
+
+- (void)testStartServiceLogWithEnabledOneCollector {
+
+  // If
+  OCMStub([self.channelUnitMock enqueueItem:[OCMArg isKindOfClass:[MSACStartServiceLog class]] flags:MSACFlagsDefault])
+      .andDo(^(NSInvocation *invocation) {
+        MSACStartServiceLog *log = nil;
+        [invocation getArgument:&log atIndex:2];
+
+        // Then.
+        XCTAssertTrue(log.isOneCollectorEnabled);
+      });
+
+  // When
+  [MSACAppCenter start:@"target=transmissionTargetToken" withServices:@[ MSACMockService.class ]];
+}
+
 - (void)testStartServiceLogWithDisabledCore {
 
   // If

--- a/AppCenter/AppCenterTests/MSACStartServiceLogTests.m
+++ b/AppCenter/AppCenterTests/MSACStartServiceLogTests.m
@@ -29,6 +29,7 @@
   // If
   NSArray<NSString *> *services = @[ @"Service0", @"Service1", @"Service2" ];
   self.sut.services = services;
+  self.sut.isOneCollectorEnabled = true;
 
   // When
   NSMutableDictionary *actual = [self.sut serializeToDictionary];
@@ -36,7 +37,9 @@
   // Then
   assertThat(actual, notNilValue());
   NSArray *actualServices = actual[@"services"];
+  NSArray *actualIsOneCollectorEnabled = actual[@"isOneCollectorEnabled"];
   XCTAssertEqual(actualServices.count, services.count);
+  XCTAssertTrue(actualIsOneCollectorEnabled);
   for (NSUInteger i = 0; i < actualServices.count; ++i) {
     assertThat(actualServices[i], equalTo(services[i]));
   }
@@ -59,7 +62,9 @@
 
   MSACStartServiceLog *log = actual;
   NSArray *actualServices = log.services;
+  BOOL *actualIsOneCollectorEnabled = log.isOneCollectorEnabled;
   XCTAssertEqual(actualServices.count, services.count);
+  XCTAssertFalse(actualIsOneCollectorEnabled);
   for (NSUInteger i = 0; i < actualServices.count; ++i) {
     assertThat(actualServices[i], equalTo(services[i]));
   }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] ~Has `CHANGELOG.md` been updated?~
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Add a new property to startService log.

## Related PRs or issues

[AB#89378](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/89378)
