### PR TITLE
[Distribute] Cancel web authorization session if application is not active

### DIFF
--- a/AppCenter/AppCenter/Internals/HttpClient/MSACHttpClient.m
+++ b/AppCenter/AppCenter/Internals/HttpClient/MSACHttpClient.m
@@ -11,8 +11,6 @@
 #import "MSACHttpUtil.h"
 #import "MSAC_Reachability.h"
 
-#define DEFAULT_RETRY_INTERVALS @[ @10, @(5 * 60), @(20 * 60) ]
-
 @implementation MSACHttpClient
 
 @synthesize delegate = _delegate;

--- a/AppCenter/AppCenter/Internals/HttpClient/Util/MSACHttpUtil.h
+++ b/AppCenter/AppCenter/Internals/HttpClient/Util/MSACHttpUtil.h
@@ -3,6 +3,8 @@
 
 #import <Foundation/Foundation.h>
 
+#define DEFAULT_RETRY_INTERVALS @[ @10, @(5 * 60), @(20 * 60) ]
+
 static short const kMSACMaxCharactersDisplayedForAppSecret = 8;
 static NSString *const kMSACHidingStringForAppSecret = @"*";
 

--- a/AppCenter/AppCenter/Internals/Ingestion/MSACHttpIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSACHttpIngestion.m
@@ -30,7 +30,7 @@ static NSString *const kMSACPartialURLComponentsName[] = {@"scheme", @"user", @"
                           apiPath:apiPath
                           headers:headers
                      queryStrings:queryStrings
-                   retryIntervals:@[ @(10), @(5 * 60), @(20 * 60) ]];
+                   retryIntervals:DEFAULT_RETRY_INTERVALS];
 }
 
 - (id)initWithHttpClient:(id<MSACHttpClientProtocol>)httpClient

--- a/AppCenter/AppCenter/Internals/Ingestion/MSACOneCollectorIngestion.m
+++ b/AppCenter/AppCenter/Internals/Ingestion/MSACOneCollectorIngestion.m
@@ -25,7 +25,7 @@
                                  [NSString stringWithFormat:kMSACOneCollectorClientVersionFormat, [MSACUtility sdkVersion]]
                            }
                       queryStrings:nil
-                    retryIntervals:@[ @(10), @(5 * 60), @(20 * 60) ]
+                    retryIntervals:DEFAULT_RETRY_INTERVALS
             maxNumberOfConnections:2];
   return self;
 }

--- a/AppCenterDistribute/AppCenterDistribute/MSACDistributeUtil.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistributeUtil.h
@@ -61,4 +61,11 @@ NSString *MSACPackageHash(void);
  */
 + (BOOL)isValidUpdateTrack:(MSACUpdateTrack)updateTrack;
 
+/**
+ * Finds and returns an active window to be used as a presentation anchor.
+ *
+ * @return Presentation anchor.
+ */
++ (ASPresentationAnchor)getPresentationAnchor API_AVAILABLE(ios(13));
+
 @end

--- a/AppCenterDistribute/AppCenterDistribute/MSACDistributeUtil.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistributeUtil.m
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#import "MSACDistributeUtil.h"
+#import <Foundation/Foundation.h>
+
 #import "MSACBasicMachOParser.h"
+#import "MSACDispatcherUtil.h"
 #import "MSACDistributeInternal.h"
 #import "MSACDistributePrivate.h"
+#import "MSACDistributeUtil.h"
 #import "MSACLogger.h"
 #import "MSACSemVer.h"
 #import "MSACUtility+StringFormatting.h"
@@ -130,6 +133,25 @@ NSString *MSACPackageHash(void) {
 
 + (BOOL)isValidUpdateTrack:(MSACUpdateTrack)updateTrack {
   return updateTrack == MSACUpdateTrackPublic || updateTrack == MSACUpdateTrackPrivate;
+}
+
++ (ASPresentationAnchor)getPresentationAnchor API_AVAILABLE(ios(13)) {
+  UIApplication *application = MSAC_DISPATCH_SELECTOR((UIApplication * (*)(id, SEL)), [UIApplication class], sharedApplication);
+  NSSet *scenes = MSAC_DISPATCH_SELECTOR((NSSet * (*)(id, SEL)), application, connectedScenes);
+  NSObject *windowScene;
+  for (NSObject *scene in scenes) {
+    NSInteger activationState = MSAC_DISPATCH_SELECTOR((NSInteger(*)(id, SEL)), scene, activationState);
+    if (activationState == 0 /* UISceneActivationStateForegroundActive */) {
+      windowScene = scene;
+    }
+  }
+  if (!windowScene) {
+    MSACLogError([MSACDistribute logTag], @"Could not find an active scene to be used as a presentation anchor");
+    return nil;
+  }
+  NSArray *windows = MSAC_DISPATCH_SELECTOR((NSArray * (*)(id, SEL)), windowScene, windows);
+  ASPresentationAnchor anchor = windows.firstObject;
+  return anchor;
 }
 
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### App Center 
 
+* **[Breaking change]** Remove `AppCenter.SetCustomProperties` API.
 * **[Fix]** Fix `Undefined symbol: OBJC_CLASS$_CTTelephonyNetworkInfo` error for Mac Catalyst platform when integrating the SDK via Swift Package Manager with Swift 5.5 and higher.
 * **[Fix]** Fix throw an exception when checking to authenticate MAC value during decryption.
+* **[Improvement]** Specified minimum cocoapods version in podspec to 1.10.0.
 
 ### App Center Analytics
 
@@ -19,10 +21,9 @@
 * **[Fix]** Fix build failure on Xcode 13, because of warning `Сompletion handler is never used`. Only observable when SDK is integrated as source code. Continuation of the previous fix that fixed the issue on the beta version.
 * **[Fix]** Fix sending `Crashes.trackError` logs after allowing network requests after the launch app.
 
-### App Center
+### App Center Distribute
 
-* **[Improvement]** Specified minimum cocoapods version in podspec to 1.10.0.
-* **[Breaking change]** Remove `AppCenter.SetCustomProperties` API.
+* **[Fix]** Cancel authorization process if application is not active, otherwise ASWebAuthenticationSession will fail opening browswer and update flow will end up being in a broken state. This only affects updating from a private distribution group.
 
 ___
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### App Center 
 
-* **[Breaking change]** Remove `AppCenter.SetCustomProperties` API.
+* **[Breaking change]** Remove `AppCenter.setCustomProperties` API.
 * **[Fix]** Fix `Undefined symbol: OBJC_CLASS$_CTTelephonyNetworkInfo` error for Mac Catalyst platform when integrating the SDK via Swift Package Manager with Swift 5.5 and higher.
 * **[Fix]** Fix throw an exception when checking to authenticate MAC value during decryption.
 * **[Improvement]** Specified minimum cocoapods version in podspec to 1.10.0.


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you check UI tests on the sample app? They are not executed on CI.
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes a broken in-app update flow on the stage of authorizing to a private distribution group. The issue happens on iOS 15 when a web browser is trying to show up before the app gets active (`applicationDidBecomeActive` is called).
These changes make sure the app is active before starting an authorization web session.

## Related PRs or issues

[AB#89320](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/89320)
#2372