### PR TITLE
Propose a workaround for SwiftPM's lack of recursive header search paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # App Center SDK for iOS, macOS and tvOS Change Log
 
 ## Version 4.4.2 (Under development)
+
+* **[Fix]** It is now possible to build the project using the command line `swift build`.
 ___
 
 ## Version 4.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 4.4.2 (Under development)
 
-* **[Fix]** It is now possible to build the project using the command line `swift build`.
+* **[Fix]** It is now possible to build the project using the AppCenterAnalytics and AppCenterCrashes targets on the command line via `swift build`.
 ___
 
 ## Version 4.4.1

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,50 @@
 
 import PackageDescription
 
+let projectHeaderSearchPaths = [
+    "../../AppCenter/AppCenter/Internals",
+    "../../AppCenter/AppCenter/Internals/Channel",
+    "../../AppCenter/AppCenter/Internals/Context/Device",
+    "../../AppCenter/AppCenter/Internals/Context/Session",
+    "../../AppCenter/AppCenter/Internals/Context/UserId",
+    "../../AppCenter/AppCenter/Internals/DelegateForwarder",
+    "../../AppCenter/AppCenter/Internals/HttpClient",
+    "../../AppCenter/AppCenter/Internals/HttpClient/Util",
+    "../../AppCenter/AppCenter/Internals/Ingestion",
+    "../../AppCenter/AppCenter/Internals/Ingestion/Util",
+    "../../AppCenter/AppCenter/Internals/Model",
+    "../../AppCenter/AppCenter/Internals/Model/CommonSchema",
+    "../../AppCenter/AppCenter/Internals/Model/Properties",
+    "../../AppCenter/AppCenter/Internals/Model/Util",
+    "../../AppCenter/AppCenter/Internals/Storage",
+    "../../AppCenter/AppCenter/Internals/Util",
+    "../../AppCenter/AppCenter/Internals/Vendor/Reachability",
+    "../../AppCenter/AppCenter/include",
+    "../../AppCenter/AppCenter/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/include",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Session",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Util",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals/Model",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals/Util",
+    "../../AppCenterCrashes/AppCenterCrashes/include",
+    "../../AppCenterCrashes/AppCenterCrashes/Model",
+    "../../AppCenterCrashes/AppCenterCrashes/WrapperSDKUtilities",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Channel",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Model",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Version",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Util",
+    "../../AppCenterDistribute/AppCenterDistribute/include",
+    "../../AppCenterDistribute/AppCenterDistribute/Model"
+]
+
+let cHeaderSearchPaths: [CSetting] = projectHeaderSearchPaths.map { .headerSearchPath($0) }
+
 let package = Package(
     name: "AppCenter",
     platforms: [
@@ -74,47 +118,3 @@ let package = Package(
         )
     ]
 )
-
-let projectHeaderSearchPaths = [
-    "../../AppCenter/AppCenter/Internals",
-    "../../AppCenter/AppCenter/Internals/Channel",
-    "../../AppCenter/AppCenter/Internals/Context/Device",
-    "../../AppCenter/AppCenter/Internals/Context/Session",
-    "../../AppCenter/AppCenter/Internals/Context/UserId",
-    "../../AppCenter/AppCenter/Internals/DelegateForwarder",
-    "../../AppCenter/AppCenter/Internals/HttpClient",
-    "../../AppCenter/AppCenter/Internals/HttpClient/Util",
-    "../../AppCenter/AppCenter/Internals/Ingestion",
-    "../../AppCenter/AppCenter/Internals/Ingestion/Util",
-    "../../AppCenter/AppCenter/Internals/Model",
-    "../../AppCenter/AppCenter/Internals/Model/CommonSchema",
-    "../../AppCenter/AppCenter/Internals/Model/Properties",
-    "../../AppCenter/AppCenter/Internals/Model/Util",
-    "../../AppCenter/AppCenter/Internals/Storage",
-    "../../AppCenter/AppCenter/Internals/Util",
-    "../../AppCenter/AppCenter/Internals/Vendor/Reachability",
-    "../../AppCenter/AppCenter/include",
-    "../../AppCenter/AppCenter/Model",
-    "../../AppCenterAnalytics/AppCenterAnalytics/include",
-    "../../AppCenterAnalytics/AppCenterAnalytics/Internals",
-    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Model",
-    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Session",
-    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Util",
-    "../../AppCenterAnalytics/AppCenterAnalytics/Model",
-    "../../AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget",
-    "../../AppCenterCrashes/AppCenterCrashes/Internals",
-    "../../AppCenterCrashes/AppCenterCrashes/Internals/Model",
-    "../../AppCenterCrashes/AppCenterCrashes/Internals/Util",
-    "../../AppCenterCrashes/AppCenterCrashes/include",
-    "../../AppCenterCrashes/AppCenterCrashes/Model",
-    "../../AppCenterCrashes/AppCenterCrashes/WrapperSDKUtilities",
-    "../../AppCenterDistribute/AppCenterDistribute/Internals",
-    "../../AppCenterDistribute/AppCenterDistribute/Internals/Channel",
-    "../../AppCenterDistribute/AppCenterDistribute/Internals/Model",
-    "../../AppCenterDistribute/AppCenterDistribute/Internals/Version",
-    "../../AppCenterDistribute/AppCenterDistribute/Internals/Util",
-    "../../AppCenterDistribute/AppCenterDistribute/include",
-    "../../AppCenterDistribute/AppCenterDistribute/Model"
-]
-
-let cHeaderSearchPaths: [CSetting] = projectHeaderSearchPaths.map { .headerSearchPath($0) }

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@
 import PackageDescription
 
 let projectHeaderSearchPaths = [
+    "**",
     "../../AppCenter/AppCenter/Internals",
     "../../AppCenter/AppCenter/Internals/Channel",
     "../../AppCenter/AppCenter/Internals/Context/Device",

--- a/Package.swift
+++ b/Package.swift
@@ -30,11 +30,14 @@ let package = Package(
             name: "AppCenter",
             path: "AppCenter/AppCenter",
             exclude: ["Support"],
-            cSettings: [
-                .define("APP_CENTER_C_VERSION", to:"\"4.4.2\""),
-                .define("APP_CENTER_C_BUILD", to:"\"1\""),
-                .headerSearchPath("**"),
-            ],
+            cSettings: {
+                var settings: [CSetting] = [
+                    .define("APP_CENTER_C_VERSION", to: "\"4.4.2\""),
+                    .define("APP_CENTER_C_BUILD", to: "\"1\"")
+                ]
+                settings.append(contentsOf: cHeaderSearchPaths)
+                return settings
+            }(),
             linkerSettings: [
                 .linkedLibrary("z"),
                 .linkedLibrary("sqlite3"),
@@ -50,10 +53,7 @@ let package = Package(
             dependencies: ["AppCenter"],
             path: "AppCenterAnalytics/AppCenterAnalytics",
             exclude: ["Support"],
-            cSettings: [
-                .headerSearchPath("**"),
-                .headerSearchPath("../../AppCenter/AppCenter/**"),
-            ],
+            cSettings: cHeaderSearchPaths,
             linkerSettings: [
                 .linkedFramework("Foundation"),
                 .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
@@ -65,10 +65,7 @@ let package = Package(
             dependencies: ["AppCenter", "CrashReporter"],
             path: "AppCenterCrashes/AppCenterCrashes",
             exclude: ["Support"],
-            cSettings: [
-                .headerSearchPath("**"),
-                .headerSearchPath("../../AppCenter/AppCenter/**"),
-            ],
+            cSettings: cHeaderSearchPaths,
             linkerSettings: [
                 .linkedFramework("Foundation"),
                 .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
@@ -77,3 +74,47 @@ let package = Package(
         )
     ]
 )
+
+let projectHeaderSearchPaths = [
+    "../../AppCenter/AppCenter/Internals",
+    "../../AppCenter/AppCenter/Internals/Channel",
+    "../../AppCenter/AppCenter/Internals/Context/Device",
+    "../../AppCenter/AppCenter/Internals/Context/Session",
+    "../../AppCenter/AppCenter/Internals/Context/UserId",
+    "../../AppCenter/AppCenter/Internals/DelegateForwarder",
+    "../../AppCenter/AppCenter/Internals/HttpClient",
+    "../../AppCenter/AppCenter/Internals/HttpClient/Util",
+    "../../AppCenter/AppCenter/Internals/Ingestion",
+    "../../AppCenter/AppCenter/Internals/Ingestion/Util",
+    "../../AppCenter/AppCenter/Internals/Model",
+    "../../AppCenter/AppCenter/Internals/Model/CommonSchema",
+    "../../AppCenter/AppCenter/Internals/Model/Properties",
+    "../../AppCenter/AppCenter/Internals/Model/Util",
+    "../../AppCenter/AppCenter/Internals/Storage",
+    "../../AppCenter/AppCenter/Internals/Util",
+    "../../AppCenter/AppCenter/Internals/Vendor/Reachability",
+    "../../AppCenter/AppCenter/include",
+    "../../AppCenter/AppCenter/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/include",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Session",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Util",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals/Model",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals/Util",
+    "../../AppCenterCrashes/AppCenterCrashes/include",
+    "../../AppCenterCrashes/AppCenterCrashes/Model",
+    "../../AppCenterCrashes/AppCenterCrashes/WrapperSDKUtilities",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Channel",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Model",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Version",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Util",
+    "../../AppCenterDistribute/AppCenterDistribute/include",
+    "../../AppCenterDistribute/AppCenterDistribute/Model"
+]
+
+let cHeaderSearchPaths: [CSetting] = projectHeaderSearchPaths.map { .headerSearchPath($0) }

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -35,11 +35,14 @@ let package = Package(
             name: "AppCenter",
             path: "AppCenter/AppCenter",
             exclude: ["Support"],
-            cSettings: [
-                .define("APP_CENTER_C_VERSION", to:"\"4.4.2\""),
-                .define("APP_CENTER_C_BUILD", to:"\"1\""),
-                .headerSearchPath("**"),
-            ],
+            cSettings: {
+                var settings: [CSetting] = [
+                    .define("APP_CENTER_C_VERSION", to: "\"4.4.2\""),
+                    .define("APP_CENTER_C_BUILD", to: "\"1\"")
+                ]
+                settings.append(contentsOf: cHeaderSearchPaths)
+                return settings
+            }(),
             linkerSettings: [
                 .linkedLibrary("z"),
                 .linkedLibrary("sqlite3"),
@@ -55,10 +58,7 @@ let package = Package(
             dependencies: ["AppCenter"],
             path: "AppCenterAnalytics/AppCenterAnalytics",
             exclude: ["Support"],
-            cSettings: [
-                .headerSearchPath("**"),
-                .headerSearchPath("../../AppCenter/AppCenter/**"),
-            ],
+            cSettings: cHeaderSearchPaths,
             linkerSettings: [
                 .linkedFramework("Foundation"),
                 .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
@@ -73,10 +73,7 @@ let package = Package(
             ],
             path: "AppCenterCrashes/AppCenterCrashes",
             exclude: ["Support", "Internals/MSACCrashesBufferedLog.hpp"],
-            cSettings: [
-                .headerSearchPath("**"),
-                .headerSearchPath("../../AppCenter/AppCenter/**"),
-            ],
+            cSettings: cHeaderSearchPaths,
             linkerSettings: [
                 .linkedFramework("Foundation"),
                 .linkedFramework("UIKit", .when(platforms: [.iOS, .tvOS])),
@@ -88,10 +85,7 @@ let package = Package(
             dependencies: ["AppCenter"],
             path: "AppCenterDistribute/AppCenterDistribute",
             exclude: ["Support"],
-            cSettings: [
-                .headerSearchPath("**"),
-                .headerSearchPath("../../AppCenter/AppCenter/**"),
-            ],
+            cSettings: cHeaderSearchPaths,
             linkerSettings: [
                 .linkedFramework("Foundation"),
                 .linkedFramework("SafariServices", .when(platforms: [.iOS])),
@@ -101,3 +95,47 @@ let package = Package(
         )
     ]
 )
+
+let projectHeaderSearchPaths = [
+    "../../AppCenter/AppCenter/Internals",
+    "../../AppCenter/AppCenter/Internals/Channel",
+    "../../AppCenter/AppCenter/Internals/Context/Device",
+    "../../AppCenter/AppCenter/Internals/Context/Session",
+    "../../AppCenter/AppCenter/Internals/Context/UserId",
+    "../../AppCenter/AppCenter/Internals/DelegateForwarder",
+    "../../AppCenter/AppCenter/Internals/HttpClient",
+    "../../AppCenter/AppCenter/Internals/HttpClient/Util",
+    "../../AppCenter/AppCenter/Internals/Ingestion",
+    "../../AppCenter/AppCenter/Internals/Ingestion/Util",
+    "../../AppCenter/AppCenter/Internals/Model",
+    "../../AppCenter/AppCenter/Internals/Model/CommonSchema",
+    "../../AppCenter/AppCenter/Internals/Model/Properties",
+    "../../AppCenter/AppCenter/Internals/Model/Util",
+    "../../AppCenter/AppCenter/Internals/Storage",
+    "../../AppCenter/AppCenter/Internals/Util",
+    "../../AppCenter/AppCenter/Internals/Vendor/Reachability",
+    "../../AppCenter/AppCenter/include",
+    "../../AppCenter/AppCenter/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/include",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Session",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Util",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals/Model",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals/Util",
+    "../../AppCenterCrashes/AppCenterCrashes/include",
+    "../../AppCenterCrashes/AppCenterCrashes/Model",
+    "../../AppCenterCrashes/AppCenterCrashes/WrapperSDKUtilities",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Channel",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Model",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Version",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Util",
+    "../../AppCenterDistribute/AppCenterDistribute/include",
+    "../../AppCenterDistribute/AppCenterDistribute/Model"
+]
+
+let cHeaderSearchPaths: [CSetting] = projectHeaderSearchPaths.map { .headerSearchPath($0) }

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -6,6 +6,7 @@
 import PackageDescription
 
 let projectHeaderSearchPaths = [
+    "**",
     "../../AppCenter/AppCenter/Internals",
     "../../AppCenter/AppCenter/Internals/Channel",
     "../../AppCenter/AppCenter/Internals/Context/Device",

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -5,6 +5,50 @@
 
 import PackageDescription
 
+let projectHeaderSearchPaths = [
+    "../../AppCenter/AppCenter/Internals",
+    "../../AppCenter/AppCenter/Internals/Channel",
+    "../../AppCenter/AppCenter/Internals/Context/Device",
+    "../../AppCenter/AppCenter/Internals/Context/Session",
+    "../../AppCenter/AppCenter/Internals/Context/UserId",
+    "../../AppCenter/AppCenter/Internals/DelegateForwarder",
+    "../../AppCenter/AppCenter/Internals/HttpClient",
+    "../../AppCenter/AppCenter/Internals/HttpClient/Util",
+    "../../AppCenter/AppCenter/Internals/Ingestion",
+    "../../AppCenter/AppCenter/Internals/Ingestion/Util",
+    "../../AppCenter/AppCenter/Internals/Model",
+    "../../AppCenter/AppCenter/Internals/Model/CommonSchema",
+    "../../AppCenter/AppCenter/Internals/Model/Properties",
+    "../../AppCenter/AppCenter/Internals/Model/Util",
+    "../../AppCenter/AppCenter/Internals/Storage",
+    "../../AppCenter/AppCenter/Internals/Util",
+    "../../AppCenter/AppCenter/Internals/Vendor/Reachability",
+    "../../AppCenter/AppCenter/include",
+    "../../AppCenter/AppCenter/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/include",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Session",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Util",
+    "../../AppCenterAnalytics/AppCenterAnalytics/Model",
+    "../../AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals/Model",
+    "../../AppCenterCrashes/AppCenterCrashes/Internals/Util",
+    "../../AppCenterCrashes/AppCenterCrashes/include",
+    "../../AppCenterCrashes/AppCenterCrashes/Model",
+    "../../AppCenterCrashes/AppCenterCrashes/WrapperSDKUtilities",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Channel",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Model",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Version",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Util",
+    "../../AppCenterDistribute/AppCenterDistribute/include",
+    "../../AppCenterDistribute/AppCenterDistribute/Model"
+]
+
+let cHeaderSearchPaths: [CSetting] = projectHeaderSearchPaths.map { .headerSearchPath($0) }
+
 let package = Package(
     name: "AppCenter",
     defaultLocalization: "en",
@@ -95,47 +139,3 @@ let package = Package(
         )
     ]
 )
-
-let projectHeaderSearchPaths = [
-    "../../AppCenter/AppCenter/Internals",
-    "../../AppCenter/AppCenter/Internals/Channel",
-    "../../AppCenter/AppCenter/Internals/Context/Device",
-    "../../AppCenter/AppCenter/Internals/Context/Session",
-    "../../AppCenter/AppCenter/Internals/Context/UserId",
-    "../../AppCenter/AppCenter/Internals/DelegateForwarder",
-    "../../AppCenter/AppCenter/Internals/HttpClient",
-    "../../AppCenter/AppCenter/Internals/HttpClient/Util",
-    "../../AppCenter/AppCenter/Internals/Ingestion",
-    "../../AppCenter/AppCenter/Internals/Ingestion/Util",
-    "../../AppCenter/AppCenter/Internals/Model",
-    "../../AppCenter/AppCenter/Internals/Model/CommonSchema",
-    "../../AppCenter/AppCenter/Internals/Model/Properties",
-    "../../AppCenter/AppCenter/Internals/Model/Util",
-    "../../AppCenter/AppCenter/Internals/Storage",
-    "../../AppCenter/AppCenter/Internals/Util",
-    "../../AppCenter/AppCenter/Internals/Vendor/Reachability",
-    "../../AppCenter/AppCenter/include",
-    "../../AppCenter/AppCenter/Model",
-    "../../AppCenterAnalytics/AppCenterAnalytics/include",
-    "../../AppCenterAnalytics/AppCenterAnalytics/Internals",
-    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Model",
-    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Session",
-    "../../AppCenterAnalytics/AppCenterAnalytics/Internals/Util",
-    "../../AppCenterAnalytics/AppCenterAnalytics/Model",
-    "../../AppCenterAnalytics/AppCenterAnalytics/TransmissionTarget",
-    "../../AppCenterCrashes/AppCenterCrashes/Internals",
-    "../../AppCenterCrashes/AppCenterCrashes/Internals/Model",
-    "../../AppCenterCrashes/AppCenterCrashes/Internals/Util",
-    "../../AppCenterCrashes/AppCenterCrashes/include",
-    "../../AppCenterCrashes/AppCenterCrashes/Model",
-    "../../AppCenterCrashes/AppCenterCrashes/WrapperSDKUtilities",
-    "../../AppCenterDistribute/AppCenterDistribute/Internals",
-    "../../AppCenterDistribute/AppCenterDistribute/Internals/Channel",
-    "../../AppCenterDistribute/AppCenterDistribute/Internals/Model",
-    "../../AppCenterDistribute/AppCenterDistribute/Internals/Version",
-    "../../AppCenterDistribute/AppCenterDistribute/Internals/Util",
-    "../../AppCenterDistribute/AppCenterDistribute/include",
-    "../../AppCenterDistribute/AppCenterDistribute/Model"
-]
-
-let cHeaderSearchPaths: [CSetting] = projectHeaderSearchPaths.map { .headerSearchPath($0) }


### PR DESCRIPTION
## Description

This PR proposes a workaround for the issue described in #2140. 

## Related PRs or issues

- #2140

## Misc

Ideally the list of header search paths could be scanned from the filesystem, however I think there are potentially bigger reliability issues with doing that than with what I've proposed. 
