### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,75 +1,76 @@
 {
-    "Registrations": [
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "name": "PLCrashReporter",
-                    "repositoryUrl": "https://github.com/microsoft/plcrashreporter.git",
-                    "commitHash": "1edf9be2c83172e7f9e3c72ffe42f07c41106f02"
-                }
-            }
-        },        
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "name": "OCHamcrest",
-                    "repositoryUrl": "https://github.com/hamcrest/OCHamcrest.git",
-                    "commitHash": "5f77cf33732dfa02e0b9f15e43d05a9110cc2ff0"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "name": "OCMock",
-                    "repositoryUrl": "https://github.com/erikdoe/ocmock.git",
-                    "commitHash": "a8e58d45b47f0a8aca04dcba4980b7ee6ffc06dc"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "name":"OHHTTPStubs",
-                    "repositoryUrl": "https://github.com/AliSoftware/OHHTTPStubs.git",
-                    "commitHash": "e92b5a5746ef16add2a1424f1fc19529d9a75cde"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "name": "Official Git mirror of the SQLite source tree",
-                    "repositoryUrl": "https://github.com/sqlite/sqlite.git",
-                    "commitHash": "562fd18b9dc27216191c0a6477bba9b175f7f0d2"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "git",
-                "git": {
-                    "name": "Protocol Buffers implementation in C",
-                    "repositoryUrl": "https://github.com/protobuf-c/protobuf-c.git",
-                    "commitHash": "1390409f4ee4e26d0635310995b516eb702c3f9e"
-                }
-            }
-        },
-        {
-            "component": {
-                "type": "other",
-                "other": {
-                    "name": "Reachability",
-                    "version": "5.0",
-                    "downloadUrl": "https://developer.apple.com/library/archive/samplecode/Reachability/Reachability.zip"
-                }
-            }
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "name": "PLCrashReporter",
+          "repositoryUrl": "https://github.com/microsoft/plcrashreporter.git",
+          "commitHash": "1edf9be2c83172e7f9e3c72ffe42f07c41106f02"
         }
-    ],
-    "Version": 1
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "name": "OCHamcrest",
+          "repositoryUrl": "https://github.com/hamcrest/OCHamcrest.git",
+          "commitHash": "5f77cf33732dfa02e0b9f15e43d05a9110cc2ff0"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "name": "OCMock",
+          "repositoryUrl": "https://github.com/erikdoe/ocmock.git",
+          "commitHash": "a8e58d45b47f0a8aca04dcba4980b7ee6ffc06dc"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "name": "OHHTTPStubs",
+          "repositoryUrl": "https://github.com/AliSoftware/OHHTTPStubs.git",
+          "commitHash": "e92b5a5746ef16add2a1424f1fc19529d9a75cde"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "name": "Official Git mirror of the SQLite source tree",
+          "repositoryUrl": "https://github.com/sqlite/sqlite.git",
+          "commitHash": "562fd18b9dc27216191c0a6477bba9b175f7f0d2"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "name": "Protocol Buffers implementation in C",
+          "repositoryUrl": "https://github.com/protobuf-c/protobuf-c.git",
+          "commitHash": "1390409f4ee4e26d0635310995b516eb702c3f9e"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "Reachability",
+          "version": "5.0",
+          "downloadUrl": "https://developer.apple.com/library/archive/samplecode/Reachability/Reachability.zip"
+        }
+      }
+    }
+  ],
+  "Version": 1
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.