### PR TITLE
Fix SwiftUI Previews in Xcode 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### App Center
 
-* **[Fix]** Fix throw exceptions when SwiftUI Preview is used in Xcode 14 when adding AppCenter through SPM.
+* **[Fix]** Fix SwiftUI Preview in Xcode 14 when adding App Center SDK through SwiftPM.
 
 ### App Center Crashes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## Version 4.4.3
 
+### App Center
+
+* **[Fix]** Fix throw exceptions when SwiftUI Preview is used in Xcode 14 when adding AppCenter through SPM.
+
 ### App Center Crashes
 
 * **[Improvement]** Update PLCrashReporter to 1.10.2.

--- a/Package.swift
+++ b/Package.swift
@@ -60,11 +60,9 @@ let package = Package(
     products: [
         .library(
             name: "AppCenterAnalytics",
-            type: .static,
             targets: ["AppCenterAnalytics"]),
         .library(
             name: "AppCenterCrashes",
-            type: .static,
             targets: ["AppCenterCrashes"])
     ],
     dependencies: [

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -61,15 +61,12 @@ let package = Package(
     products: [
         .library(
             name: "AppCenterAnalytics",
-            type: .static,
             targets: ["AppCenterAnalytics"]),
         .library(
             name: "AppCenterCrashes",
-            type: .static,
             targets: ["AppCenterCrashes"]),
         .library(
             name: "AppCenterDistribute",
-            type: .static,
             targets: ["AppCenterDistribute"]),
     ],
     dependencies: [


### PR DESCRIPTION
SwiftUI Previews in Xcode 14 failing to run when adding AppCenter through SPM

<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* ~[ ] Are tests passing locally?~
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests?~
* ~[ ] Did you check UI tests on the sample app? They are not executed on CI.~
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixing SwiftUI Previews in Xcode 14 that failed to run when adding AppCenter through SPM. 

[AB#2429](https://github.com/microsoft/appcenter-sdk-apple/issues/2429/)