### PR TITLE
Move channels iteration under synchronized

### DIFF
--- a/AppCenter/AppCenter/Internals/Channel/MSACChannelGroupDefault.m
+++ b/AppCenter/AppCenter/Internals/Channel/MSACChannelGroupDefault.m
@@ -229,8 +229,8 @@ static char *const kMSACLogsDispatchQueue = "com.microsoft.appcenter.ChannelGrou
   // Disable ingestion, sending log will not be possible but they'll still be stored.
   [self.ingestion setEnabled:NO andDeleteDataOnDisabled:NO];
 
-  // Pause each channel asynchronously.
-  for (id<MSACChannelProtocol> channel in self.channels) {
+  NSArray *copyArray = [self.channels copy];
+  for (id<MSACChannelProtocol> channel in copyArray) {
     [channel pauseWithIdentifyingObject:identifyingObject];
   }
 }
@@ -240,8 +240,8 @@ static char *const kMSACLogsDispatchQueue = "com.microsoft.appcenter.ChannelGrou
   // Resume ingestion, logs can be sent again. Pending logs are sent.
   [self.ingestion setEnabled:YES andDeleteDataOnDisabled:NO];
 
-  // Resume each channel asynchronously.
-  for (id<MSACChannelProtocol> channel in self.channels) {
+  NSArray *copyArray = [self.channels copy];
+  for (id<MSACChannelProtocol> channel in copyArray) {
     [channel resumeWithIdentifyingObject:identifyingObject];
   }
 }

--- a/AppCenter/AppCenterTests/MSACChannelGroupDefaultTests.m
+++ b/AppCenter/AppCenterTests/MSACChannelGroupDefaultTests.m
@@ -229,6 +229,46 @@
   OCMVerify([channelMock pauseWithIdentifyingObject:identifyingObject]);
 }
 
+- (void)testResumeWithConcurrentChannelsModification {
+
+  // If
+  for (int i = 0; i < 1000; i++) {
+    id<MSACChannelUnitProtocol> channelMock = OCMProtocolMock(@protocol(MSACChannelUnitProtocol));
+    [self.sut.channels addObject:channelMock];
+  }
+  NSObject *token = [NSObject new];
+
+  // When
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+      for (int i = 0; i < 1000; i++) {
+        [self.sut.channels removeLastObject];
+      }
+  });
+
+  // Then
+  XCTAssertNoThrow([self.sut resumeWithIdentifyingObject:token]);
+}
+
+- (void)testPauseWithConcurrentChannelsModification {
+
+    // If
+    for (int i = 0; i < 1000; i++) {
+        id<MSACChannelUnitProtocol> channelMock = OCMProtocolMock(@protocol(MSACChannelUnitProtocol));
+        [self.sut.channels addObject:channelMock];
+    }
+    NSObject *token = [NSObject new];
+
+    // When
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        for (int i = 0; i < 1000; i++) {
+            [self.sut.channels removeLastObject];
+        }
+    });
+
+    // Then
+    XCTAssertNoThrow([self.sut pauseWithIdentifyingObject:token]);
+}
+
 - (void)testChannelUnitIsCorrectlyInitialized {
 
   // If

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version 5.0.1 (Under development)
 
+### App Center
+
+* **[Fix]** Fix "Collection was mutated while being enumerated" exception in MSACChannelGroupDefault.
+
 ### App Center Distribute
 
 * **[Fix]** Fix crash in getPresentationAnchor function if the active scene is not an instance of UIWindowScene.


### PR DESCRIPTION
The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests? 
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description
NSFastEnumerationMutationHandler throws exception usually when we are changing list while iterating over it. For example removing item. In this case looks like some other thread does this with channels property. Added synchronized block for proper access. 

## Related PRs or issues
[AB#95990](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/95990)
