### PR TITLE
Always use isDirectory parameter to improve performace

### DIFF
--- a/AppCenter/AppCenter/Internals/Util/MSACUtility+File.m
+++ b/AppCenter/AppCenter/Internals/Util/MSACUtility+File.m
@@ -25,7 +25,7 @@ static NSString *const kMSACAppCenterBundleIdentifier = @"com.microsoft.appcente
                       forceOverwrite:(BOOL)forceOverwrite {
   @synchronized(self) {
     if (filePathComponent) {
-      NSURL *fileURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:filePathComponent];
+      NSURL *fileURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:filePathComponent isDirectory:NO];
 
       // Check if item already exists. We need to check this as writeToURL:atomically: can override an existing file.
       if (!forceOverwrite && [fileURL checkResourceIsReachableAndReturnError:nil]) {
@@ -51,7 +51,7 @@ static NSString *const kMSACAppCenterBundleIdentifier = @"com.microsoft.appcente
 + (BOOL)deleteItemForPathComponent:(NSString *)itemPathComponent {
   @synchronized(self) {
     if (itemPathComponent) {
-      NSURL *itemURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:itemPathComponent];
+      NSURL *itemURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:itemPathComponent isDirectory:YES];
       NSError *error = nil;
       BOOL succeeded;
       succeeded = [[NSFileManager defaultManager] removeItemAtURL:itemURL error:&error];
@@ -89,7 +89,7 @@ static NSString *const kMSACAppCenterBundleIdentifier = @"com.microsoft.appcente
 + (NSURL *)createDirectoryForPathComponent:(NSString *)directoryPathComponent {
   @synchronized(self) {
     if (directoryPathComponent) {
-      NSURL *subDirURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:directoryPathComponent];
+      NSURL *subDirURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:directoryPathComponent isDirectory:YES];
       BOOL success = [self createDirectoryAtURL:subDirURL];
       return success ? subDirURL : nil;
     }
@@ -100,7 +100,7 @@ static NSString *const kMSACAppCenterBundleIdentifier = @"com.microsoft.appcente
 + (NSData *)loadDataForPathComponent:(NSString *)filePathComponent {
   @synchronized(self) {
     if (filePathComponent) {
-      NSURL *fileURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:filePathComponent];
+      NSURL *fileURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:filePathComponent isDirectory:NO];
       return [NSData dataWithContentsOfURL:fileURL];
     }
     return nil;
@@ -133,7 +133,7 @@ static NSString *const kMSACAppCenterBundleIdentifier = @"com.microsoft.appcente
 
 + (BOOL)fileExistsForPathComponent:(NSString *)filePathComponent {
   {
-    NSURL *fileURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:filePathComponent];
+    NSURL *fileURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:filePathComponent isDirectory:NO];
     return [fileURL checkResourceIsReachableAndReturnError:nil];
   }
 }
@@ -141,7 +141,7 @@ static NSString *const kMSACAppCenterBundleIdentifier = @"com.microsoft.appcente
 + (NSURL *)fullURLForPathComponent:(NSString *)filePathComponent {
   {
     if (filePathComponent) {
-      return [[self appCenterDirectoryURL] URLByAppendingPathComponent:filePathComponent];
+      return [[self appCenterDirectoryURL] URLByAppendingPathComponent:filePathComponent isDirectory:NO];
     }
     return nil;
   }
@@ -168,9 +168,9 @@ static NSString *const kMSACAppCenterBundleIdentifier = @"com.microsoft.appcente
 
     // Use the application's bundle identifier for macOS to make sure to use separate directories for each app.
     NSString *bundleIdentifier = [NSString stringWithFormat:@"%@/", [MSAC_APP_MAIN_BUNDLE bundleIdentifier]];
-    dirURL = [[baseDirUrl URLByAppendingPathComponent:bundleIdentifier] URLByAppendingPathComponent:kMSACAppCenterBundleIdentifier];
+    dirURL = [[baseDirUrl URLByAppendingPathComponent:bundleIdentifier isDirectory:YES] URLByAppendingPathComponent:kMSACAppCenterBundleIdentifier isDirectory:YES];
 #else
-    dirURL = [baseDirUrl URLByAppendingPathComponent:kMSACAppCenterBundleIdentifier];
+    dirURL = [baseDirUrl URLByAppendingPathComponent:kMSACAppCenterBundleIdentifier isDirectory:YES];
 #endif
     [self createDirectoryAtURL:dirURL];
   });

--- a/AppCenter/AppCenter/Internals/Util/MSACUtility+File.m
+++ b/AppCenter/AppCenter/Internals/Util/MSACUtility+File.m
@@ -51,7 +51,7 @@ static NSString *const kMSACAppCenterBundleIdentifier = @"com.microsoft.appcente
 + (BOOL)deleteItemForPathComponent:(NSString *)itemPathComponent {
   @synchronized(self) {
     if (itemPathComponent) {
-      NSURL *itemURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:itemPathComponent isDirectory:YES];
+      NSURL *itemURL = [[self appCenterDirectoryURL] URLByAppendingPathComponent:itemPathComponent];
       NSError *error = nil;
       BOOL succeeded;
       succeeded = [[NSFileManager defaultManager] removeItemAtURL:itemURL error:&error];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### App Center
 
 * **[Fix]** Fix NSLog congestion on Apple's Framework Thread.
+* **[Improvement]** Always specify `isDirectory` parameter for `[NSURL URLByAppendingPathComponent:]` for better performace.
+
  ___
 
 ## Version 5.0.1


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* ~[ ] Did you add unit tests?~
* ~[ ] Did you check UI tests on the sample app? They are not executed on CI.~
* [ ] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Using `[NSURL URLByAppendingPathComponent:]` may cause performance issues if we don't specify `isDirectory`.
Quote from apple docs:

> If the receiver is a file URL and pathComponent does not end with a trailing slash, this method may read file metadata to determine whether the resulting path is a directory. This is done synchronously, and may have significant performance costs if the receiver is a location on a network mounted filesystem. You can instead call the [URLByAppendingPathComponent:isDirectory:](https://developer.apple.com/documentation/foundation/nsurl/1413953-urlbyappendingpathcomponent) method if you know whether the resulting path is a directory to avoid this file metadata operation.


This PR adds all missing `isDirectory` arguments.

~~Note, that `deleteItemForPathComponent` is used for both files and directories. However, I specify  `isDirectory:YES` assuming it would not break anything. Alternatively I would need to add an additional parameter to this method, which affects multiple parts of the code, so I would better to avoid that.~~

## Related PRs or issues

[AB#98782](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/98782)