### PR TITLE
Fix the build issue with Xcode 15 beta when integrating via Swift Package Manager (#2484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Version 5.0.3 (Under development)
 
+* **[Fix]** Fix the build issue with Xcode 15 beta when integrating via Swift Package Manager.
+
 ## Version 5.0.2
 
 ### App Center

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ let projectHeaderSearchPaths = [
     "../../AppCenterCrashes/AppCenterCrashes/WrapperSDKUtilities",
     "../../AppCenterDistribute/AppCenterDistribute/Internals",
     "../../AppCenterDistribute/AppCenterDistribute/Internals/Channel",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Ingestion",
     "../../AppCenterDistribute/AppCenterDistribute/Internals/Model",
     "../../AppCenterDistribute/AppCenterDistribute/Internals/Version",
     "../../AppCenterDistribute/AppCenterDistribute/Internals/Util",

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -41,6 +41,7 @@ let projectHeaderSearchPaths = [
     "../../AppCenterCrashes/AppCenterCrashes/WrapperSDKUtilities",
     "../../AppCenterDistribute/AppCenterDistribute/Internals",
     "../../AppCenterDistribute/AppCenterDistribute/Internals/Channel",
+    "../../AppCenterDistribute/AppCenterDistribute/Internals/Ingestion",
     "../../AppCenterDistribute/AppCenterDistribute/Internals/Model",
     "../../AppCenterDistribute/AppCenterDistribute/Internals/Version",
     "../../AppCenterDistribute/AppCenterDistribute/Internals/Util",


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes the build issue with Xcode 15 beta when integrating via Swift Package Manager by adding the missing header search path into `Package.swift`.

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-apple/issues/2484

## Misc

