### PR TITLE
Reduce number of threads when setting up log buffer for crashes

### DIFF
--- a/AppCenterCrashes/AppCenterCrashesTests/MSACCrashesTests.mm
+++ b/AppCenterCrashes/AppCenterCrashesTests/MSACCrashesTests.mm
@@ -49,7 +49,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)applicationWillEnterForeground;
 - (void)didReceiveMemoryWarning:(NSNotification *)notification;
 
-@property(nonatomic) dispatch_group_t bufferFileGroup;
+@property(nonatomic) NSOperationQueue *bufferFileQueue;
 
 @property dispatch_source_t memoryPressureSource;
 
@@ -98,7 +98,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
   [MSACCrashes resetSharedInstance];
 
   // Wait for creation of buffers.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // Delete all files.
   [self.sut deleteAllFromCrashesDirectory];
@@ -125,7 +125,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
   XCTAssertTrue(msACCrashesLogBuffer.size() == ms_crashes_log_buffer_size);
 
   // Wait for creation of buffers.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
   NSArray *files = [MSACUtility contentsOfDirectory:self.sut.logBufferPathComponent propertiesForKeys:nil];
   assertThat(files, hasCountOf(ms_crashes_log_buffer_size));
 }
@@ -329,7 +329,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testProcessCrashes {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -414,7 +414,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testProcessCrashesWithErrorAttachments {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -468,7 +468,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testProcessCrashesOnEnterForeground {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -562,7 +562,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 
   // If
   // Wait for creation of buffers.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // Then
   NSArray<NSURL *> *first = [MSACUtility contentsOfDirectory:self.sut.logBufferPathComponent
@@ -713,7 +713,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testLogBufferSave {
 
   // Wait for creation of buffers.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   __block NSUInteger numInvocations = 0;
@@ -821,7 +821,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testSendOrAwaitWhenAlwaysSendIsTrue {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -855,7 +855,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testSendOrAwaitWhenAlwaysSendIsFalseAndNotifyAlwaysSend {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -895,7 +895,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testSendOrAwaitWhenAlwaysSendIsFalseAndNotifySend {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -935,7 +935,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testSendOrAwaitWhenAlwaysSendIsFalseAndNotifyDontSend {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -970,7 +970,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testGetUnprocessedCrashReportsWhenThereAreNone {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -989,7 +989,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testSendErrorAttachments {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -1029,7 +1029,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testGetUnprocessedCrashReports {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -1057,7 +1057,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testStartingCrashesWithoutAutomaticProcessing {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -1085,7 +1085,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testStartingCrashesWithAutomaticProcessing {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -1102,7 +1102,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testErrorOnIncorrectNotifyWithUserConfirmationCall {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   self.sut = OCMPartialMock(self.sut);
@@ -1120,7 +1120,7 @@ static unsigned int kAttachmentsPerCrashReport = 3;
 - (void)testCrashesSetCorrectUserIdToLogs {
 
   // Wait for creation of buffers to avoid corruption on OCMPartialMock.
-  dispatch_group_wait(self.sut.bufferFileGroup, DISPATCH_TIME_FOREVER);
+  [self.sut.bufferFileQueue waitUntilAllOperationsAreFinished];
 
   // If
   __block XCTestExpectation *expectation = [self expectationWithDescription:@"Channel received a log"];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * **[Improvement]** Update App Center SDK to include privacy manifest.
 * **[Internal]** Add `dataResidencyRegion` option.
+* **[Fix]** Mitigate the runtime pressure when starting App Center Crashes
 
 ## Version 5.0.3
 


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [x] Has `CHANGELOG.md` been updated?
* [x] Are tests passing locally?
However the following test was failing **before** made changes:
<img width="500" alt="Screenshot 2023-09-20 at 8 08 43 AM" src="https://github.com/microsoft/appcenter-sdk-apple/assets/1112653/219aeebb-c3bc-4e31-8e01-245f402983b8">

* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
No need to add new tests as the affected functionality has been already covered
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?
Yes, the test app which was used to identify the issue (see #2497) does not have the number of threads observed with the proposed change.

## Description

When log buffer for crashes is setup, `ms_crashes_log_buffer_size` asynchronous operations are scheduled on a hight priority GCD queue and because of the shared lock when a file is created, it potentially leads to spawning of the mentioned number of lightweight threads. This is causing the runtime pressure as executing process usually does this setup along with other initial app specific setup (which requires additional threads for asynchronous work to be done), and so this may lead to sporadic crashes.

The fix is to limit a number of concurrent operations in the mentioned setup to 5 by using `NSOperationQueue` instead of GCD dispatch queue (and group for testing purpose).

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-apple/issues/2497

## Misc

Despite the fact, dispatch queue is not supposed to spawn a number of threads over some limit leading to runtime pressure and crashes.
