### PR TITLE
add support to override default bundle for resources

### DIFF
--- a/AppCenterDistribute/AppCenterDistribute/MSACDistribute.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistribute.h
@@ -53,6 +53,11 @@ typedef NS_ENUM(NSInteger, MSACUpdateTrack) {
 @property(class, nonatomic) MSACUpdateTrack updateTrack;
 
 /**
+ * Overrides default bundle for resources to be searched in
+ */
+@property(class, nullable, nonatomic) NSBundle* resourceBundle;
+
+/**
  * Distribute delegate
  *
  * @discussion If Distribute delegate is set and releaseAvailableWithDetails is returning <code>YES</code>, you must call

--- a/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistribute.m
@@ -72,6 +72,8 @@ static dispatch_once_t onceToken;
 
 @synthesize updateTrack = _updateTrack;
 
+@synthesize resourceBundle = _resourceBundle;
+
 #pragma mark - Service initialization
 
 - (instancetype)init {
@@ -351,6 +353,14 @@ static dispatch_once_t onceToken;
 
 + (void)checkForUpdate {
   [[MSACDistribute sharedInstance] checkForUpdate];
+}
+
++(void)setResourceBundle:(NSBundle *)resourceBundle {
+  [MSACDistribute sharedInstance].resourceBundle = resourceBundle;
+}
+
++(NSBundle *)resourceBundle {
+  return [MSACDistribute sharedInstance].resourceBundle;
 }
 
 #pragma mark - Private
@@ -1337,6 +1347,18 @@ static dispatch_once_t onceToken;
 - (MSACUpdateTrack)updateTrack {
   @synchronized(self) {
     return _updateTrack;
+  }
+}
+
+- (void)setResourceBundle:(NSBundle *)resourceBundle {
+  @synchronized(self) {
+    _resourceBundle = resourceBundle;
+  }
+}
+
+- (NSBundle *)resourceBundle {
+  @synchronized(self) {
+    return _resourceBundle;
   }
 }
 

--- a/AppCenterDistribute/AppCenterDistribute/MSACDistributePrivate.h
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistributePrivate.h
@@ -176,6 +176,11 @@ static NSString *const kMSACTesterAppUpdateSetupFailedKey = @"TesterAppUpdateSet
 @property(nonatomic) MSACUpdateTrack updateTrack;
 
 /**
+ * Overrides default bundle for resources to be searched in
+ */
+@property(nullable, nonatomic) NSBundle* resourceBundle;
+
+/**
  * A flag to indicate whether automatic update check is disabled on start or not.
  */
 @property(atomic) BOOL automaticCheckForUpdateDisabled;

--- a/AppCenterDistribute/AppCenterDistribute/MSACDistributeUtil.m
+++ b/AppCenterDistribute/AppCenterDistribute/MSACDistributeUtil.m
@@ -21,7 +21,12 @@ NSBundle *MSACDistributeBundle(void) {
 #ifdef SWIFTPM_MODULE_BUNDLE
     bundle = SWIFTPM_MODULE_BUNDLE;
 #else
-    NSBundle *mainBundle = [NSBundle bundleForClass:[MSACDistribute class]];
+    NSBundle *mainBundle = [MSACDistribute resourceBundle];
+
+    if (!mainBundle) {
+      mainBundle = [NSBundle bundleForClass:[MSACDistribute class]];
+    }
+
     NSURL *url = [mainBundle URLForResource:APP_CENTER_DISTRIBUTE_BUNDLE_NAME withExtension:@"bundle"];
     if (url) {
       bundle = [NSBundle bundleWithURL:url];

--- a/AppCenterDistribute/AppCenterDistribute/Resources/de.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/de.lproj/AppCenterDistribute.strings
@@ -15,4 +15,4 @@
 "MSDistributeAppUpdateAvailableMandatoryUpdateMessage" = "Die Entwickler dieser App verlangen, dass Sie %@ %@ (%@) aktualisieren.";
 "MSDistributeAppUpdateAvailableOptionalUpdateMessage" = "%@ %@ (%@) ist zum Herunterladen und Installieren verfügbar.";
 "MSDistributeInAppUpdatesAreDisabled" = "In-App-Updates sind deaktiviert.";
-"MSDistributeInstallFailedMessage" = "Diese Version wurde entweder Seiten geladen oder mit einem Browser im privaten Modus heruntergeladen.";
+"MSDistributeInstallFailedMessage" = "Diese Version wurde entweder aus unbekannten Quellen oder mit einem Browser im privaten Modus heruntergeladen.";

--- a/AppCenterDistribute/AppCenterDistribute/Resources/tr.lproj/AppCenterDistribute.strings
+++ b/AppCenterDistribute/AppCenterDistribute/Resources/tr.lproj/AppCenterDistribute.strings
@@ -11,8 +11,8 @@
 /*
  * Update dialog titles/messages
  */
-"MSDistributeAppUpdateAvailable" = "Uygulama güncelleştirmesi kullanılabilir";
-"MSDistributeAppUpdateAvailableMandatoryUpdateMessage" = "Bu uygulamanın geliştiricileri %@ %@ (%@) sürümüne güncelleştirmenizi gerektiriyor.";
+"MSDistributeAppUpdateAvailable" = "Uygulama güncellemesi mevcut";
+"MSDistributeAppUpdateAvailableMandatoryUpdateMessage" = "Bu uygulamanın geliştiricileri %@ %@ (%@) sürümüne güncelleştirmenizi rica ediyor.";
 "MSDistributeAppUpdateAvailableOptionalUpdateMessage" = "%@ %@ (%@), indirme ve yükleme için hazır.";
 "MSDistributeInAppUpdatesAreDisabled" = "Uygulama içi güncelleştirmeler devre dışı.";
-"MSDistributeInstallFailedMessage" = "Bu sürüm ya yan yüklenen veya özel modda bir tarayıcı kullanılarak indirilmiş.";
+"MSDistributeInstallFailedMessage" = "Bu sürüm ya bilinmeyen bir kaynaktan veya özel modda bir tarayıcı kullanılarak indirilmiş.";


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Cheers!

The App Center team -->

Things to consider before you submit the PR:

* [ ] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [ ] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

Adds a nullable property which can be used to override the default bundle for Distribute to search for its resources.

## Related PRs or issues

https://github.com/microsoft/appcenter-sdk-apple/issues/2297

## Misc

This is a workaround to use binary swift packages to improve build times. Each xcframework has to be zipped and uploaded separately. Example swift package release can be found here https://github.com/ilendemli/appcenter-sdk-apple-spm/releases/tag/5.0.4
