### PR TITLE
Refactor carrierCountry method to check for valid carrier country

### DIFF
--- a/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTracker.m
+++ b/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTracker.m
@@ -404,11 +404,15 @@ static MSACDeviceTracker *sharedInstance = nil;
 }
 
 - (NSString *)carrierCountry:(CTCarrier *)carrier {
-  return ([carrier.isoCountryCode length] > 0) ? carrier.isoCountryCode : nil;
+  return [self isValidCarrierCountry:carrier.isoCountryCode] ? carrier.isoCountryCode : nil;
 }
 
 - (BOOL)isValidCarrierName:(NSString *)carrier {
   return [carrier length] > 0 && [@"carrier" caseInsensitiveCompare:carrier] != NSOrderedSame;
+}
+
+- (BOOL)isValidCarrierCountry:(NSString *)country {
+  return [country length] > 0 && [@"--" caseInsensitiveCompare:country] != NSOrderedSame;
 }
 
 - (CTCarrier *)firstCarrier:(NSDictionary<NSString *, CTCarrier *> *)carriers {

--- a/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTracker.m
+++ b/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTracker.m
@@ -408,13 +408,13 @@ static MSACDeviceTracker *sharedInstance = nil;
 }
 
 - (BOOL)isCarrierNameValid:(NSString *)carrier {
-  return [carrier length] > 0 && [@"carrier" caseInsensitiveCompare:carrier] != NSOrderedSame && [@"--" isEqualToString:carrier] != NSOrderedSame;
+  return [carrier length] > 0 && [@"carrier" caseInsensitiveCompare:carrier] != NSOrderedSame && ![@"--" isEqualToString:carrier];
 }
 
 // The CTCarrier is deprecated without replacement since iOS 16 (https://developer.apple.com/documentation/coretelephony/ctcarrier)
 // and will always return "--" for isoCountryCode.
 - (BOOL)isCarrierCountyValid:(NSString *)country {
-  return [country length] > 0 && [@"--" isEqualToString:country] != NSOrderedSame;
+  return [country length] > 0 && ![@"--" isEqualToString:country];
 }
 
 - (CTCarrier *)firstCarrier:(NSDictionary<NSString *, CTCarrier *> *)carriers {

--- a/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTracker.m
+++ b/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTracker.m
@@ -411,8 +411,9 @@ static MSACDeviceTracker *sharedInstance = nil;
   return [carrier length] > 0 && [@"carrier" caseInsensitiveCompare:carrier] != NSOrderedSame;
 }
 
+// The CTCarrier is deprecated without replacement since iOS 17 and will always return "--" for isoCountryCode.
 - (BOOL)isValidCarrierCountry:(NSString *)country {
-  return [country length] > 0 && [@"--" caseInsensitiveCompare:country] != NSOrderedSame;
+  return [country length] > 0 && [@"--" compare:country] != NSOrderedSame;
 }
 
 - (CTCarrier *)firstCarrier:(NSDictionary<NSString *, CTCarrier *> *)carriers {

--- a/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTracker.m
+++ b/AppCenter/AppCenter/Internals/Context/Device/MSACDeviceTracker.m
@@ -400,20 +400,21 @@ static MSACDeviceTracker *sharedInstance = nil;
 
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (NSString *)carrierName:(CTCarrier *)carrier {
-  return [self isValidCarrierName:carrier.carrierName] ? carrier.carrierName : nil;
+  return [self isCarrierNameValid:carrier.carrierName] ? carrier.carrierName : nil;
 }
 
 - (NSString *)carrierCountry:(CTCarrier *)carrier {
-  return [self isValidCarrierCountry:carrier.isoCountryCode] ? carrier.isoCountryCode : nil;
+  return [self isCarrierCountyValid:carrier.isoCountryCode] ? carrier.isoCountryCode : nil;
 }
 
-- (BOOL)isValidCarrierName:(NSString *)carrier {
-  return [carrier length] > 0 && [@"carrier" caseInsensitiveCompare:carrier] != NSOrderedSame;
+- (BOOL)isCarrierNameValid:(NSString *)carrier {
+  return [carrier length] > 0 && [@"carrier" caseInsensitiveCompare:carrier] != NSOrderedSame && [@"--" isEqualToString:carrier] != NSOrderedSame;
 }
 
-// The CTCarrier is deprecated without replacement since iOS 17 and will always return "--" for isoCountryCode.
-- (BOOL)isValidCarrierCountry:(NSString *)country {
-  return [country length] > 0 && [@"--" compare:country] != NSOrderedSame;
+// The CTCarrier is deprecated without replacement since iOS 16 (https://developer.apple.com/documentation/coretelephony/ctcarrier)
+// and will always return "--" for isoCountryCode.
+- (BOOL)isCarrierCountyValid:(NSString *)country {
+  return [country length] > 0 && [@"--" isEqualToString:country] != NSOrderedSame;
 }
 
 - (CTCarrier *)firstCarrier:(NSDictionary<NSString *, CTCarrier *> *)carriers {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Version 5.0.5 (Under development)
 
+* **[Fix]** Handle the special value (--) returned by CTCarrier after it has been depcrecated with iOS 16.
+
 ## Version 5.0.4
 
 * **[Improvement]** Update App Center SDK to include privacy manifest.
 * **[Internal]** Add `dataResidencyRegion` option.
-* **[Fix]** Mitigate the runtime pressure when starting App Center Crashes
+* **[Fix]** Mitigate the runtime pressure when starting App Center Crashes.
 
 ## Version 5.0.3
 


### PR DESCRIPTION
* [x] Has `CHANGELOG.md` been updated?
* [ ] Are tests passing locally?
* [x] Are the files formatted correctly?
* [ ] Did you add unit tests?
* [ ] Did you check UI tests on the sample app? They are not executed on CI.
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

With iOS 16, the [CTCarrier](https://developer.apple.com/documentation/coretelephony/ctcarrier) service is deprecated and no direct replacement is offered. This change affects how the country code is retrieved, as it may now return "--". Our previous validation method is no longer applicable in this context.

## Related PRs or issues

[AB#104204](https://dev.azure.com/msmobilecenter/454a20a9-dfe6-4c1f-8ae8-417f76adb472/_workitems/edit/104204)
