### PR TITLE
[Fix] Fixes the system exception when initializing NSString from `exceptionReason` with nil value

### DIFF
--- a/AppCenterCrashes/AppCenterCrashes/Internals/Util/MSACErrorLogFormatter.m
+++ b/AppCenterCrashes/AppCenterCrashes/Internals/Util/MSACErrorLogFormatter.m
@@ -633,7 +633,12 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
 
   // Uncaught Exception.
   if (report.hasExceptionInfo) {
-    exceptionReason = [NSString stringWithString:report.exceptionInfo.exceptionReason];
+    NSString *reasonFromReport = report.exceptionInfo.exceptionReason;
+    if (reasonFromReport == nil) {
+      exceptionReason = @"N/A: exception reason is nil";
+    } else {
+      exceptionReason = [NSString stringWithString:reasonFromReport];
+    }
   }
   return exceptionReason;
 }


### PR DESCRIPTION
## Description

We encountered a system exception on Outlook iOS when `[NSString stringWithString:report.exceptionInfo.exceptionReason];` tried to create a string from a nil value. This PR prevents this by checking that `exceptionReason` is not nil before using it.