### PR TITLE
[CI] Update xcode and macOS version

### DIFF
--- a/.azure-pipelines/build-frameworks-and-docs-1ES.yml
+++ b/.azure-pipelines/build-frameworks-and-docs-1ES.yml
@@ -9,7 +9,6 @@ variables:
   Configuration: Release
   SDK: ''
   EOCompliance-Mac: true
-  XCODE_PATH: '/Applications/Xcode_13.2.1.app/Contents/Developer'
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -60,8 +59,6 @@ extends:
           inputs:
             xcWorkspacePath: AppCenter.xcworkspace
             scheme: 'All App Center Frameworks'
-            xcodeVersion: specifyPath
-            xcodeDeveloperDir: '$(XCODE_PATH)'
             args: 'SYMROOT="$(Build.BinariesDirectory)" GCC_TREAT_WARNINGS_AS_ERRORS=YES SWIFT_TREAT_WARNINGS_AS_ERRORS=YES'
           timeoutInMinutes: 50
         - task: Xcode@5

--- a/.azure-pipelines/build-frameworks-and-docs-1ES.yml
+++ b/.azure-pipelines/build-frameworks-and-docs-1ES.yml
@@ -24,7 +24,7 @@ extends:
   parameters:
     pool:
       name: Azure Pipelines
-      image: macos-latest
+      image: macos-13
       os: macOS
     customBuildTags:
     - ES365AIMigrationTooling-BulkMigrated

--- a/.azure-pipelines/build-frameworks-and-docs-1ES.yml
+++ b/.azure-pipelines/build-frameworks-and-docs-1ES.yml
@@ -9,6 +9,7 @@ variables:
   Configuration: Release
   SDK: ''
   EOCompliance-Mac: true
+  XCODE_PATH: '/Applications/Xcode_14.2.app/Contents/Developer'
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -35,9 +36,6 @@ extends:
       - job: sdkBuildJob
         displayName: Build SDK for All Platforms
         templateContext:
-          sdl:
-            codeql:
-              language: javascript, ruby, cpp
           outputs:
           - output: pipelineArtifact
             displayName: 'Publish Artifacts'
@@ -59,6 +57,8 @@ extends:
           inputs:
             xcWorkspacePath: AppCenter.xcworkspace
             scheme: 'All App Center Frameworks'
+            xcodeVersion: specifyPath
+            xcodeDeveloperDir: '$(XCODE_PATH)'
             args: 'SYMROOT="$(Build.BinariesDirectory)" GCC_TREAT_WARNINGS_AS_ERRORS=YES SWIFT_TREAT_WARNINGS_AS_ERRORS=YES'
           timeoutInMinutes: 50
         - task: Xcode@5


### PR DESCRIPTION
## Description
Fixed build failure with macos-13 in order to use xcode 14.2 version instead of 13.2 which isn't available.
[Build](https://dev.azure.com/msmobilecenter/SDK/_build/results?buildId=1551633&view=results)