### PR TITLE
Update PLCrashReporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Version 5.0.6 (Under development)
 
 * **[Improvement]** Update target iOS and tvOS version to 12.0.
+* **[Improvement]** Update PLCrashReporter.
+* **[Improvement]** Update sqlite to 3.46.1, which fixes [CVE-2020-11656](https://github.com/advisories/GHSA-x2v5-p27f-53wp).
 
 ## Version 5.0.5
 

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -7,7 +7,7 @@
         "git": {
           "name": "PLCrashReporter",
           "repositoryUrl": "https://github.com/microsoft/plcrashreporter.git",
-          "commitHash": "41b159864c40093cb868c5c516465cd7689c524e"
+          "commitHash": "52d876d704750b0e17758d1a213a94ada5becc80"
         }
       }
     },


### PR DESCRIPTION
This PR updates PLCrashReporter which includes the following changes:
- [Increase Xcode to 14.3.1 and macOS to 11.5](https://github.com/microsoft/plcrashreporter/commit/6d192399ba6d64c8ddeac1dd76e44e8589445f08)
- [Update target version to 12.0](https://github.com/microsoft/plcrashreporter/commit/845458f8e09c7c2c87dbbe34f1586285d140970e)
- [Exclude shellscript from Package.swift](https://github.com/microsoft/plcrashreporter/commit/03c3319583a178e6d812f91b659db3684959282c)
- [Fix proto files build process warning](https://github.com/microsoft/plcrashreporter/commit/247243454ab9ebbebf74c368979a7ce80c5587ae)